### PR TITLE
Add AI dashboard route with charts

### DIFF
--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -1027,6 +1027,27 @@ exports.getSpendingByTag = async (req, res) => {
   }
 };
 
+exports.getUploadHeatmap = async (req, res) => {
+  try {
+    const result = await pool.query(`
+      SELECT EXTRACT(DOW FROM created_at) AS dow,
+             EXTRACT(HOUR FROM created_at) AS hour,
+             COUNT(*) AS count
+      FROM invoices
+      GROUP BY dow, hour
+    `);
+    const heatmap = result.rows.map(r => ({
+      day: parseInt(r.dow, 10),
+      hour: parseInt(r.hour, 10),
+      count: parseInt(r.count, 10)
+    }));
+    res.json({ heatmap });
+  } catch (err) {
+    console.error('Upload heatmap error:', err);
+    res.status(500).json({ message: 'Failed to fetch heatmap data' });
+  }
+};
+
 exports.exportDashboardPDF = async (req, res) => {
   const client = await pool.connect();
   try {
@@ -1463,5 +1484,6 @@ module.exports = {
   getVendorBio: exports.getVendorBio,
   getVendorScorecards: exports.getVendorScorecards,
   getRelationshipGraph: exports.getRelationshipGraph,
+  getUploadHeatmap: exports.getUploadHeatmap,
 };
 

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -21,6 +21,7 @@ const {
   getCashFlow,
   getTopVendors,
   getSpendingByTag,
+  getUploadHeatmap,
   exportDashboardPDF,
   checkRecurringInvoice,
   getRecurringInsights,
@@ -90,6 +91,7 @@ router.get('/cash-flow', authMiddleware, getCashFlow);
 router.post('/cash-flow/scenario', authMiddleware, scenarioCashFlow);
 router.get('/top-vendors', authMiddleware, getTopVendors);
 router.get('/spending-by-tag', authMiddleware, getSpendingByTag);
+router.get('/upload-heatmap', authMiddleware, getUploadHeatmap);
 router.get('/recurring/insights', authMiddleware, getRecurringInsights);
 router.get('/vendor-profile/:vendor', authMiddleware, getVendorProfile);
 router.get('/vendor-bio/:vendor', authMiddleware, getVendorBio);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.1.0",
         "react-force-graph": "^1.47.6",
         "react-force-graph-2d": "^1.27.1",
+        "react-router-dom": "6.22.3",
         "react-scripts": "5.0.1",
         "recharts": "^2.15.3",
         "web-vitals": "^2.1.4"
@@ -3117,6 +3118,15 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
+      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -15798,6 +15808,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
+      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.15.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.22.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
+      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.15.3",
+        "react-router": "6.22.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "react-dom": "^19.1.0",
     "react-force-graph": "^1.47.6",
     "react-force-graph-2d": "^1.27.1",
+    "react-router-dom": "6.22.3",
     "react-scripts": "5.0.1",
     "recharts": "^2.15.3",
     "web-vitals": "^2.1.4"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-use-before-define */
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import LiveFeed from './components/LiveFeed';
 import TenantSwitcher from './components/TenantSwitcher';
 import {
@@ -1441,6 +1442,7 @@ useEffect(() => {
           <div className="flex items-center space-x-4">
             <TenantSwitcher tenant={tenant} onChange={setTenant} />
             <NotificationBell notifications={notifications} onOpen={markNotificationsRead} />
+            <Link to="/dashboard" className="underline text-sm">Dashboard</Link>
             <button
               onClick={() => setDarkMode((d) => !d)}
               className="text-xl focus:outline-none"

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
+
+function Dashboard() {
+  const token = localStorage.getItem('token') || '';
+  const [vendors, setVendors] = useState([]);
+  const [cashFlow, setCashFlow] = useState([]);
+  const [heatmap, setHeatmap] = useState([]);
+
+  useEffect(() => {
+    if (!token) return;
+    const headers = { Authorization: `Bearer ${token}` };
+    fetch('http://localhost:3000/api/invoices/top-vendors', { headers })
+      .then(r => r.json().then(d => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => { if (ok) setVendors(d.topVendors || []); });
+    fetch('http://localhost:3000/api/invoices/cash-flow?interval=monthly', { headers })
+      .then(r => r.json().then(d => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => { if (ok) setCashFlow(d.data || []); });
+    fetch('http://localhost:3000/api/invoices/upload-heatmap', { headers })
+      .then(r => r.json().then(d => ({ ok: r.ok, d })))
+      .then(({ ok, d }) => { if (ok) setHeatmap(d.heatmap || []); });
+  }, [token]);
+
+  const grid = Array.from({ length: 7 }, () => Array(24).fill(0));
+  let max = 0;
+  heatmap.forEach(({ day, hour, count }) => {
+    grid[day][hour] = count;
+    if (count > max) max = count;
+  });
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
+      <nav className="mb-4 flex justify-between items-center">
+        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">AI Dashboard</h1>
+        <Link to="/" className="text-blue-600 underline">Back to App</Link>
+      </nav>
+      {!token ? (
+        <p className="text-center text-gray-600">Please log in from the main app.</p>
+      ) : (
+        <div className="space-y-8">
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={vendors} dataKey="total" nameKey="vendor" outerRadius={80}>
+                  {vendors.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={cashFlow}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="period" tickFormatter={(v) => new Date(v).toLocaleDateString()} />
+                <YAxis />
+                <Tooltip labelFormatter={(v) => new Date(v).toLocaleDateString()} />
+                <Bar dataKey="total" fill="#3b82f6" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Suspicious Pattern Heatmap</h2>
+            <div className="overflow-x-auto">
+              <table className="table-fixed border-collapse">
+                <thead>
+                  <tr>
+                    <th></th>
+                    {Array.from({ length: 24 }).map((_, h) => (
+                      <th key={h} className="px-1 text-xs font-normal">{h}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {grid.map((row, d) => (
+                    <tr key={d} className="text-center">
+                      <td className="pr-1 text-xs font-normal">{['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][d]}</td>
+                      {row.map((c, h) => {
+                        const intensity = max ? Math.round((c / max) * 255) : 0;
+                        const bg = `rgba(220,38,38,${intensity / 255})`;
+                        return <td key={h} style={{ backgroundColor: bg }} className="w-4 h-4"></td>;
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Highest Vendor Expenses</h2>
+            <ul className="list-disc pl-5 text-gray-700 dark:text-gray-300">
+              {vendors.map(v => (
+                <li key={v.vendor}>{v.vendor}: ${v.total.toFixed(2)}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import Dashboard from './Dashboard';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 
@@ -16,7 +18,14 @@ if (apiBase) {
   });
 }
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <BrowserRouter>
+    <Routes>
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/*" element={<App />} />
+    </Routes>
+  </BrowserRouter>
+);
 
 // register service worker for offline support
 serviceWorkerRegistration.unregister();


### PR DESCRIPTION
## Summary
- create AI dashboard page with vendor pie chart, cash flow bar chart, vendor expenses list and heatmap
- add routing via react-router-dom
- expose new backend endpoint `/api/invoices/upload-heatmap`
- link dashboard from navigation

## Testing
- `npm test -- --watchAll=false` *(fails: SyntaxError in GraphView.js)*

------
https://chatgpt.com/codex/tasks/task_e_684a7e90ae64832ea334c4096490ba97