### PR TITLE
Fix sidebar dropdown layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1558,7 +1558,7 @@ useEffect(() => {
 
       {token && (
         <aside
-          className={`fixed inset-y-0 left-0 w-64 bg-white dark:bg-gray-800 shadow-lg transform transition-transform z-30 ${
+          className={`fixed top-16 bottom-0 left-0 w-64 bg-white dark:bg-gray-800 shadow-lg transform transition-transform z-30 ${
             filterSidebarOpen ? 'translate-x-0' : '-translate-x-full'
           } md:translate-x-0 md:static md:shadow-none`}
         >

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
+// Mock graph component which uses ESM build incompatible with jest
+jest.mock('react-force-graph-2d', () => () => null);
+
 test('renders login heading by default', () => {
   render(<App />);
   const heading = screen.getByRole('heading', { name: /login/i });


### PR DESCRIPTION
## Summary
- fix sidebar overlay by adding top offset
- mock graph component in tests so Jest can run

## Testing
- `npm test --silent --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_684b6f8c7614832e8ac33e2019682329