### PR TITLE
Fix handleBulkArchive initialization

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -324,6 +324,12 @@ const searchInputRef = useRef();
     fetchInvoices(showArchived, selectedAssignee);
   }, [fetchInvoices, showArchived, selectedAssignee]);
 
+  const handleBulkArchive = useCallback(() => {
+    selectedInvoices.forEach((id) => handleArchive(id));
+    setSelectedInvoices([]);
+  }, [selectedInvoices, handleArchive]);
+
+
   
   useEffect(() => {
     localStorage.setItem('viewMode', viewMode);
@@ -470,13 +476,7 @@ const searchInputRef = useRef();
       setSelectedInvoices(visibleIds);
     }
   };
-  
-  const handleBulkArchive = useCallback(() => {
-    selectedInvoices.forEach((id) => handleArchive(id));
-    setSelectedInvoices([]);
-  }, [selectedInvoices, handleArchive]);
-  
-  const handleBulkDelete = () => {
+const handleBulkDelete = () => {
     selectedInvoices.forEach((id) => handleDelete(id));
     setSelectedInvoices([]);
   };


### PR DESCRIPTION
## Summary
- fix runtime error from `handleBulkArchive` being referenced before initialization

## Testing
- `npm test --silent --yes` *(fails: react-scripts not configured for Jest in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684b368efe68832eb4c5ec794049a096