### PR TITLE
Add confirmation modals and fuzzy search

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "fuse.js": "^7.1.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-force-graph": "^1.47.6",
@@ -9647,6 +9648,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "fuse.js": "^7.1.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-force-graph": "^1.47.6",

--- a/frontend/src/components/ConfirmModal.js
+++ b/frontend/src/components/ConfirmModal.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function ConfirmModal({ open, message, onConfirm, onCancel }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg max-w-sm w-full">
+        <p className="mb-4 text-sm">{message}</p>
+        <div className="flex justify-end space-x-2">
+          <button onClick={onCancel} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100">Cancel</button>
+          <button onClick={onConfirm} className="px-3 py-1 rounded bg-blue-600 text-white">Confirm</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SuggestionChips.js
+++ b/frontend/src/components/SuggestionChips.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function SuggestionChips({ suggestions = [], onClick }) {
+  if (!suggestions.length) return null;
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {suggestions.map((s, idx) => (
+        <button
+          key={idx}
+          onClick={() => onClick && onClick(s)}
+          className="bg-indigo-100 text-indigo-800 px-2 py-0.5 rounded text-xs hover:bg-indigo-200"
+        >
+          {s}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ConfirmModal` and `SuggestionChips` components
- use modal confirmations for delete/archive/clear actions
- implement fuzzy searching of invoices with Fuse.js
- render AI suggestions as clickable chips

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Jest couldn't handle ESM module)*
- `cd backend && npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_684b52139f40832eba1006437b06d7a1