### PR TITLE
Fix graph view error

### DIFF
--- a/frontend/src/components/GraphView.js
+++ b/frontend/src/components/GraphView.js
@@ -3,6 +3,7 @@ import ForceGraph2D from 'react-force-graph-2d';
 
 const GraphView = ({ token, tenant }) => {
   const [data, setData] = useState({ nodes: [], links: [] });
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchGraph = async () => {
@@ -14,24 +15,34 @@ const GraphView = ({ token, tenant }) => {
           },
         });
         const json = await res.json();
-        setData(json);
+        if (!res.ok || !json.nodes || !json.links) {
+          throw new Error(json.message || 'Invalid graph response');
+        }
+        setData({ nodes: json.nodes, links: json.links });
+        setError(null);
       } catch (err) {
         console.error('Graph fetch error:', err);
+        setError('Failed to load graph');
+        setData({ nodes: [], links: [] });
       }
     };
     fetchGraph();
   }, [token, tenant]);
 
   return (
-    <div className="h-96 border rounded">
-      <ForceGraph2D
-        graphData={data}
-        nodeId="id"
-        nodeLabel="label"
-        nodeAutoColorBy="type"
-        linkDirectionalArrowLength={4}
-        linkDirectionalArrowRelPos={1}
-      />
+    <div className="h-96 border rounded flex items-center justify-center">
+      {error ? (
+        <p className="text-sm text-red-500">{error}</p>
+      ) : (
+        <ForceGraph2D
+          graphData={data}
+          nodeId="id"
+          nodeLabel="label"
+          nodeAutoColorBy="type"
+          linkDirectionalArrowLength={4}
+          linkDirectionalArrowRelPos={1}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- handle invalid graph responses in `GraphView`
- show user-friendly error message

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a0451a044832ead38a2398a8f7eaa