### PR TITLE
Implement invoice hash + retention policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ ALTER TABLE invoices ADD COLUMN current_step INTEGER DEFAULT 0;
 ALTER TABLE invoices ADD COLUMN payment_terms TEXT;
 ALTER TABLE invoices ADD COLUMN private_notes TEXT;
 ALTER TABLE invoices ADD COLUMN due_date DATE;
+ALTER TABLE invoices ADD COLUMN integrity_hash TEXT;
+ALTER TABLE invoices ADD COLUMN retention_policy TEXT DEFAULT 'forever';
+ALTER TABLE invoices ADD COLUMN delete_at TIMESTAMP;
 ```
 
 Create an `activity_logs` table for the audit trail:
@@ -88,12 +91,17 @@ CREATE TABLE budgets (
 The backend automatically archives invoices older than 90 days
 unless they are marked as `priority`.
 
+Invoices also store a SHA256 `integrity_hash` generated at upload time. You can
+set a retention policy (`6m`, `2y`, or `forever`) on upload or later. A daily
+job deletes invoices once their `delete_at` date passes.
+
 ### New Endpoints
 
 - `POST /api/invoices/budgets` – create/update a monthly or quarterly budget by vendor or tag
 - `GET /api/invoices/budgets/warnings` – check if spending has exceeded 90% of a budget
 - `GET /api/invoices/anomalies` – list vendors with unusual spending spikes
 - `GET /api/invoices/:id/timeline` – view a timeline of state changes for an invoice
+- `PATCH /api/invoices/:id/retention` – update an invoice retention policy (6m, 2y, forever)
 
 ### Frontend
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,7 +4,7 @@ const express = require('express');         // web server framework
 const cors = require('cors');
 require('dotenv').config();                 // load environment variables
 const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
-const { autoArchiveOldInvoices } = require('./controllers/invoiceController');
+const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
 
 const app = express();                      // create the app
 
@@ -17,6 +17,8 @@ app.use('/api/invoices', invoiceRoutes);    // route all invoice requests here
 // Run auto-archive daily
 autoArchiveOldInvoices();
 setInterval(autoArchiveOldInvoices, 24 * 60 * 60 * 1000); // every 24h
+autoDeleteExpiredInvoices();
+setInterval(autoDeleteExpiredInvoices, 24 * 60 * 60 * 1000);
 
 console.log('🟢 Routes mounted');
 

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -40,6 +40,7 @@ const {
   bulkRejectInvoices,
   exportPDFBundle,
   updatePrivateNotes,
+  updateRetentionPolicy,
 } = require('../controllers/invoiceController');
 
 
@@ -100,6 +101,7 @@ router.patch('/bulk/approve', authMiddleware, authorizeRoles('approver','admin')
 router.patch('/bulk/reject', authMiddleware, authorizeRoles('approver','admin'), bulkRejectInvoices);
 router.post('/bulk/pdf', authMiddleware, exportPDFBundle);
 router.patch('/:id/notes', authMiddleware, authorizeRoles('admin'), updatePrivateNotes);
+router.patch('/:id/retention', authMiddleware, authorizeRoles('admin'), updateRetentionPolicy);
 router.post('/suggest-tags', authMiddleware, suggestTags);
 router.post('/:id/update-tags', authMiddleware, updateInvoiceTags);
 router.get('/logs', authMiddleware, authorizeRoles('admin'), getActivityLogs);


### PR DESCRIPTION
## Summary
- generate a SHA256 integrity hash when uploading invoices
- allow invoices to have a retention policy
- schedule daily cleanup of expired invoices
- expose a route to update retention policy
- document DB changes and new behavior

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f6d94354832eac74910f438df0ac