### PR TITLE
Add filter sidebar with presets

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -4,6 +4,7 @@ import TenantSwitcher from './TenantSwitcher';
 import NotificationBell from './NotificationBell';
 import {
   Bars3Icon,
+  AdjustmentsHorizontalIcon,
   HomeIcon,
   DocumentChartBarIcon,
   ArchiveBoxIcon,
@@ -23,6 +24,7 @@ export default function Navbar({
   darkMode,
   setDarkMode,
   token,
+  onToggleFilters,
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [userOpen, setUserOpen] = useState(false);
@@ -37,6 +39,15 @@ export default function Navbar({
         <div className="flex items-center space-x-3 relative">
           <TenantSwitcher tenant={tenant} onChange={onTenantChange} />
           <NotificationBell notifications={notifications} onOpen={onNotificationsOpen} />
+          {token && (
+            <button
+              onClick={onToggleFilters}
+              className="focus:outline-none"
+              title="Filters"
+            >
+              <AdjustmentsHorizontalIcon className="h-6 w-6" />
+            </button>
+          )}
           {token && (
             <>
               <button


### PR DESCRIPTION
## Summary
- add toggleable sidebar for filters and presets
- allow saving & loading filter presets to localStorage
- add filter toggle button in navbar
- highlight table rows on hover and add tooltips on status labels
- shift main content on wider screens

## Testing
- `npm install`
- `npm test -- -w=1` *(fails: SyntaxError in react-force-graph-2d)*

------
https://chatgpt.com/codex/tasks/task_e_684b6d3d3334832eb551e70d32eeaae5