### PR TITLE
Initialize database columns on server start

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ require('dotenv').config();                 // load environment variables
 const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
 const feedbackRoutes = require('./routes/feedbackRoutes');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
+const { initDb } = require('./utils/dbInit');
 
 const app = express();                      // create the app
 
@@ -16,15 +17,19 @@ app.use(express.json());                    // allow reading JSON data
 app.use('/api/invoices', invoiceRoutes);    // route all invoice requests here
 app.use('/api/feedback', feedbackRoutes);
 
-// Run auto-archive daily
-autoArchiveOldInvoices();
-setInterval(autoArchiveOldInvoices, 24 * 60 * 60 * 1000); // every 24h
-autoDeleteExpiredInvoices();
-setInterval(autoDeleteExpiredInvoices, 24 * 60 * 60 * 1000);
+(async () => {
+  await initDb();
 
-console.log('🟢 Routes mounted');
+  // Run auto-archive daily
+  autoArchiveOldInvoices();
+  setInterval(autoArchiveOldInvoices, 24 * 60 * 60 * 1000); // every 24h
+  autoDeleteExpiredInvoices();
+  setInterval(autoDeleteExpiredInvoices, 24 * 60 * 60 * 1000);
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`🚀 Server running on http://localhost:${port}`);
-});
+  console.log('🟢 Routes mounted');
+
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`🚀 Server running on http://localhost:${port}`);
+  });
+})();

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -1,0 +1,51 @@
+const pool = require('../config/db');
+
+async function initDb() {
+  try {
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS assignee TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS approval_status TEXT DEFAULT 'Pending'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS approval_history JSONB DEFAULT '[]'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS comments JSONB DEFAULT '[]'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS priority BOOLEAN DEFAULT FALSE");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS flagged BOOLEAN DEFAULT FALSE");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS flag_reason TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS approval_chain JSONB DEFAULT '["Manager","Finance","CFO"]'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS current_step INTEGER DEFAULT 0");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS payment_terms TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS private_notes TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS due_date DATE");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS integrity_hash TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS retention_policy TEXT DEFAULT 'forever'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS delete_at TIMESTAMP");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS tenant_id TEXT DEFAULT 'default'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS department TEXT");
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS activity_logs (
+      id SERIAL PRIMARY KEY,
+      user_id INTEGER,
+      action TEXT NOT NULL,
+      invoice_id INTEGER,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS budgets (
+      id SERIAL PRIMARY KEY,
+      vendor TEXT,
+      tag TEXT,
+      period TEXT NOT NULL,
+      amount NUMERIC NOT NULL,
+      UNIQUE(vendor, tag, period)
+    )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS feedback (
+      id SERIAL PRIMARY KEY,
+      endpoint TEXT,
+      rating INTEGER NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+  } catch (err) {
+    console.error('Database init error:', err);
+  }
+}
+
+module.exports = { initDb };


### PR DESCRIPTION
## Summary
- add `dbInit.js` to ensure required invoice columns and tables exist
- call `initDb` from `app.js` before scheduling background tasks

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849ee205398832eb9ea37f16e273e65