### PR TITLE
Add AI-based tag color suggestions

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -49,7 +49,7 @@ const {
 
 
 const { summarizeUploadErrors } = require('../controllers/aiController');
-const { invoiceQualityScore, assistantQuery, paymentRiskScore, nlChartQuery } = require('../controllers/aiController');
+const { invoiceQualityScore, assistantQuery, paymentRiskScore, nlChartQuery, suggestTagColors } = require('../controllers/aiController');
 const router = express.Router();
 const { sendSummaryEmail } = require('../controllers/emailController');
 const { summarizeVendorData } = require('../controllers/aiController');
@@ -118,6 +118,7 @@ router.post('/bulk/auto-categorize', authMiddleware, bulkAutoCategorize);
 router.patch('/:id/notes', authMiddleware, authorizeRoles('admin'), updatePrivateNotes);
 router.patch('/:id/retention', authMiddleware, authorizeRoles('admin'), updateRetentionPolicy);
 router.post('/suggest-tags', authMiddleware, suggestTags);
+router.post('/suggest-tag-colors', authMiddleware, suggestTagColors);
 router.post('/:id/update-tags', authMiddleware, updateInvoiceTags);
 router.get('/logs', authMiddleware, authorizeRoles('admin'), getActivityLogs);
 router.get('/logs/export', authMiddleware, authorizeRoles('admin'), exportComplianceReport);


### PR DESCRIPTION
## Summary
- add tag color suggestion API using OpenRouter AI
- expose new route to fetch tag color suggestions
- fetch semantic colors on invoice load and render tags with them

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848b49ebea4832e910ceb40283a85e7