### PR TITLE
Add top vendors chart with filter

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -19,6 +19,7 @@ const {
   exportArchivedInvoicesCSV,
   getMonthlyInsights,
   getCashFlow,
+  getTopVendors,
 } = require('../controllers/invoiceController');
 
 
@@ -56,6 +57,7 @@ router.get('/export-all', authMiddleware, exportAllInvoices);
 router.post('/summarize-vendor-data', summarizeVendorData);
 router.get('/monthly-insights', authMiddleware, getMonthlyInsights);
 router.get('/cash-flow', authMiddleware, getCashFlow);
+router.get('/top-vendors', authMiddleware, getTopVendors);
 router.post('/flag-suspicious', authMiddleware, flagSuspiciousInvoice);
 router.patch('/:id/archive', authMiddleware, archiveInvoice);
 router.post('/:id/unarchive', authMiddleware, unarchiveInvoice);


### PR DESCRIPTION
## Summary
- add backend endpoint `GET /top-vendors`
- wire new endpoint into router
- fetch and display top vendors chart with dropdown filter for tag/date/amount

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6847a49865cc832eb0b0a145e7b35b5c