### PR TITLE
Add AI assistance for flags, categorization and vendor info

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Shared comment threads for team discussion
 - Approver reminders with escalation
 - Batch actions with bulk approval and PDF export
+- AI explanations for why an invoice was flagged
+- AI-powered bulk categorization of uploaded invoices
+- Hoverable vendor bios with website and industry info
 
 ## Setup Instructions
 

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -41,6 +41,9 @@ const {
   exportPDFBundle,
   updatePrivateNotes,
   updateRetentionPolicy,
+  explainFlaggedInvoice,
+  bulkAutoCategorize,
+  getVendorBio,
 } = require('../controllers/invoiceController');
 
 
@@ -85,8 +88,10 @@ router.get('/top-vendors', authMiddleware, getTopVendors);
 router.get('/spending-by-tag', authMiddleware, getSpendingByTag);
 router.get('/recurring/insights', authMiddleware, getRecurringInsights);
 router.get('/vendor-profile/:vendor', authMiddleware, getVendorProfile);
+router.get('/vendor-bio/:vendor', authMiddleware, getVendorBio);
 router.get('/dashboard/pdf', authMiddleware, exportDashboardPDF);
 router.post('/flag-suspicious', authMiddleware, flagSuspiciousInvoice);
+router.get('/:id/flag-explanation', authMiddleware, explainFlaggedInvoice);
 router.patch('/:id/archive', authMiddleware, archiveInvoice);
 router.post('/:id/unarchive', authMiddleware, unarchiveInvoice);
 router.post('/suggest-vendor', authMiddleware, handleSuggestion);
@@ -100,6 +105,7 @@ router.patch('/bulk/assign', authMiddleware, authorizeRoles('admin'), bulkAssign
 router.patch('/bulk/approve', authMiddleware, authorizeRoles('approver','admin'), bulkApproveInvoices);
 router.patch('/bulk/reject', authMiddleware, authorizeRoles('approver','admin'), bulkRejectInvoices);
 router.post('/bulk/pdf', authMiddleware, exportPDFBundle);
+router.post('/bulk/auto-categorize', authMiddleware, bulkAutoCategorize);
 router.patch('/:id/notes', authMiddleware, authorizeRoles('admin'), updatePrivateNotes);
 router.patch('/:id/retention', authMiddleware, authorizeRoles('admin'), updateRetentionPolicy);
 router.post('/suggest-tags', authMiddleware, suggestTags);


### PR DESCRIPTION
## Summary
- explain flagged invoices using OpenRouter
- add bulk auto-categorization endpoint
- provide vendor bio info via AI
- expose the new endpoints in routes
- document new AI features in README

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684895400d44832e88d1e99dce948527