### PR TITLE
Add team management page

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ require('dotenv').config();                 // load environment variables
 const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
 const feedbackRoutes = require('./routes/feedbackRoutes');
 const analyticsRoutes = require('./routes/analyticsRoutes');
+const userRoutes = require('./routes/userRoutes');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
 const { initDb } = require('./utils/dbInit');
 
@@ -18,6 +19,7 @@ app.use(express.json());                    // allow reading JSON data
 app.use('/api/invoices', invoiceRoutes);    // route all invoice requests here
 app.use('/api/feedback', feedbackRoutes);
 app.use('/api/analytics', analyticsRoutes);
+app.use('/api/users', userRoutes);
 
 (async () => {
   await initDb();

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const router = express.Router();
+const {
+  getUsers,
+  addUser,
+  deleteUser,
+  updateUserRole,
+  authMiddleware,
+  authorizeRoles
+} = require('../controllers/userController');
+
+router.get('/', authMiddleware, authorizeRoles('admin'), getUsers);
+router.post('/', authMiddleware, authorizeRoles('admin'), addUser);
+router.delete('/:id', authMiddleware, authorizeRoles('admin'), deleteUser);
+router.patch('/:id/role', authMiddleware, authorizeRoles('admin'), updateUserRole);
+
+module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1448,6 +1448,9 @@ useEffect(() => {
             <Link to="/dashboard" className="underline text-sm">Dashboard</Link>
             <Link to="/reports" className="underline text-sm">Reports</Link>
             <Link to="/archive" className="underline text-sm">Archive</Link>
+            {role === 'admin' && (
+              <Link to="/team" className="underline text-sm">Team</Link>
+            )}
             <button
               onClick={() => setDarkMode((d) => !d)}
               className="text-xl focus:outline-none"

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+function TeamManagement() {
+  const token = localStorage.getItem('token') || '';
+  const role = localStorage.getItem('role') || '';
+  const [users, setUsers] = useState([]);
+  const [logs, setLogs] = useState([]);
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [newRole, setNewRole] = useState('viewer');
+
+  const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+  const fetchUsers = async () => {
+    const res = await fetch('http://localhost:3000/api/users', { headers });
+    const data = await res.json();
+    if (res.ok) setUsers(data);
+  };
+
+  const fetchLogs = async () => {
+    const res = await fetch('http://localhost:3000/api/invoices/logs', { headers });
+    const data = await res.json();
+    if (res.ok) setLogs(data);
+  };
+
+  useEffect(() => { if (token) { fetchUsers(); fetchLogs(); } }, [token]);
+
+  const addUser = async () => {
+    await fetch('http://localhost:3000/api/users', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ username, password, role: newRole })
+    });
+    setUsername('');
+    setPassword('');
+    setNewRole('viewer');
+    fetchUsers();
+  };
+
+  const deleteUser = async (id) => {
+    await fetch(`http://localhost:3000/api/users/${id}`, { method: 'DELETE', headers });
+    fetchUsers();
+  };
+
+  const changeRole = async (id, role) => {
+    await fetch(`http://localhost:3000/api/users/${id}/role`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ role })
+    });
+    fetchUsers();
+  };
+
+  if (role !== 'admin') {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-700">Access denied.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
+      <nav className="mb-4 flex justify-between items-center">
+        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Team Management</h1>
+        <Link to="/" className="text-blue-600 underline">Back to App</Link>
+      </nav>
+      <div className="space-y-6 max-w-xl">
+        <div className="space-y-2">
+          <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="border p-2 rounded w-full" />
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2 rounded w-full" />
+          <select value={newRole} onChange={e => setNewRole(e.target.value)} className="border p-2 rounded w-full">
+            <option value="viewer">viewer</option>
+            <option value="approver">approver</option>
+            <option value="admin">admin</option>
+          </select>
+          <button onClick={addUser} className="bg-blue-600 text-white px-3 py-1 rounded">Add User</button>
+        </div>
+        <table className="w-full text-left border mt-4">
+          <thead>
+            <tr className="bg-gray-200 dark:bg-gray-700">
+              <th className="p-2">Username</th>
+              <th className="p-2">Role</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map(u => (
+              <tr key={u.id} className="border-t">
+                <td className="p-2">{u.username}</td>
+                <td className="p-2">
+                  <select value={u.role} onChange={e => changeRole(u.id, e.target.value)} className="border p-1 rounded">
+                    <option value="viewer">viewer</option>
+                    <option value="approver">approver</option>
+                    <option value="admin">admin</option>
+                  </select>
+                </td>
+                <td className="p-2">
+                  <button onClick={() => deleteUser(u.id)} className="text-red-600">Remove</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Activity Logs</h2>
+          <ul className="max-h-64 overflow-y-auto text-sm">
+            {logs.map(log => (
+              <li key={log.id}>{new Date(log.created_at).toLocaleString()} - {log.action} (user {log.user_id})</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TeamManagement;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,6 +4,7 @@ import App from './App';
 import Dashboard from './Dashboard';
 import Reports from './Reports';
 import Archive from './Archive';
+import TeamManagement from './TeamManagement';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
@@ -26,6 +27,7 @@ root.render(
       <Route path="/dashboard" element={<Dashboard />} />
       <Route path="/reports" element={<Reports />} />
       <Route path="/archive" element={<Archive />} />
+      <Route path="/team" element={<TeamManagement />} />
       <Route path="/*" element={<App />} />
     </Routes>
   </BrowserRouter>


### PR DESCRIPTION
## Summary
- add REST routes for user management
- extend backend to create/update/delete users and view user list
- mount the new user routes in the server
- create TeamManagement React page for admins
- link team page from navbar and router

## Testing
- `CI=true npm test --silent` *(fails: Jest encountered an unexpected token)*
- `npm test` in backend *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684b3ffb4100832eaefe790e0a64d85b