### PR TITLE
Implement vendor management page with notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Polite vendor notification emails for flagged or rejected invoices
 - Scenario planning to test payment delays
 - Vendor scorecards rating responsiveness, payment consistency, and volume/price trends
+- Vendor management page with notes and spending totals per vendor
 
 ## Setup Instructions
 
@@ -108,6 +109,15 @@ CREATE TABLE budgets (
 );
 ```
 
+Create a `vendor_notes` table to store notes about each vendor:
+
+```sql
+CREATE TABLE vendor_notes (
+  vendor TEXT PRIMARY KEY,
+  notes TEXT
+);
+```
+
 Create a `feedback` table for storing ratings on AI results:
 
 ```sql
@@ -153,6 +163,8 @@ apply custom approval rules:
 - `GET /api/feedback` – view average ratings by endpoint
 - `GET /api/invoices/vendor-scorecards` – view vendor responsiveness and payment metrics
 - `GET /api/invoices/graph` – network graph data linking vendors and duplicate invoices
+- `GET /api/vendors` – list vendors with last invoice date and total spend
+- `PATCH /api/vendors/:vendor/notes` – update notes for a vendor
 
 ### Vendor Reply Drafts
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -7,6 +7,7 @@ const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
 const feedbackRoutes = require('./routes/feedbackRoutes');
 const analyticsRoutes = require('./routes/analyticsRoutes');
 const userRoutes = require('./routes/userRoutes');
+const vendorRoutes = require('./routes/vendorRoutes');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
 const { initDb } = require('./utils/dbInit');
 
@@ -20,6 +21,7 @@ app.use('/api/invoices', invoiceRoutes);    // route all invoice requests here
 app.use('/api/feedback', feedbackRoutes);
 app.use('/api/analytics', analyticsRoutes);
 app.use('/api/users', userRoutes);
+app.use('/api/vendors', vendorRoutes);
 
 (async () => {
   await initDb();

--- a/backend/controllers/vendorController.js
+++ b/backend/controllers/vendorController.js
@@ -1,0 +1,45 @@
+const pool = require('../config/db');
+const { logActivity } = require('../utils/activityLogger');
+
+exports.listVendors = async (_req, res) => {
+  try {
+    const result = await pool.query(`
+      SELECT i.vendor,
+             MAX(i.date) AS last_invoice,
+             SUM(i.amount) AS total_spend,
+             v.notes
+      FROM invoices i
+      LEFT JOIN vendor_notes v ON LOWER(v.vendor) = LOWER(i.vendor)
+      GROUP BY i.vendor, v.notes
+      ORDER BY i.vendor
+    `);
+    const vendors = result.rows.map(r => ({
+      vendor: r.vendor,
+      last_invoice: r.last_invoice,
+      total_spend: parseFloat(r.total_spend),
+      notes: r.notes || ''
+    }));
+    res.json({ vendors });
+  } catch (err) {
+    console.error('List vendors error:', err);
+    res.status(500).json({ message: 'Failed to fetch vendors' });
+  }
+};
+
+exports.updateVendorNotes = async (req, res) => {
+  const { vendor } = req.params;
+  const { notes } = req.body;
+  try {
+    await pool.query(
+      `INSERT INTO vendor_notes (vendor, notes)
+       VALUES ($1, $2)
+       ON CONFLICT (vendor) DO UPDATE SET notes = EXCLUDED.notes`,
+      [vendor, notes || '']
+    );
+    await logActivity(req.user?.userId, 'update_vendor_notes');
+    res.json({ message: 'Notes updated' });
+  } catch (err) {
+    console.error('Update vendor notes error:', err);
+    res.status(500).json({ message: 'Failed to update notes' });
+  }
+};

--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { listVendors, updateVendorNotes } = require('../controllers/vendorController');
+const { authMiddleware, authorizeRoles } = require('../controllers/userController');
+
+router.get('/', authMiddleware, listVendors);
+router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
+
+module.exports = router;

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -43,6 +43,11 @@ async function initDb() {
       rating INTEGER NOT NULL,
       created_at TIMESTAMP DEFAULT NOW()
     )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS vendor_notes (
+      vendor TEXT PRIMARY KEY,
+      notes TEXT
+    )`);
   } catch (err) {
     console.error('Database init error:', err);
   }

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+function VendorManagement() {
+  const token = localStorage.getItem('token') || '';
+  const [vendors, setVendors] = useState([]);
+  const [notesInput, setNotesInput] = useState({});
+
+  const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
+
+  const fetchVendors = async () => {
+    const res = await fetch('http://localhost:3000/api/vendors', { headers });
+    const data = await res.json();
+    if (res.ok) setVendors(data.vendors || []);
+  };
+
+  useEffect(() => { if (token) fetchVendors(); }, [token]);
+
+  const saveNotes = async (vendor) => {
+    const notes = notesInput[vendor] ?? '';
+    await fetch(`http://localhost:3000/api/vendors/${encodeURIComponent(vendor)}/notes`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ notes })
+    });
+    fetchVendors();
+  };
+
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-700">Access denied.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
+      <nav className="mb-4 flex justify-between items-center">
+        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Vendor Management</h1>
+        <Link to="/" className="text-blue-600 underline">Back to App</Link>
+      </nav>
+      <table className="w-full text-left border">
+        <thead>
+          <tr className="bg-gray-200 dark:bg-gray-700">
+            <th className="p-2">Vendor</th>
+            <th className="p-2">Last Invoice</th>
+            <th className="p-2">Total Spend</th>
+            <th className="p-2">Notes</th>
+            <th className="p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vendors.map(v => (
+            <tr key={v.vendor} className="border-t">
+              <td className="p-2">{v.vendor}</td>
+              <td className="p-2">{v.last_invoice ? new Date(v.last_invoice).toLocaleDateString() : '-'}</td>
+              <td className="p-2">${v.total_spend.toFixed(2)}</td>
+              <td className="p-2">
+                <textarea
+                  className="border rounded p-1 w-full"
+                  value={notesInput[v.vendor] ?? v.notes}
+                  onChange={e => setNotesInput({ ...notesInput, [v.vendor]: e.target.value })}
+                />
+              </td>
+              <td className="p-2">
+                <button
+                  onClick={() => saveNotes(v.vendor)}
+                  className="bg-blue-600 text-white px-3 py-1 rounded"
+                >
+                  Save
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default VendorManagement;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -5,6 +5,7 @@ import Dashboard from './Dashboard';
 import Reports from './Reports';
 import Archive from './Archive';
 import TeamManagement from './TeamManagement';
+import VendorManagement from './VendorManagement';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './index.css';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
@@ -28,6 +29,7 @@ root.render(
       <Route path="/reports" element={<Reports />} />
       <Route path="/archive" element={<Archive />} />
       <Route path="/team" element={<TeamManagement />} />
+      <Route path="/vendors" element={<VendorManagement />} />
       <Route path="/*" element={<App />} />
     </Routes>
   </BrowserRouter>


### PR DESCRIPTION
## Summary
- add vendor management bullet in docs
- document new vendor_notes table
- expose vendor list and notes API endpoints
- create vendor controller and routes
- initialize vendor_notes table on server start
- register vendor routes
- add React page to manage vendors
- route /vendors to new page

## Testing
- `npm test --silent` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_684b46163094832e9834b4ddb8c22c62