### PR TITLE
Add invoice detail modal with editing

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import Skeleton from './components/Skeleton';
 import ChatSidebar from './components/ChatSidebar';
 import GraphView from './components/GraphView';
 import ConfirmModal from './components/ConfirmModal';
+import InvoiceDetailModal from './components/InvoiceDetailModal';
 import SuggestionChips from './components/SuggestionChips';
 import Fuse from 'fuse.js';
 import {
@@ -99,6 +100,7 @@ const searchInputRef = useRef();
   const [timeline, setTimeline] = useState([]);
   const [showTimeline, setShowTimeline] = useState(false);
   const [timelineInvoice, setTimelineInvoice] = useState(null);
+  const [detailInvoice, setDetailInvoice] = useState(null);
   const [topVendors, setTopVendors] = useState([]);
   const [tagReport, setTagReport] = useState([]);
   const [filterType, setFilterType] = useState('none');
@@ -1541,6 +1543,12 @@ useEffect(() => {
           </div>
         </div>
       )}
+      <InvoiceDetailModal
+        open={!!detailInvoice}
+        invoice={detailInvoice}
+        onClose={() => setDetailInvoice(null)}
+        onUpdate={handleUpdateInvoice}
+      />
       <Navbar
         tenant={tenant}
         onTenantChange={setTenant}
@@ -2263,7 +2271,7 @@ useEffect(() => {
                       />
                     </td>
                     <td className="border px-4 py-2">{inv.id}</td>
-                    <td className="border px-4 py-2">
+                    <td className="border px-4 py-2 cursor-pointer" onClick={() => setDetailInvoice(inv)}>
                       <div className="flex flex-col items-center">
                         <span className="font-medium">{inv.invoice_number}</span>
                         <div className="flex space-x-1 mt-1">
@@ -2567,6 +2575,7 @@ useEffect(() => {
                   ) : sortedInvoices.map((inv) => (
                     <div
                     key={inv.id}
+                    onClick={() => setDetailInvoice(inv)}
                     className={`border rounded-lg p-4 shadow-sm flex flex-col space-y-2 ${
                       inv.archived ? 'bg-gray-100 text-gray-500 italic' : 'bg-white'
                     }`}
@@ -2590,7 +2599,7 @@ useEffect(() => {
                       <div className="mt-2 flex flex-wrap gap-2">
                       {!inv.archived && (
                         <button
-                          onClick={() => handleArchive(inv.id)}
+                          onClick={(e) => { e.stopPropagation(); handleArchive(inv.id); }}
                           className="bg-gray-600 text-white px-2 py-1 rounded text-xs hover:bg-gray-700"
                           title="Archive"
                         >
@@ -2599,7 +2608,7 @@ useEffect(() => {
                       )}
                       {role === 'admin' && (
                         <button
-                          onClick={() => handleDelete(inv.id)}
+                          onClick={(e) => { e.stopPropagation(); handleDelete(inv.id); }}
                           className="bg-red-600 text-white px-2 py-1 rounded text-xs hover:bg-red-700"
                           title="Delete"
                         >
@@ -2609,21 +2618,21 @@ useEffect(() => {
                       {(role === 'approver' || role === 'admin') && (
                         <>
                           <button
-                            onClick={() => handleApprove(inv.id)}
+                            onClick={(e) => { e.stopPropagation(); handleApprove(inv.id); }}
                             className="bg-green-500 text-white px-2 py-1 rounded text-xs hover:bg-green-600"
                             title="Approve"
                           >
                             <CheckCircleIcon className="w-4 h-4" />
                           </button>
                           <button
-                            onClick={() => handleReject(inv.id)}
+                            onClick={(e) => { e.stopPropagation(); handleReject(inv.id); }}
                             className="bg-red-500 text-white px-2 py-1 rounded text-xs hover:bg-red-600"
                             title="Reject"
                           >
                             <XCircleIcon className="w-4 h-4" />
                           </button>
                           <button
-                            onClick={() => handlePaymentRequest(inv.id)}
+                            onClick={(e) => { e.stopPropagation(); handlePaymentRequest(inv.id); }}
                             className="bg-indigo-500 text-white px-2 py-1 rounded text-xs hover:bg-indigo-600"
                             disabled={paymentRequestId === inv.id}
                           >
@@ -2647,11 +2656,12 @@ useEffect(() => {
                           type="text"
                           value={commentInputs[inv.id] || ''}
                           onChange={(e) => setCommentInputs((p) => ({ ...p, [inv.id]: e.target.value }))}
+                          onClick={(e) => e.stopPropagation()}
                           className="input text-xs flex-1 px-1"
                           placeholder="Add comment"
                         />
                         <button
-                          onClick={() => handleAddComment(inv.id)}
+                          onClick={(e) => { e.stopPropagation(); handleAddComment(inv.id); }}
                           className="bg-indigo-600 text-white text-xs px-2 py-1 ml-1 rounded"
                         >
                           Post

--- a/frontend/src/components/InvoiceDetailModal.js
+++ b/frontend/src/components/InvoiceDetailModal.js
@@ -1,0 +1,106 @@
+import React, { useState, useEffect } from 'react';
+
+export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate }) {
+  const [editMode, setEditMode] = useState(false);
+  const [form, setForm] = useState({ invoice_number: '', date: '', amount: '', vendor: '' });
+
+  useEffect(() => {
+    if (invoice) {
+      setForm({
+        invoice_number: invoice.invoice_number || '',
+        date: invoice.date ? invoice.date.substring(0, 10) : '',
+        amount: invoice.amount || '',
+        vendor: invoice.vendor || '',
+      });
+    }
+  }, [invoice]);
+
+  if (!open || !invoice) return null;
+
+  const handleChange = (field, value) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = () => {
+    Object.entries(form).forEach(([field, value]) => {
+      if (value !== (invoice[field] || '')) {
+        onUpdate(invoice.id, field, value);
+      }
+    });
+    setEditMode(false);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-96">
+        <h2 className="text-lg font-bold mb-2">Invoice #{invoice.invoice_number}</h2>
+        <div className="space-y-2 text-sm">
+          <div>
+            <span className="font-semibold mr-2">ID:</span>{invoice.id}
+          </div>
+          <div>
+            <span className="font-semibold mr-2">Date:</span>
+            {editMode ? (
+              <input
+                type="date"
+                value={form.date}
+                onChange={(e) => handleChange('date', e.target.value)}
+                className="input px-1 text-sm w-full"
+              />
+            ) : (
+              invoice.date ? new Date(invoice.date).toLocaleDateString() : ''
+            )}
+          </div>
+          <div>
+            <span className="font-semibold mr-2">Amount:</span>
+            {editMode ? (
+              <input
+                type="text"
+                value={form.amount}
+                onChange={(e) => handleChange('amount', e.target.value)}
+                className="input px-1 text-sm w-full"
+              />
+            ) : (
+              invoice.amount
+            )}
+          </div>
+          <div>
+            <span className="font-semibold mr-2">Vendor:</span>
+            {editMode ? (
+              <input
+                type="text"
+                value={form.vendor}
+                onChange={(e) => handleChange('vendor', e.target.value)}
+                className="input px-1 text-sm w-full"
+              />
+            ) : (
+              invoice.vendor
+            )}
+          </div>
+          <div>
+            <span className="font-semibold mr-2">Status:</span>{invoice.approval_status || 'Pending'}
+          </div>
+          <div>
+            <span className="font-semibold mr-2">Created:</span>
+            {invoice.created_at ? new Date(invoice.created_at).toLocaleString() : ''}
+          </div>
+          <div>
+            <span className="font-semibold mr-2">Updated:</span>
+            {invoice.updated_at ? new Date(invoice.updated_at).toLocaleString() : ''}
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end space-x-2">
+          {editMode ? (
+            <>
+              <button onClick={handleSave} className="bg-indigo-600 text-white px-3 py-1 rounded" title="Save">Save</button>
+              <button onClick={() => setEditMode(false)} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700" title="Cancel">Cancel</button>
+            </>
+          ) : (
+            <button onClick={() => setEditMode(true)} className="bg-indigo-600 text-white px-3 py-1 rounded" title="Edit">Edit</button>
+          )}
+          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700" title="Close">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show invoice details in new `InvoiceDetailModal`
- open modal from invoice number or card view
- allow editing fields in modal

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684b78121eb8832ea2a717bfe1612d18