### PR TITLE
Add upload preview and floating AI chat

### DIFF
--- a/frontend/src/components/ChatSidebar.js
+++ b/frontend/src/components/ChatSidebar.js
@@ -3,6 +3,7 @@ import {
   ChatBubbleLeftRightIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
+import SuggestionChips from './SuggestionChips';
 import {
   BarChart,
   Bar,
@@ -16,6 +17,15 @@ import {
 export default function ChatSidebar({ open, onClose, onAsk, onChart, history }) {
   const [question, setQuestion] = useState('');
   const [chartQ, setChartQ] = useState('');
+  const suggestions = [
+    'Find duplicate invoices',
+    'Summarize top vendors',
+    'Show anomalies',
+  ];
+
+  const handleSuggestion = (s) => {
+    onAsk(s);
+  };
 
   const submitAsk = () => {
     onAsk(question);
@@ -28,8 +38,8 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, history }) 
 
   return (
     <div
-      className={`fixed top-0 right-0 h-full w-80 max-w-full bg-white dark:bg-gray-800 shadow-lg transform transition-transform z-30 ${
-        open ? 'translate-x-0' : 'translate-x-full'
+      className={`fixed bottom-4 right-4 w-80 h-96 max-w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg transform transition-transform z-30 ${
+        open ? 'translate-y-0' : 'translate-y-full'
       }`}
     >
       <div className="p-2 border-b flex justify-between items-center">
@@ -64,6 +74,7 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, history }) 
         ))}
       </div>
       <div className="p-2 space-y-2 border-t">
+        <SuggestionChips suggestions={suggestions} onClick={handleSuggestion} />
         <div className="flex space-x-1">
           <input
             value={question}

--- a/frontend/src/components/PreviewModal.js
+++ b/frontend/src/components/PreviewModal.js
@@ -1,0 +1,54 @@
+import React from 'react';
+
+export default function PreviewModal({ open, onClose, onConfirm, data }) {
+  if (!open || !data) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-96 max-w-full">
+        <h2 className="text-lg font-bold mb-2">Preview {data.name}</h2>
+        <div className="overflow-auto max-h-60 border">
+          <table className="table-auto text-xs w-full">
+            <thead>
+              <tr>
+                {data.preview[0].map((h, i) => (
+                  <th key={i} className="px-1 py-0.5 text-left border-b">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {data.preview.slice(1).map((row, ri) => (
+                <tr key={ri}>
+                  {row.map((cell, ci) => (
+                    <td key={ci} className="px-1 py-0.5 border-b">
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <div className="flex justify-end space-x-2 mt-2">
+          {onConfirm && (
+            <button
+              onClick={onConfirm}
+              className="px-3 py-1 rounded bg-indigo-600 text-white text-sm"
+              title="Upload"
+            >
+              Upload
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-sm"
+            title="Close"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- guide invoice uploads with step icons
- show preview of parsed rows before uploading
- convert AI assistant to floating chat with prompt suggestions

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684b9ff8bb4c832eba9f569d162bfd91