### PR TITLE
Implement fraud pattern detection and AI explainability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - AI-generated summaries of common CSV issues (via OpenAI)
 - Query invoices using natural language (via OpenAI)
 - AI-powered invoice quality scores with tips
-- Conversational assistant to analyze spending
+- Ask Me Anything assistant for financial questions
 - Role-based access control (Admins, Approvers, Viewers)
 - Activity log of invoice actions
 - Auto-routing invoices by vendor or tag
 - Budget threshold warnings
 - Anomaly detection dashboard
+- Fraud pattern detection for suspicious vendor activity
 - Timeline view of invoice changes
 - Recurring invoice detection with notifications
 - Smart auto-fill suggestions for vendor tags and payment terms
@@ -28,6 +29,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Approver reminders with escalation
 - Batch actions with bulk approval and PDF export
 - AI explanations for why an invoice was flagged
+- "Why did AI say this?" links show confidence and reasoning
 - AI-powered bulk categorization of uploaded invoices
 - Hoverable vendor bios with website and industry info
 - Smart keyboard shortcuts (press **A** to archive, **F** to flag, **/** to focus search)

--- a/backend/controllers/fraudController.js
+++ b/backend/controllers/fraudController.js
@@ -1,0 +1,45 @@
+const pool = require('../config/db');
+
+exports.detectPatterns = async (req, res) => {
+  try {
+    const repeatedRes = await pool.query(`
+      SELECT vendor, amount, COUNT(*) AS count, MIN(created_at) AS first_seen
+      FROM invoices
+      GROUP BY vendor, amount
+      HAVING COUNT(*) > 1
+    `);
+    const totalsRes = await pool.query('SELECT vendor, COUNT(*) AS total FROM invoices GROUP BY vendor');
+    const totals = {};
+    totalsRes.rows.forEach(r => { totals[r.vendor] = parseInt(r.total, 10); });
+    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+    const repeatedAmounts = repeatedRes.rows
+      .filter(r => (totals[r.vendor] || 0) <= 3 && new Date(r.first_seen) > thirtyDaysAgo)
+      .map(r => ({ vendor: r.vendor, amount: parseFloat(r.amount), count: parseInt(r.count, 10) }));
+
+    const vendorRes = await pool.query('SELECT DISTINCT vendor FROM invoices');
+    const domainMap = {};
+    vendorRes.rows.forEach(r => {
+      const base = r.vendor.toLowerCase().replace(/\d+/g, '');
+      domainMap[base] = domainMap[base] ? [...domainMap[base], r.vendor] : [r.vendor];
+    });
+    const similarDomainVendors = Object.values(domainMap).filter(list => list.length > 1);
+
+    const offHoursRes = await pool.query(`
+      SELECT id, vendor, amount, created_at
+      FROM invoices
+      WHERE EXTRACT(HOUR FROM created_at) < 8 OR EXTRACT(HOUR FROM created_at) > 18
+      ORDER BY created_at DESC
+    `);
+    const offHoursUploads = offHoursRes.rows.map(r => ({
+      id: r.id,
+      vendor: r.vendor,
+      amount: parseFloat(r.amount),
+      created_at: r.created_at
+    }));
+
+    res.json({ repeatedAmounts, similarDomainVendors, offHoursUploads });
+  } catch (err) {
+    console.error('Fraud pattern detection error:', err);
+    res.status(500).json({ message: 'Failed to detect fraud patterns' });
+  }
+};

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -63,6 +63,7 @@ const { generateInvoicePDF } = require('../controllers/invoiceController');
 const { getActivityLogs, getInvoiceTimeline } = require('../controllers/activityController');
 const { setBudget, getBudgets, checkBudgetWarnings } = require('../controllers/budgetController');
 const { getAnomalies } = require('../controllers/anomalyController');
+const { detectPatterns } = require('../controllers/fraudController');
 
 
 router.get('/export-archived', authMiddleware, exportArchivedInvoicesCSV);
@@ -118,6 +119,7 @@ router.post('/budgets', authMiddleware, authorizeRoles('admin'), setBudget);
 router.get('/budgets', authMiddleware, authorizeRoles('admin'), getBudgets);
 router.get('/budgets/warnings', authMiddleware, checkBudgetWarnings);
 router.get('/anomalies', authMiddleware, getAnomalies);
+router.get('/fraud/patterns', authMiddleware, authorizeRoles('admin'), detectPatterns);
 router.get('/:id/check-recurring', authMiddleware, checkRecurringInvoice);
 
 


### PR DESCRIPTION
## Summary
- add a FraudController for detecting suspicious invoice patterns
- return reasoning and confidence when explaining flags
- include explanation and confidence for tag suggestions
- expose `GET /api/invoices/fraud/patterns` endpoint
- document new features in README

## Testing
- `npm install` in backend
- `npm install` and `npm test --silent` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6848a54abe50832e903f94c0808de057