### PR TITLE
Add undo toast for invoice deletion

### DIFF
--- a/frontend/src/components/Toast.js
+++ b/frontend/src/components/Toast.js
@@ -1,9 +1,19 @@
 import React from 'react';
 
-export default function Toast({ message, type }) {
-  const base = 'px-4 py-2 rounded shadow-lg text-white mb-2';
+export default function Toast({ message, type, actionText, onAction }) {
+  const base = 'px-4 py-2 rounded shadow-lg text-white mb-2 flex items-center';
   const color = type === 'error' ? 'bg-red-600' : 'bg-green-600';
   return (
-    <div className={`${base} ${color} animate-fade-in`}>{message}</div>
+    <div className={`${base} ${color} animate-fade-in`}>
+      <span className="flex-1 mr-2">{message}</span>
+      {actionText && (
+        <button
+          className="underline font-semibold"
+          onClick={onAction}
+        >
+          {actionText}
+        </button>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add action support to Toast component
- extend `addToast` helper to handle actions
- implement undo-able invoice delete and show Undo toast

## Testing
- `CI=true npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847d380e54c832eb96e70cae15aa39b