### PR TITLE
Add consistent input styling and collapsible filters

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1435,7 +1435,7 @@ useEffect(() => {
             type="text"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
-            className="w-full mb-3 px-3 py-2 border rounded"
+            className="input w-full mb-3"
           />
           <label htmlFor="password" className="block text-sm font-medium">
             Password
@@ -1445,7 +1445,7 @@ useEffect(() => {
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full mb-3 px-3 py-2 border rounded"
+            className="input w-full mb-3"
           />
           <button onClick={handleLogin} className="btn btn-primary w-full">
             Log In
@@ -1565,9 +1565,9 @@ useEffect(() => {
     )}
   </fieldset>
 
-  <fieldset className="border border-gray-200 p-4 rounded flex flex-wrap gap-4 items-end flex-1">
-    <legend className="text-sm font-semibold px-2">Filters</legend>
-    <div className="flex flex-col">
+  <details className="border border-gray-200 p-4 rounded flex-1">
+    <summary className="font-semibold cursor-pointer select-none">Filters</summary>
+    <div className="mt-2 flex flex-wrap gap-4 items-end">
       <label htmlFor="searchTerm" className="text-xs font-medium mb-1">Search</label>
       <input
         id="searchTerm"
@@ -1575,9 +1575,8 @@ useEffect(() => {
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
         ref={searchInputRef}
-        className="border border-gray-300 rounded px-3 py-2 text-sm w-60"
+        className="input w-60"
       />
-    </div>
     <label htmlFor="archivedToggle" className="flex items-center space-x-2 text-sm">
       <input
         id="archivedToggle"
@@ -1594,7 +1593,7 @@ useEffect(() => {
         id="vendorSelect"
         value={selectedVendor}
         onChange={(e) => setSelectedVendor(e.target.value)}
-        className="border border-gray-300 rounded px-3 py-2 text-sm"
+        className="input"
       >
         <option value="">All Vendors</option>
         {vendorList.map((vendor, idx) => (
@@ -1610,7 +1609,7 @@ useEffect(() => {
         id="assigneeSelect"
         value={selectedAssignee}
         onChange={(e) => setSelectedAssignee(e.target.value)}
-        className="border border-gray-300 rounded px-3 py-2 text-sm"
+        className="input"
       >
         <option value="">All Assignees</option>
         {[...new Set([...teamMembers, ...assigneeList])].map((person, idx) => (
@@ -1627,7 +1626,7 @@ useEffect(() => {
         type="number"
         value={minAmount}
         onChange={(e) => setMinAmount(e.target.value)}
-        className="border border-gray-300 rounded px-2 py-2 text-sm w-28"
+        className="input w-28"
       />
     </div>
     <div className="flex flex-col">
@@ -1637,7 +1636,7 @@ useEffect(() => {
         type="number"
         value={maxAmount}
         onChange={(e) => setMaxAmount(e.target.value)}
-        className="border border-gray-300 rounded px-2 py-2 text-sm w-28"
+        className="input w-28"
       />
     </div>
     <button
@@ -1651,7 +1650,8 @@ useEffect(() => {
     >
       Export Filtered Invoices
     </button>
-  </fieldset>
+  </div>
+  </details>
 </div>
   
             {message && (
@@ -1856,7 +1856,7 @@ useEffect(() => {
                             value={chatQuestion}
                             onChange={(e) => setChatQuestion(e.target.value)}
                             placeholder="Ask AI about invoices..."
-                            className="border rounded p-1 flex-1 text-sm"
+                            className="input flex-1 text-sm"
                           />
                           <button
                             onClick={handleAssistantQuery}
@@ -1874,7 +1874,7 @@ useEffect(() => {
                             value={chartQuestion}
                             onChange={(e) => setChartQuestion(e.target.value)}
                             placeholder="Ask for a chart..."
-                            className="border rounded p-1 flex-1 text-sm"
+                            className="input flex-1 text-sm"
                           />
                           <button
                             onClick={handleChartQuery}
@@ -1911,7 +1911,7 @@ useEffect(() => {
                             <select
                               value={selectedVendor}
                               onChange={(e) => setSelectedVendor(e.target.value)}
-                              className="border rounded p-1"
+                              className="input p-1"
                             >
                               <option value="">All Vendors</option>
                               {vendorList.map((vendor, idx) => (
@@ -1989,7 +1989,7 @@ useEffect(() => {
                         <select
                           value={cashFlowInterval}
                           onChange={(e) => setCashFlowInterval(e.target.value)}
-                          className="border rounded p-1 text-sm"
+                          className="input p-1 text-sm"
                         >
                           <option value="monthly">Monthly</option>
                           <option value="weekly">Weekly</option>
@@ -2016,7 +2016,7 @@ useEffect(() => {
                         <select
                           value={filterType}
                           onChange={(e) => setFilterType(e.target.value)}
-                          className="border rounded p-1"
+                          className="input p-1"
                         >
                           <option value="none">None</option>
                           <option value="tag">Tag</option>
@@ -2029,7 +2029,7 @@ useEffect(() => {
                             value={filterTag}
                             onChange={(e) => setFilterTag(e.target.value)}
                             placeholder="Tag"
-                            className="border rounded p-1"
+                            className="input p-1"
                           />
                         )}
                         {filterType === 'date' && (
@@ -2038,13 +2038,13 @@ useEffect(() => {
                               type="date"
                               value={filterStartDate}
                               onChange={(e) => setFilterStartDate(e.target.value)}
-                              className="border rounded p-1"
+                              className="input p-1"
                             />
                             <input
                               type="date"
                               value={filterEndDate}
                               onChange={(e) => setFilterEndDate(e.target.value)}
-                              className="border rounded p-1"
+                              className="input p-1"
                             />
                           </>
                         )}
@@ -2055,14 +2055,14 @@ useEffect(() => {
                               value={filterMinAmount}
                               onChange={(e) => setFilterMinAmount(e.target.value)}
                               placeholder="Min"
-                              className="border rounded p-1"
+                              className="input p-1"
                             />
                             <input
                               type="number"
                               value={filterMaxAmount}
                               onChange={(e) => setFilterMaxAmount(e.target.value)}
                               placeholder="Max"
-                              className="border rounded p-1"
+                              className="input p-1"
                             />
                           </>
                         )}
@@ -2217,7 +2217,7 @@ useEffect(() => {
                             handleUpdateInvoice(inv.id, 'date', editingValue);
                             setEditingInvoiceId(null);
                           }}
-                          className="border px-1 text-sm w-full"
+                          className="input px-1 text-sm w-full"
                           autoFocus
                         />
                       ) : (
@@ -2277,7 +2277,7 @@ useEffect(() => {
                             handleUpdateInvoice(inv.id, 'vendor', editingValue);
                             setEditingInvoiceId(null);
                           }}
-                          className="border px-1 text-sm w-full"
+                          className="input px-1 text-sm w-full"
                           autoFocus
                         />
                         
@@ -2433,14 +2433,14 @@ useEffect(() => {
                           🚩 {suspicionFlags[inv.id]}
                         </div>
                       )}
-                     <input
+                      <input
                         type="text"
                         value={tagInputs[inv.id] || ''}
                         onChange={(e) =>
                           setTagInputs((prev) => ({ ...prev, [inv.id]: e.target.value }))
                         }
                         placeholder="Add tag"
-                        className="text-xs p-1 border rounded w-full"
+                        className="input text-xs w-full"
                       />
                       <button
                         onClick={() => handleAddTag(inv.id, tagInputs[inv.id])}
@@ -2565,7 +2565,7 @@ useEffect(() => {
                           type="text"
                           value={commentInputs[inv.id] || ''}
                           onChange={(e) => setCommentInputs((p) => ({ ...p, [inv.id]: e.target.value }))}
-                          className="border rounded px-1 text-xs flex-1"
+                          className="input text-xs flex-1 px-1"
                           placeholder="Add comment"
                         />
                         <button

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -56,9 +56,9 @@ function Archive() {
       </nav>
       <div className="space-y-4 max-w-4xl mx-auto">
         <div className="flex flex-wrap items-end space-x-2">
-          <input value={vendor} onChange={(e) => setVendor(e.target.value)} placeholder="Vendor" className="border p-2 rounded" />
-          <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="border p-2 rounded" />
-          <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="border p-2 rounded" />
+          <input value={vendor} onChange={(e) => setVendor(e.target.value)} placeholder="Vendor" className="input" />
+          <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className="input" />
+          <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="input" />
           <label className="flex items-center space-x-1 text-sm">
             <input type="checkbox" checked={priorityOnly} onChange={(e) => setPriorityOnly(e.target.checked)} />
             <span>Priority</span>

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -48,7 +48,7 @@ export default function Login({ onLogin, addToast }) {
             placeholder="Username"
             value={username}
             onChange={(e) => setUsername(e.target.value)}
-            className="w-full mb-3 px-3 py-2 border rounded"
+            className="input w-full mb-3"
           />
 
           <input
@@ -56,7 +56,7 @@ export default function Login({ onLogin, addToast }) {
             placeholder="Password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full mb-4 px-3 py-2 border rounded"
+            className="input w-full mb-4"
           />
 
           <button onClick={handleLogin} className="btn btn-primary w-full" title="Log In">

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -72,13 +72,13 @@ function Reports() {
       </nav>
       <div className="space-y-4 max-w-2xl">
         <div className="grid grid-cols-2 gap-2">
-          <input value={vendor} onChange={e => setVendor(e.target.value)} placeholder="Vendor" className="border p-2 rounded" />
+          <input value={vendor} onChange={e => setVendor(e.target.value)} placeholder="Vendor" className="input" />
           <div className="flex space-x-2">
-            <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} className="border p-2 rounded w-full" />
-            <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} className="border p-2 rounded w-full" />
+            <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} className="input w-full" />
+            <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} className="input w-full" />
           </div>
-          <input type="number" value={minAmount} onChange={e => setMinAmount(e.target.value)} placeholder="Min" className="border p-2 rounded" />
-          <input type="number" value={maxAmount} onChange={e => setMaxAmount(e.target.value)} placeholder="Max" className="border p-2 rounded" />
+          <input type="number" value={minAmount} onChange={e => setMinAmount(e.target.value)} placeholder="Min" className="input" />
+          <input type="number" value={maxAmount} onChange={e => setMaxAmount(e.target.value)} placeholder="Max" className="input" />
         </div>
         <div className="space-x-2">
           <button onClick={fetchReport} className="btn btn-primary" title="Run Report">Run Report</button>
@@ -87,7 +87,7 @@ function Reports() {
         <div>
           <h2 className="font-semibold mb-1 text-gray-800 dark:text-gray-100">Auto-Flag Rule</h2>
           <div className="flex space-x-2 items-center">
-            <input type="number" value={threshold} onChange={e => setThreshold(e.target.value)} className="border p-2 rounded w-32" />
+            <input type="number" value={threshold} onChange={e => setThreshold(e.target.value)} className="input w-32" />
             <button onClick={addAmountRule} className="btn btn-primary" title="Set Threshold">Set Threshold</button>
           </div>
           <ul className="list-disc pl-5 mt-2 text-gray-700 dark:text-gray-300">

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -68,9 +68,9 @@ function TeamManagement() {
       </nav>
       <div className="space-y-6 max-w-xl">
         <div className="space-y-2">
-          <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="border p-2 rounded w-full" />
-          <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="border p-2 rounded w-full" />
-          <select value={newRole} onChange={e => setNewRole(e.target.value)} className="border p-2 rounded w-full">
+          <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="input w-full" />
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" className="input w-full" />
+          <select value={newRole} onChange={e => setNewRole(e.target.value)} className="input w-full">
             <option value="viewer">viewer</option>
             <option value="approver">approver</option>
             <option value="admin">admin</option>
@@ -90,7 +90,7 @@ function TeamManagement() {
               <tr key={u.id} className="border-t">
                 <td className="p-2">{u.username}</td>
                 <td className="p-2">
-                  <select value={u.role} onChange={e => changeRole(u.id, e.target.value)} className="border p-1 rounded">
+                  <select value={u.role} onChange={e => changeRole(u.id, e.target.value)} className="input p-1">
                     <option value="viewer">viewer</option>
                     <option value="approver">approver</option>
                     <option value="admin">admin</option>

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -58,7 +58,7 @@ function VendorManagement() {
               <td className="p-2">${v.total_spend.toFixed(2)}</td>
               <td className="p-2">
                 <textarea
-                  className="border rounded p-1 w-full"
+                  className="input w-full p-1"
                   value={notesInput[v.vendor] ?? v.notes}
                   onChange={e => setNotesInput({ ...notesInput, [v.vendor]: e.target.value })}
                 />

--- a/frontend/src/components/TenantSwitcher.js
+++ b/frontend/src/components/TenantSwitcher.js
@@ -4,7 +4,7 @@ export default function TenantSwitcher({ tenant, onChange }) {
     <select
       value={tenant}
       onChange={(e) => onChange(e.target.value)}
-      className="ml-2 border rounded p-1 text-sm"
+      className="input ml-2 text-sm"
     >
       {tenants.map((t) => (
         <option key={t} value={t}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -41,4 +41,7 @@ code {
   .btn-danger {
     @apply bg-red-500 text-white hover:bg-red-600;
   }
+  .input {
+    @apply border border-gray-300 rounded px-3 py-2 text-sm;
+  }
 }


### PR DESCRIPTION
## Summary
- unify input and select styling through new `.input` utility class
- update existing forms to use `.input`
- wrap filter controls inside a collapsible `<details>` element

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6720815c832eba1932011be5ba9b