### PR TITLE
Implement vendor scorecard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Multi-tenant support so agencies can switch between different client accounts
 - Polite vendor notification emails for flagged or rejected invoices
 - Scenario planning to test payment delays
+- Vendor scorecards rating responsiveness, payment consistency, and volume/price trends
 
 ## Setup Instructions
 
@@ -138,6 +139,7 @@ job deletes invoices once their `delete_at` date passes.
 - `GET /api/invoices/:id/payment-request` – download a JSON payload for a payment request form
 - `POST /api/feedback` – submit a rating for an AI-generated result
 - `GET /api/feedback` – view average ratings by endpoint
+- `GET /api/invoices/vendor-scorecards` – view vendor responsiveness and payment metrics
 
 ### Vendor Reply Drafts
 

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -44,6 +44,7 @@ const {
   explainFlaggedInvoice,
   bulkAutoCategorize,
   getVendorBio,
+  getVendorScorecards,
 } = require('../controllers/invoiceController');
 
 
@@ -126,6 +127,7 @@ router.get('/budgets/warnings', authMiddleware, checkBudgetWarnings);
 router.get('/anomalies', authMiddleware, getAnomalies);
 router.get('/fraud/patterns', authMiddleware, authorizeRoles('admin'), detectPatterns);
 router.get('/:id/check-recurring', authMiddleware, checkRecurringInvoice);
+router.get('/vendor-scorecards', authMiddleware, getVendorScorecards);
 
 
 // ✅ GET PDF download


### PR DESCRIPTION
## Summary
- compute vendor scorecards for responsiveness, payment consistency and spending trends
- expose new `GET /api/invoices/vendor-scorecards` route
- document vendor scorecards and endpoint in README

## Testing
- `npm install` *(fails: no command)*

------
https://chatgpt.com/codex/tasks/task_e_6848ae1fa7e8832eb32ed0ec275c61a2