### PR TITLE
Improve wording consistency and add tooltips

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -55,7 +55,7 @@ function App() {
   actions: true,
   updated_at: true
 });
-const [files, setFile] = useState([]);   // file objects to upload
+const [files, setFile] = useState([]);   // file objects to submit
 const [filePreviews, setFilePreviews] = useState([]);
 const [fileErrors, setFileErrors] = useState([]);
 const [dragActive, setDragActive] = useState(false);
@@ -366,6 +366,20 @@ const searchInputRef = useRef();
   }, [darkMode]);
 
   useEffect(() => {
+    const addTitles = () => {
+      document.querySelectorAll('button').forEach((btn) => {
+        if (!btn.getAttribute('title') && btn.textContent.trim()) {
+          btn.setAttribute('title', btn.textContent.trim());
+        }
+      });
+    };
+    addTitles();
+    const observer = new MutationObserver(addTitles);
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
     const orig = window.fetch;
     window.fetch = async (url, options = {}) => {
       const headers = { 'X-Tenant-Id': tenant, ...(options.headers || {}) };
@@ -667,8 +681,8 @@ useEffect(() => {
         
         const data = await res.json();
   
-        setMessage((prev) => prev + `\n✅ ${data.inserted} invoice(s) uploaded from ${file.name}`);
-        addToast(`✅ Uploaded ${data.inserted} invoice(s) from ${file.name}`);
+        setMessage((prev) => prev + `\n✅ ${data.inserted} invoice(s) submitted from ${file.name}`);
+        addToast(`✅ Submitted ${data.inserted} invoice(s) from ${file.name}`);
         if (data.errors?.length) {
           setMessage((prev) => prev + `\n❌ ${data.errors.length} row(s) had issues in ${file.name}`);
           setErrors((prev) => [...prev, ...data.errors]);
@@ -701,8 +715,8 @@ useEffect(() => {
           }
         }
       } catch (err) {
-        console.error(`Upload failed for ${file.name}:`, err);
-        setMessage((prev) => prev + `\n❌ Upload failed for ${file.name}`);
+        console.error(`Submission failed for ${file.name}:`, err);
+        setMessage((prev) => prev + `\n❌ Submission failed for ${file.name}`);
       }
     }
 
@@ -1475,7 +1489,7 @@ useEffect(() => {
                 <li key={i}>{new Date(t.created_at).toLocaleString()} - {t.action}</li>
               ))}
             </ul>
-            <button onClick={() => setShowTimeline(false)} className="mt-2 bg-blue-600 text-white px-3 py-1 rounded">Close</button>
+            <button onClick={() => setShowTimeline(false)} className="mt-2 bg-blue-600 text-white px-3 py-1 rounded" title="Close">Close</button>
           </div>
         </div>
       )}
@@ -1494,6 +1508,7 @@ useEffect(() => {
             <button
               onClick={() => setDarkMode((d) => !d)}
               className="text-xl focus:outline-none"
+              title={darkMode ? 'Light Mode' : 'Dark Mode'}
             >
               {darkMode ? '☀️' : '🌙'}
             </button>
@@ -1501,6 +1516,7 @@ useEffect(() => {
               <button
                 onClick={() => setDarkMode(false)}
                 className="ml-2 px-2 py-1 text-sm bg-gray-200 dark:bg-gray-700 rounded focus:outline-none"
+                title="Light Mode"
               >
                 Light Mode
               </button>
@@ -1511,6 +1527,7 @@ useEffect(() => {
                 <button
                   onClick={handleLogout}
                   className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded text-sm"
+                  title="Logout"
                 >
                   Logout
                 </button>
@@ -1537,7 +1554,7 @@ useEffect(() => {
 
 <div className="flex flex-wrap gap-4 mb-6 items-start">
   <fieldset className="border border-gray-200 p-4 rounded flex flex-col gap-2">
-    <legend className="text-sm font-semibold px-2">Upload</legend>
+    <legend className="text-sm font-semibold px-2">Submit Invoice</legend>
     <div
       className={`border-2 border-dashed p-4 rounded cursor-pointer ${dragActive ? 'bg-blue-50' : ''}`}
       onDragOver={(e) => e.preventDefault()}
@@ -1794,7 +1811,7 @@ useEffect(() => {
                               {loading && (
                                 <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full"></div>
                               )}
-                              <span>{loading ? 'Uploading...' : 'Upload CSV'}</span>
+                              <span>{loading ? 'Submitting...' : 'Submit Invoice'}</span>
                             </button>
                           )}
 
@@ -1869,6 +1886,7 @@ useEffect(() => {
                         <button
                             onClick={handleAssistantQuery}
                             className="bg-blue-600 text-white px-3 py-1 rounded text-sm"
+                            title="Ask"
                           >
                             Ask
                           </button>
@@ -1884,6 +1902,7 @@ useEffect(() => {
                           <button
                             onClick={handleChartQuery}
                             className="bg-green-600 text-white px-3 py-1 rounded text-sm"
+                            title="Chart"
                           >
                             Chart
                           </button>
@@ -2158,7 +2177,7 @@ useEffect(() => {
               ) : sortedInvoices.length === 0 ? (
                 <tr>
                   <td colSpan="7" className="text-center py-10 text-gray-500 italic">
-                    💤 No invoices to display. Try uploading one or adjusting your filters.
+                    💤 No invoices to display. Try submitting one or adjusting your filters.
                   </td>
                 </tr>
               ) : (

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -82,7 +82,7 @@ function Archive() {
                 <td className="px-2 py-1">{inv.vendor}</td>
                 <td className="px-2 py-1">${inv.amount}</td>
                 <td className="px-2 py-1">
-                  <button onClick={() => handleRestore(inv.id)} className="bg-blue-500 text-white px-2 py-1 rounded text-xs">
+                  <button onClick={() => handleRestore(inv.id)} className="bg-blue-500 text-white px-2 py-1 rounded text-xs" title="Restore">
                     Restore
                   </button>
                 </td>

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -59,7 +59,7 @@ export default function Login({ onLogin, addToast }) {
             className="w-full mb-4 px-3 py-2 border rounded"
           />
 
-          <button onClick={handleLogin} className="btn btn-primary w-full">
+          <button onClick={handleLogin} className="btn btn-primary w-full" title="Log In">
             Log In
           </button>
         </div>

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -81,14 +81,14 @@ function Reports() {
           <input type="number" value={maxAmount} onChange={e => setMaxAmount(e.target.value)} placeholder="Max" className="border p-2 rounded" />
         </div>
         <div className="space-x-2">
-          <button onClick={fetchReport} className="btn btn-primary">Run Report</button>
-          <button onClick={exportPDF} className="btn btn-primary bg-green-700 hover:bg-green-800">Export PDF</button>
+          <button onClick={fetchReport} className="btn btn-primary" title="Run Report">Run Report</button>
+          <button onClick={exportPDF} className="btn btn-primary bg-green-700 hover:bg-green-800" title="Export PDF">Export PDF</button>
         </div>
         <div>
           <h2 className="font-semibold mb-1 text-gray-800 dark:text-gray-100">Auto-Flag Rule</h2>
           <div className="flex space-x-2 items-center">
             <input type="number" value={threshold} onChange={e => setThreshold(e.target.value)} className="border p-2 rounded w-32" />
-            <button onClick={addAmountRule} className="btn btn-primary">Set Threshold</button>
+            <button onClick={addAmountRule} className="btn btn-primary" title="Set Threshold">Set Threshold</button>
           </div>
           <ul className="list-disc pl-5 mt-2 text-gray-700 dark:text-gray-300">
             {rules.map((r, i) => <li key={i}>{r.flagReason}</li>)}

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -75,7 +75,7 @@ function TeamManagement() {
             <option value="approver">approver</option>
             <option value="admin">admin</option>
           </select>
-          <button onClick={addUser} className="bg-blue-600 text-white px-3 py-1 rounded">Add User</button>
+          <button onClick={addUser} className="bg-blue-600 text-white px-3 py-1 rounded" title="Add User">Add User</button>
         </div>
         <table className="w-full text-left border mt-4">
           <thead>
@@ -97,7 +97,7 @@ function TeamManagement() {
                   </select>
                 </td>
                 <td className="p-2">
-                  <button onClick={() => deleteUser(u.id)} className="text-red-600">Remove</button>
+                  <button onClick={() => deleteUser(u.id)} className="text-red-600" title="Remove">Remove</button>
                 </td>
               </tr>
             ))}

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -67,6 +67,7 @@ function VendorManagement() {
                 <button
                   onClick={() => saveNotes(v.vendor)}
                   className="bg-blue-600 text-white px-3 py-1 rounded"
+                  title="Save"
                 >
                   Save
                 </button>

--- a/frontend/src/components/ConfirmModal.js
+++ b/frontend/src/components/ConfirmModal.js
@@ -7,8 +7,8 @@ export default function ConfirmModal({ open, message, onConfirm, onCancel }) {
       <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg max-w-sm w-full">
         <p className="mb-4 text-sm">{message}</p>
         <div className="flex justify-end space-x-2">
-          <button onClick={onCancel} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100">Cancel</button>
-          <button onClick={onConfirm} className="px-3 py-1 rounded bg-blue-600 text-white">Confirm</button>
+          <button onClick={onCancel} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100" title="Cancel">Cancel</button>
+          <button onClick={onConfirm} className="px-3 py-1 rounded bg-blue-600 text-white" title="Confirm">Confirm</button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -15,6 +15,7 @@ export default function NotificationBell({ notifications = [], onOpen }) {
         className="text-xl focus:outline-none"
         onClick={handleToggle}
         aria-label="Notifications"
+        title="Notifications"
       >
         🔔
         {unreadCount > 0 && (

--- a/frontend/src/components/SuggestionChips.js
+++ b/frontend/src/components/SuggestionChips.js
@@ -9,6 +9,7 @@ export default function SuggestionChips({ suggestions = [], onClick }) {
           key={idx}
           onClick={() => onClick && onClick(s)}
           className="bg-indigo-100 text-indigo-800 px-2 py-0.5 rounded text-xs hover:bg-indigo-200"
+          title={s}
         >
           {s}
         </button>

--- a/frontend/src/components/Toast.js
+++ b/frontend/src/components/Toast.js
@@ -10,6 +10,7 @@ export default function Toast({ message, type, actionText, onAction }) {
         <button
           className="underline font-semibold"
           onClick={onAction}
+          title={actionText}
         >
           {actionText}
         </button>


### PR DESCRIPTION
## Summary
- switch interface text from *Upload* to *Submit Invoice*
- ensure icon buttons show tooltips
- auto-add `title` attributes to buttons

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b54a51aec832ebd4c885b58ea2822