### PR TITLE
Add PDF dashboard export and tag spending report

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -20,6 +20,8 @@ const {
   getMonthlyInsights,
   getCashFlow,
   getTopVendors,
+  getSpendingByTag,
+  exportDashboardPDF,
 } = require('../controllers/invoiceController');
 
 
@@ -62,6 +64,8 @@ router.post('/summarize-vendor-data', summarizeVendorData);
 router.get('/monthly-insights', authMiddleware, getMonthlyInsights);
 router.get('/cash-flow', authMiddleware, getCashFlow);
 router.get('/top-vendors', authMiddleware, getTopVendors);
+router.get('/spending-by-tag', authMiddleware, getSpendingByTag);
+router.get('/dashboard/pdf', authMiddleware, exportDashboardPDF);
 router.post('/flag-suspicious', authMiddleware, flagSuspiciousInvoice);
 router.patch('/:id/archive', authMiddleware, archiveInvoice);
 router.post('/:id/unarchive', authMiddleware, unarchiveInvoice);


### PR DESCRIPTION
## Summary
- add routes for spending-by-tag and dashboard PDF export
- implement controllers for tag-based spending and dashboard PDF
- show tag report chart and export button in UI

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847e681b064832e91c7e8522941af3c