### PR TITLE
Improve UI usability

### DIFF
--- a/frontend/src/components/Skeleton.js
+++ b/frontend/src/components/Skeleton.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function Skeleton({ rows = 5, className = '', height = 'h-6' }) {
+  return (
+    <div className={`space-y-2 ${className}`}>
+      {Array.from({ length: rows }).map((_, idx) => (
+        <div key={idx} className={`${height} bg-gray-200 rounded animate-pulse`} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add general Skeleton component
- integrate skeleton loaders while fetching invoices
- enhance search to include tags and description
- add toast when duplicates detected and uploads succeed

## Testing
- `npm install`
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6847a8c1d0c4832e982185cb63930005