### PR TITLE
Add approval workflow and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Add an `assignee` column for storing invoice assignments:
 
 ```sql
 ALTER TABLE invoices ADD COLUMN assignee TEXT;
+ALTER TABLE invoices ADD COLUMN approval_status TEXT DEFAULT 'Pending';
+ALTER TABLE invoices ADD COLUMN approval_history JSONB DEFAULT '[]';
+ALTER TABLE invoices ADD COLUMN comments JSONB DEFAULT '[]';
 ```
 
 ### Frontend

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -34,6 +34,7 @@ const { suggestTags } = require('../controllers/invoiceController');
 const { updateInvoiceTags } = require('../controllers/invoiceController');
 const { generateInvoicePDF } = require('../controllers/invoiceController');
 const { assignInvoice } = require('../controllers/invoiceController');
+const { approveInvoice, rejectInvoice, addComment } = require('../controllers/invoiceController');
 
 
 router.get('/export-archived', authMiddleware, exportArchivedInvoicesCSV);
@@ -59,6 +60,9 @@ router.post('/:id/unarchive', authMiddleware, unarchiveInvoice);
 router.post('/suggest-vendor', authMiddleware, handleSuggestion);
 router.patch('/:id/update', authMiddleware, updateInvoiceField);
 router.patch('/:id/assign', authMiddleware, assignInvoice);
+router.patch('/:id/approve', authMiddleware, approveInvoice);
+router.patch('/:id/reject', authMiddleware, rejectInvoice);
+router.post('/:id/comments', authMiddleware, addComment);
 router.post('/suggest-tags', authMiddleware, suggestTags);
 router.post('/:id/update-tags', authMiddleware, updateInvoiceTags);
 


### PR DESCRIPTION
## Summary
- expand DB setup instructions for new approval fields
- implement approve/reject/comment endpoints on the backend
- expose new routes for approving, rejecting and commenting
- add frontend state and handlers for approval flow
- render approval status, approve/reject buttons and comments UI

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a02d2ca8832e92cab071882c2bed