### PR TITLE
Add explicit Light Mode button

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1507,6 +1507,14 @@ useEffect(() => {
             >
               {darkMode ? '☀️' : '🌙'}
             </button>
+            {darkMode && (
+              <button
+                onClick={() => setDarkMode(false)}
+                className="ml-2 px-2 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded focus:outline-none"
+              >
+                Light Mode
+              </button>
+            )}
             {token && (
               <>
                 <span className="text-sm">by Bini</span>


### PR DESCRIPTION
## Summary
- add button to switch from dark mode back to light mode

## Testing
- `npm test --silent` *(fails: SyntaxError when running jest)*

------
https://chatgpt.com/codex/tasks/task_e_684a4aaa57d8832e9f3bbf9df60fa241