### PR TITLE
Add vendor reply email draft API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Smart keyboard shortcuts (press **A** to archive, **F** to flag, **/** to focus search)
 - Real-time "Ops Mode" dashboard with a live feed of invoice activity
 - Multi-tenant support so agencies can switch between different client accounts
+- Polite vendor notification emails for flagged or rejected invoices
 
 ## Setup Instructions
 
@@ -119,6 +120,42 @@ job deletes invoices once their `delete_at` date passes.
 - `PATCH /api/invoices/:id/retention` – update an invoice retention policy (6m, 2y, forever)
 - `POST /api/invoices/payment-risk` – predict payment delay risk for a vendor
 - `POST /api/invoices/nl-chart` – run a natural language query and return data for charts
+- `POST /api/invoices/:id/vendor-reply` – generate or send a polite vendor email when an invoice is flagged or rejected
+
+### Vendor Reply Drafts
+
+Request a draft:
+
+```bash
+POST /api/invoices/42/vendor-reply
+{
+  "status": "flagged",
+  "reason": "Incorrect PO number"
+}
+```
+
+Example response:
+
+```json
+{ "draft": "Dear Vendor, ..." }
+```
+
+Send after manual edits:
+
+```bash
+POST /api/invoices/42/vendor-reply
+{
+  "status": "flagged",
+  "manualEdit": "Hi team, please resend with the right PO",
+  "email": "billing@acme.com"
+}
+```
+
+Response:
+
+```json
+{ "message": "Email sent successfully." }
+```
 
 ### Frontend
 

--- a/backend/controllers/vendorReplyController.js
+++ b/backend/controllers/vendorReplyController.js
@@ -1,0 +1,66 @@
+const openai = require('../config/openai');
+const nodemailer = require('nodemailer');
+const pool = require('../config/db');
+require('dotenv').config();
+
+/**
+ * Generate a polite vendor notification email draft when an invoice is flagged or rejected.
+ * If `manualEdit` is provided in the request body the email will be sent directly
+ * to the specified vendor email address instead of returning a draft.
+ */
+exports.vendorReply = async (req, res) => {
+  const { id } = req.params;
+  const { status, reason, manualEdit, email } = req.body;
+
+  if (!status || !['flagged', 'rejected'].includes(status)) {
+    return res.status(400).json({ message: 'Status must be flagged or rejected.' });
+  }
+
+  try {
+    const result = await pool.query(
+      'SELECT invoice_number, vendor, amount, date, flag_reason FROM invoices WHERE id = $1',
+      [id]
+    );
+    if (result.rows.length === 0) return res.status(404).json({ message: 'Invoice not found' });
+    const inv = result.rows[0];
+
+    const why = reason || inv.flag_reason || '';
+
+    // If manualEdit is provided, send the email using that text
+    if (manualEdit) {
+      if (!email) {
+        return res.status(400).json({ message: 'Vendor email required to send.' });
+      }
+      const transporter = nodemailer.createTransport({
+        host: 'smtp.gmail.com',
+        port: 465,
+        secure: true,
+        auth: {
+          user: process.env.EMAIL_USER,
+          pass: process.env.EMAIL_PASS,
+        },
+      });
+      await transporter.sendMail({
+        from: process.env.EMAIL_USER,
+        to: email,
+        subject: `Regarding Invoice ${inv.invoice_number}`,
+        text: manualEdit,
+      });
+      return res.json({ message: 'Email sent successfully.' });
+    }
+
+    const prompt = `Write a short, professional email to vendor ${inv.vendor} letting them know their invoice number ${inv.invoice_number} dated ${inv.date.toISOString().split('T')[0]} for $${inv.amount} was ${status}. Reason: ${why}. Offer guidance on how to correct and resubmit.`;
+
+    const completion = await openai.chat.completions.create({
+      model: 'openai/gpt-3.5-turbo',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.5,
+    });
+
+    const draft = completion.choices[0].message.content;
+    res.json({ draft });
+  } catch (err) {
+    console.error('Vendor reply error:', err.response?.data || err.message);
+    res.status(500).json({ message: 'Failed to generate vendor reply.' });
+  }
+};

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -64,6 +64,7 @@ const { getActivityLogs, getInvoiceTimeline } = require('../controllers/activity
 const { setBudget, getBudgets, checkBudgetWarnings } = require('../controllers/budgetController');
 const { getAnomalies } = require('../controllers/anomalyController');
 const { detectPatterns } = require('../controllers/fraudController');
+const { vendorReply } = require('../controllers/vendorReplyController');
 
 
 router.get('/export-archived', authMiddleware, exportArchivedInvoicesCSV);
@@ -103,6 +104,7 @@ router.patch('/:id/assign', authMiddleware, assignInvoice);
 router.patch('/:id/approve', authMiddleware, authorizeRoles('approver','admin'), approveInvoice);
 router.patch('/:id/reject', authMiddleware, authorizeRoles('approver','admin'), rejectInvoice);
 router.post('/:id/comments', authMiddleware, authorizeRoles('approver','admin'), addComment);
+router.post('/:id/vendor-reply', authMiddleware, authorizeRoles('approver','admin'), vendorReply);
 router.patch('/bulk/archive', authMiddleware, authorizeRoles('admin'), bulkArchiveInvoices);
 router.patch('/bulk/assign', authMiddleware, authorizeRoles('admin'), bulkAssignInvoices);
 router.patch('/bulk/approve', authMiddleware, authorizeRoles('approver','admin'), bulkApproveInvoices);


### PR DESCRIPTION
## Summary
- create `vendorReplyController` for drafting/sending vendor emails
- expose `/api/invoices/:id/vendor-reply` route
- document feature and example requests in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848a89b3564832e943ca64ad34d48cb