### PR TITLE
Fix frontend white screen

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -9,13 +9,17 @@ if (savedTheme === 'dark') {
   document.documentElement.classList.add('dark');
 }
 
-const apiBase = process.env.REACT_APP_API_BASE_URL;
-fetch(`${apiBase}/api/invoices`);
+const apiBase = process.env.REACT_APP_API_BASE_URL || '';
+if (apiBase) {
+  fetch(`${apiBase}/api/invoices`).catch((err) => {
+    console.error('API connection failed', err);
+  });
+}
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);
 
 // register service worker for offline support
-serviceWorkerRegistration.register();
+serviceWorkerRegistration.unregister();
 
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
## Summary
- disable the service worker to avoid caching old assets
- handle missing API base URL to prevent runtime fetch error

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a7c1542bc832eb4b0ff8b3ca273fe