### PR TITLE
Add analytics reports feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Recurring invoice detection with notifications
 - Linked invoice relationship graph to spot duplicates and vendor patterns
 - Smart auto-fill suggestions for vendor tags and payment terms
+- Analytics and reports page with filtering and PDF export
 - Private notes on invoices
 - Shared comment threads for team discussion
 - Approver reminders with escalation

--- a/backend/app.js
+++ b/backend/app.js
@@ -5,6 +5,7 @@ const cors = require('cors');
 require('dotenv').config();                 // load environment variables
 const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
 const feedbackRoutes = require('./routes/feedbackRoutes');
+const analyticsRoutes = require('./routes/analyticsRoutes');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
 const { initDb } = require('./utils/dbInit');
 
@@ -16,6 +17,7 @@ app.use(cors());
 app.use(express.json());                    // allow reading JSON data
 app.use('/api/invoices', invoiceRoutes);    // route all invoice requests here
 app.use('/api/feedback', feedbackRoutes);
+app.use('/api/analytics', analyticsRoutes);
 
 (async () => {
   await initDb();

--- a/backend/controllers/analyticsController.js
+++ b/backend/controllers/analyticsController.js
@@ -1,0 +1,72 @@
+const pool = require('../config/db');
+const PDFDocument = require('pdfkit');
+
+function buildFilterQuery({ vendor, startDate, endDate, minAmount, maxAmount }) {
+  const params = [];
+  const conditions = [];
+  if (vendor) {
+    params.push(`%${vendor}%`);
+    conditions.push(`LOWER(vendor) LIKE LOWER($${params.length})`);
+  }
+  if (startDate) {
+    params.push(startDate);
+    conditions.push(`date >= $${params.length}`);
+  }
+  if (endDate) {
+    params.push(endDate);
+    conditions.push(`date <= $${params.length}`);
+  }
+  if (minAmount) {
+    params.push(minAmount);
+    conditions.push(`amount >= $${params.length}`);
+  }
+  if (maxAmount) {
+    params.push(maxAmount);
+    conditions.push(`amount <= $${params.length}`);
+  }
+  const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  return { where, params };
+}
+
+exports.getReport = async (req, res) => {
+  const { vendor, startDate, endDate, minAmount, maxAmount } = req.query;
+  const { where, params } = buildFilterQuery({ vendor, startDate, endDate, minAmount, maxAmount });
+  try {
+    const result = await pool.query(
+      `SELECT id, invoice_number, date, vendor, amount FROM invoices ${where} ORDER BY date DESC`,
+      params
+    );
+    res.json({ invoices: result.rows });
+  } catch (err) {
+    console.error('Analytics report error:', err);
+    res.status(500).json({ message: 'Failed to fetch report' });
+  }
+};
+
+exports.exportReportPDF = async (req, res) => {
+  const { vendor, startDate, endDate, minAmount, maxAmount } = req.query;
+  const { where, params } = buildFilterQuery({ vendor, startDate, endDate, minAmount, maxAmount });
+  try {
+    const result = await pool.query(
+      `SELECT invoice_number, date, vendor, amount FROM invoices ${where} ORDER BY date DESC`,
+      params
+    );
+    const doc = new PDFDocument();
+    res.setHeader('Content-Type', 'application/pdf');
+    res.setHeader('Content-Disposition', 'attachment; filename="report.pdf"');
+    doc.pipe(res);
+    doc.fontSize(18).text('Invoice Report', { align: 'center' });
+    doc.moveDown();
+    result.rows.forEach((inv) => {
+      doc.fontSize(12).text(`Invoice #${inv.invoice_number}`);
+      doc.text(`Date: ${inv.date}`);
+      doc.text(`Vendor: ${inv.vendor}`);
+      doc.text(`Amount: $${parseFloat(inv.amount).toFixed(2)}`);
+      doc.moveDown();
+    });
+    doc.end();
+  } catch (err) {
+    console.error('Report PDF error:', err);
+    res.status(500).json({ message: 'Failed to export report' });
+  }
+};

--- a/backend/controllers/rulesController.js
+++ b/backend/controllers/rulesController.js
@@ -1,0 +1,14 @@
+const { getRules, addRule } = require('../utils/rulesEngine');
+
+exports.listRules = (_req, res) => {
+  res.json({ rules: getRules() });
+};
+
+exports.addRule = (req, res) => {
+  const rule = req.body;
+  if (!rule || (!rule.vendor && !rule.amountGreaterThan)) {
+    return res.status(400).json({ message: 'Invalid rule' });
+  }
+  addRule(rule);
+  res.json({ message: 'Rule added', rules: getRules() });
+};

--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const { getReport, exportReportPDF } = require('../controllers/analyticsController');
+const { listRules, addRule } = require('../controllers/rulesController');
+const { authMiddleware } = require('../controllers/userController');
+
+router.get('/report', authMiddleware, getReport);
+router.get('/report/pdf', authMiddleware, exportReportPDF);
+router.get('/rules', authMiddleware, listRules);
+router.post('/rules', authMiddleware, addRule);
+
+module.exports = router;

--- a/backend/utils/rulesEngine.js
+++ b/backend/utils/rulesEngine.js
@@ -1,15 +1,15 @@
-const rules = [
-  { vendor: 'X', amountGreaterThan: 500, flagReason: 'Vendor X amount > $500' }
+let rules = [
+  { vendor: 'X', amountGreaterThan: 500, flagReason: 'Vendor X amount > $500' },
+  { amountGreaterThan: 5000, flagReason: 'Amount exceeds $5000' },
 ];
 
 function applyRules(invoice) {
   let flagged = false;
   let reason = null;
   for (const r of rules) {
-    if (
-      r.vendor && invoice.vendor && invoice.vendor.toLowerCase() === r.vendor.toLowerCase() &&
-      r.amountGreaterThan && parseFloat(invoice.amount) > r.amountGreaterThan
-    ) {
+    const matchVendor = !r.vendor || (invoice.vendor && invoice.vendor.toLowerCase() === r.vendor.toLowerCase());
+    const matchAmount = r.amountGreaterThan && parseFloat(invoice.amount) > r.amountGreaterThan;
+    if (matchVendor && matchAmount) {
       flagged = true;
       reason = r.flagReason || 'Rule triggered';
       break;
@@ -18,4 +18,16 @@ function applyRules(invoice) {
   return { ...invoice, flagged, flag_reason: reason };
 }
 
-module.exports = { applyRules };
+function getRules() {
+  return rules;
+}
+
+function addRule(rule) {
+  rules.push(rule);
+}
+
+function setRules(newRules) {
+  rules = newRules;
+}
+
+module.exports = { applyRules, getRules, addRule, setRules };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1443,6 +1443,7 @@ useEffect(() => {
             <TenantSwitcher tenant={tenant} onChange={setTenant} />
             <NotificationBell notifications={notifications} onOpen={markNotificationsRead} />
             <Link to="/dashboard" className="underline text-sm">Dashboard</Link>
+            <Link to="/reports" className="underline text-sm">Reports</Link>
             <button
               onClick={() => setDarkMode((d) => !d)}
               className="text-xl focus:outline-none"

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -1,0 +1,124 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+
+function Reports() {
+  const token = localStorage.getItem('token') || '';
+  const [vendor, setVendor] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [minAmount, setMinAmount] = useState('');
+  const [maxAmount, setMaxAmount] = useState('');
+  const [invoices, setInvoices] = useState([]);
+  const [threshold, setThreshold] = useState(5000);
+  const [rules, setRules] = useState([]);
+
+  const fetchReport = async () => {
+    const params = new URLSearchParams();
+    if (vendor) params.append('vendor', vendor);
+    if (startDate) params.append('startDate', startDate);
+    if (endDate) params.append('endDate', endDate);
+    if (minAmount) params.append('minAmount', minAmount);
+    if (maxAmount) params.append('maxAmount', maxAmount);
+    const res = await fetch(`http://localhost:3000/api/analytics/report?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (res.ok) setInvoices(data.invoices || []);
+  };
+
+  const exportPDF = async () => {
+    const params = new URLSearchParams();
+    if (vendor) params.append('vendor', vendor);
+    if (startDate) params.append('startDate', startDate);
+    if (endDate) params.append('endDate', endDate);
+    if (minAmount) params.append('minAmount', minAmount);
+    if (maxAmount) params.append('maxAmount', maxAmount);
+    const res = await fetch(`http://localhost:3000/api/analytics/report/pdf?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'report.pdf';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  const loadRules = async () => {
+    const res = await fetch('http://localhost:3000/api/analytics/rules', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (res.ok) setRules(data.rules || []);
+  };
+
+  const addAmountRule = async () => {
+    await fetch('http://localhost:3000/api/analytics/rules', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ amountGreaterThan: parseFloat(threshold), flagReason: `Amount over $${threshold}` })
+    });
+    loadRules();
+  };
+
+  useEffect(() => { if (token) loadRules(); }, [token]);
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
+      <nav className="mb-4 flex justify-between items-center">
+        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Reports</h1>
+        <Link to="/" className="text-blue-600 underline">Back to App</Link>
+      </nav>
+      <div className="space-y-4 max-w-2xl">
+        <div className="grid grid-cols-2 gap-2">
+          <input value={vendor} onChange={e => setVendor(e.target.value)} placeholder="Vendor" className="border p-2 rounded" />
+          <div className="flex space-x-2">
+            <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} className="border p-2 rounded w-full" />
+            <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} className="border p-2 rounded w-full" />
+          </div>
+          <input type="number" value={minAmount} onChange={e => setMinAmount(e.target.value)} placeholder="Min" className="border p-2 rounded" />
+          <input type="number" value={maxAmount} onChange={e => setMaxAmount(e.target.value)} placeholder="Max" className="border p-2 rounded" />
+        </div>
+        <div className="space-x-2">
+          <button onClick={fetchReport} className="btn btn-primary">Run Report</button>
+          <button onClick={exportPDF} className="btn btn-primary bg-green-700 hover:bg-green-800">Export PDF</button>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-1 text-gray-800 dark:text-gray-100">Auto-Flag Rule</h2>
+          <div className="flex space-x-2 items-center">
+            <input type="number" value={threshold} onChange={e => setThreshold(e.target.value)} className="border p-2 rounded w-32" />
+            <button onClick={addAmountRule} className="btn btn-primary">Set Threshold</button>
+          </div>
+          <ul className="list-disc pl-5 mt-2 text-gray-700 dark:text-gray-300">
+            {rules.map((r, i) => <li key={i}>{r.flagReason}</li>)}
+          </ul>
+        </div>
+        <div>
+          <table className="min-w-full border text-sm">
+            <thead>
+              <tr className="bg-gray-200 dark:bg-gray-700">
+                <th className="px-2 py-1">#</th>
+                <th className="px-2 py-1">Date</th>
+                <th className="px-2 py-1">Vendor</th>
+                <th className="px-2 py-1">Amount</th>
+              </tr>
+            </thead>
+            <tbody>
+              {invoices.map(inv => (
+                <tr key={inv.id} className="border-t">
+                  <td className="px-2 py-1">{inv.invoice_number}</td>
+                  <td className="px-2 py-1">{new Date(inv.date).toLocaleDateString()}</td>
+                  <td className="px-2 py-1">{inv.vendor}</td>
+                  <td className="px-2 py-1">${inv.amount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Reports;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import Dashboard from './Dashboard';
+import Reports from './Reports';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
@@ -22,6 +23,7 @@ root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/reports" element={<Reports />} />
       <Route path="/*" element={<App />} />
     </Routes>
   </BrowserRouter>


### PR DESCRIPTION
## Summary
- implement analytics routes and controllers for filtered reports
- manage custom rules via rules engine
- expose new /reports page in React frontend
- update navigation and routing
- document reports feature in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a805d798c832eb7fdc5e89e10e2c8