### PR TITLE
Add scenario cash-flow endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Real-time "Ops Mode" dashboard with a live feed of invoice activity
 - Multi-tenant support so agencies can switch between different client accounts
 - Polite vendor notification emails for flagged or rejected invoices
+- Scenario planning to test payment delays
 
 ## Setup Instructions
 
@@ -132,6 +133,7 @@ job deletes invoices once their `delete_at` date passes.
 - `PATCH /api/invoices/:id/retention` – update an invoice retention policy (6m, 2y, forever)
 - `POST /api/invoices/payment-risk` – predict payment delay risk for a vendor
 - `POST /api/invoices/nl-chart` – run a natural language query and return data for charts
+- `POST /api/invoices/cash-flow/scenario` – recalculate cash flow under payment delay scenarios
 - `POST /api/invoices/:id/vendor-reply` – generate or send a polite vendor email when an invoice is flagged or rejected
 - `GET /api/invoices/:id/payment-request` – download a JSON payload for a payment request form
 - `POST /api/feedback` – submit a rating for an AI-generated result

--- a/backend/controllers/scenarioController.js
+++ b/backend/controllers/scenarioController.js
@@ -1,0 +1,31 @@
+const pool = require('../config/db');
+
+exports.scenarioCashFlow = async (req, res) => {
+  const delayDays = parseInt(req.body.delayDays, 10) || 0;
+  try {
+    const result = await pool.query(
+      `SELECT amount, COALESCE(due_date, date) AS pay_date, priority
+       FROM invoices`
+    );
+    const baseline = {};
+    const scenario = {};
+    for (const row of result.rows) {
+      const amount = parseFloat(row.amount);
+      const payDate = new Date(row.pay_date);
+      const baseKey = payDate.toISOString().slice(0, 10);
+      baseline[baseKey] = (baseline[baseKey] || 0) + amount;
+
+      const scenarioDate = new Date(payDate);
+      if (!row.priority) {
+        scenarioDate.setDate(scenarioDate.getDate() + delayDays);
+      }
+      const scenarioKey = scenarioDate.toISOString().slice(0, 10);
+      scenario[scenarioKey] = (scenario[scenarioKey] || 0) + amount;
+    }
+    const format = obj => Object.keys(obj).sort().map(d => ({ date: d, total: obj[d] }));
+    res.json({ delayDays, baseline: format(baseline), scenario: format(scenario) });
+  } catch (err) {
+    console.error('Scenario cash flow error:', err);
+    res.status(500).json({ message: 'Failed to calculate scenario cash flow' });
+  }
+};

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -66,6 +66,7 @@ const { getAnomalies } = require('../controllers/anomalyController');
 const { detectPatterns } = require('../controllers/fraudController');
 const { vendorReply } = require('../controllers/vendorReplyController');
 const { paymentRequest } = require('../controllers/paymentRequestController');
+const { scenarioCashFlow } = require('../controllers/scenarioController');
 
 
 router.get('/export-archived', authMiddleware, exportArchivedInvoicesCSV);
@@ -89,6 +90,7 @@ router.get('/export-all', authMiddleware, exportAllInvoices);
 router.post('/summarize-vendor-data', summarizeVendorData);
 router.get('/monthly-insights', authMiddleware, getMonthlyInsights);
 router.get('/cash-flow', authMiddleware, getCashFlow);
+router.post('/cash-flow/scenario', authMiddleware, scenarioCashFlow);
 router.get('/top-vendors', authMiddleware, getTopVendors);
 router.get('/spending-by-tag', authMiddleware, getSpendingByTag);
 router.get('/recurring/insights', authMiddleware, getRecurringInsights);


### PR DESCRIPTION
## Summary
- add scenario planning bullet
- document cash flow scenario endpoint
- implement `scenarioCashFlow` controller
- expose `/cash-flow/scenario` route

## Testing
- `npm install --silent` in `backend`
- `node -e "require('./backend/controllers/scenarioController.js'); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_6848aceaf71c832eac2ddc3ab01c297e