### PR TITLE
Add smart tag suggestions

### DIFF
--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -4,6 +4,13 @@ const { parseCSV } = require('../utils/csvParser');
 const openai = require("../config/openai"); // ✅ re-use the config
 const axios = require('axios');
 
+// Basic vendor -> tag mapping for quick suggestions
+const vendorTagMap = {
+  staples: ['Office Supplies'],
+  notion: ['SaaS'],
+  figma: ['SaaS'],
+};
+
 
 exports.uploadInvoiceCSV = async (req, res) => {
   try {
@@ -389,6 +396,14 @@ exports.updateInvoiceField = async (req, res) => {
 exports.suggestTags = async (req, res) => {
   try {
     const { invoice } = req.body;
+
+    // Check simple mapping first
+    const vendorKey = invoice.vendor?.toLowerCase() || '';
+    for (const [key, tags] of Object.entries(vendorTagMap)) {
+      if (vendorKey.includes(key)) {
+        return res.json({ tags });
+      }
+    }
 
     const prompt = `
       You are an intelligent finance assistant. Based on the following invoice details:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -153,7 +153,12 @@ const [files, setFile] = useState([]);   // ✅ new
       const data = await res.json();
       if (res.ok) {
         addToast(data.message);
-        fetchInvoices(); // ✅ Refresh invoice list
+        const updatedList = await fetchInvoices(); // refresh and get new data
+
+        if (field === 'vendor') {
+          const updatedInv = updatedList?.find((inv) => inv.id === id);
+          if (updatedInv) handleSuggestTags(updatedInv);
+        }
   
         // ✅ ✅ Add this to show a green checkmark after update
         setUpdatedFields((prev) => ({
@@ -282,6 +287,12 @@ useEffect(() => {
       .filter(inv => !invoices.some(existing => existing.id === inv.id))
       .map(inv => inv.id);
 
+    // automatically fetch tag suggestions for newly uploaded invoices
+    newIds.forEach((newId) => {
+      const inv = updatedData.find(i => i.id === newId);
+      if (inv) handleSuggestTags(inv);
+    });
+
     if (newIds.length > 0) {
       setRecentInvoices(newIds);
       setTimeout(() => {
@@ -322,6 +333,7 @@ useEffect(() => {
         });
         setDuplicateFlags(dupMap);
 
+        return data;
       } catch (err) {
         console.error('Fetch error:', err);
         setMessage('❌ Could not load invoices');


### PR DESCRIPTION
## Summary
- map common vendors to default tags on the backend
- call smart tag suggestions after invoice upload or vendor edit on the frontend
- refresh invoice fetch returns data for further processing

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*
- `npm --prefix backend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68478cd2dbd4832e82db7cacd90f1cbb