### PR TITLE
Add rules engine and approval chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ ALTER TABLE invoices ADD COLUMN approval_status TEXT DEFAULT 'Pending';
 ALTER TABLE invoices ADD COLUMN approval_history JSONB DEFAULT '[]';
 ALTER TABLE invoices ADD COLUMN comments JSONB DEFAULT '[]';
 ALTER TABLE invoices ADD COLUMN priority BOOLEAN DEFAULT FALSE;
+ALTER TABLE invoices ADD COLUMN flagged BOOLEAN DEFAULT FALSE;
+ALTER TABLE invoices ADD COLUMN flag_reason TEXT;
+ALTER TABLE invoices ADD COLUMN approval_chain JSONB DEFAULT '["Manager","Finance","CFO"]';
+ALTER TABLE invoices ADD COLUMN current_step INTEGER DEFAULT 0;
 ```
 
 Create an `activity_logs` table for the audit trail:

--- a/backend/utils/rulesEngine.js
+++ b/backend/utils/rulesEngine.js
@@ -1,0 +1,21 @@
+const rules = [
+  { vendor: 'X', amountGreaterThan: 500, flagReason: 'Vendor X amount > $500' }
+];
+
+function applyRules(invoice) {
+  let flagged = false;
+  let reason = null;
+  for (const r of rules) {
+    if (
+      r.vendor && invoice.vendor && invoice.vendor.toLowerCase() === r.vendor.toLowerCase() &&
+      r.amountGreaterThan && parseFloat(invoice.amount) > r.amountGreaterThan
+    ) {
+      flagged = true;
+      reason = r.flagReason || 'Rule triggered';
+      break;
+    }
+  }
+  return { ...invoice, flagged, flag_reason: reason };
+}
+
+module.exports = { applyRules };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -976,12 +976,14 @@ useEffect(() => {
     try {
       const res = await fetch(`http://localhost:3000/api/invoices/${id}/approve`, {
         method: 'PATCH',
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ comment: commentInputs[id] || '' }),
       });
       const data = await res.json();
       if (res.ok) {
         addToast(data.message);
         fetchInvoices(showArchived, selectedAssignee);
+        setCommentInputs((p) => ({ ...p, [id]: '' }));
       } else {
         addToast('Failed to approve invoice', 'error');
       }
@@ -995,12 +997,14 @@ useEffect(() => {
     try {
       const res = await fetch(`http://localhost:3000/api/invoices/${id}/reject`, {
         method: 'PATCH',
-        headers: { Authorization: `Bearer ${token}` },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ comment: commentInputs[id] || '' }),
       });
       const data = await res.json();
       if (res.ok) {
         addToast(data.message);
         fetchInvoices(showArchived, selectedAssignee);
+        setCommentInputs((p) => ({ ...p, [id]: '' }));
       } else {
         addToast('Failed to reject invoice', 'error');
       }


### PR DESCRIPTION
## Summary
- add instructions for flagged invoices and approval chains to database setup
- create `rulesEngine` utility
- apply rules on upload to auto-flag invoices
- implement multi-step approval workflow with comments
- send approval comments from frontend

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm test` in `backend` *(fails: Missing script)*
- `npm test -- -w` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847de4fb85c832e867f25c804ee5564