### PR TITLE
Revamp UI elements for modern feel

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1599,9 +1599,9 @@ useEffect(() => {
       <div className="pt-16 grid md:grid-cols-[250px_1fr] min-h-screen">
       {token && (
         <aside
-          className={`fixed top-16 bottom-0 left-0 w-64 bg-white dark:bg-gray-800 shadow-lg transform transition-transform z-30 ${
-            filterSidebarOpen ? 'translate-x-0' : '-translate-x-full'
-          } md:translate-x-0 md:static md:shadow-none md:border-r md:border-gray-200 md:flex-shrink-0`}
+          className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 ${
+            filterSidebarOpen ? '' : 'hidden md:block'
+          } md:fixed md:top-16 md:bottom-0 md:left-0 md:shadow-none md:border-r md:border-gray-200 md:flex-shrink-0`}
         >
           <div className="p-4 space-y-4 overflow-y-auto h-full">
             <button
@@ -1754,8 +1754,8 @@ useEffect(() => {
 
 <div className="mb-6">
   <fieldset className="border border-gray-300 p-4 rounded-md flex flex-col gap-2">
-    <legend className="text-sm font-semibold px-2">Upload Invoice</legend>
-    <ol className="flex space-x-4 text-sm text-gray-600 mb-2">
+    <legend className="text-lg font-semibold px-2">Upload Invoice</legend>
+    <ol className="flex space-x-4 text-sm text-gray-500 mb-2">
       <li className="flex items-center space-x-1">
         <ArrowUpTrayIcon className="w-4 h-4 text-indigo-500" />
         <span>Select File</span>
@@ -1777,7 +1777,7 @@ useEffect(() => {
       onDrop={(e) => { e.preventDefault(); setDragActive(false); handleFiles(e.dataTransfer.files); }}
       onClick={() => fileInputRef.current.click()}
     >
-      <p className="text-sm text-gray-600">Drag & drop CSV/PDF here or click to select</p>
+      <p className="text-sm text-gray-500">Drag & drop CSV/PDF here or click to select</p>
       <input
         type="file"
         multiple
@@ -1827,9 +1827,13 @@ useEffect(() => {
     <button
       onClick={openUploadPreview}
       disabled={!token || !files.length}
-      className="btn btn-primary text-sm mt-2 self-start disabled:opacity-60 flex items-center space-x-1"
+      className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded flex items-center space-x-2 mt-2 disabled:opacity-60"
     >
-      {loading && <Spinner className="h-4 w-4" />}
+      {loading ? (
+        <Spinner className="h-4 w-4" />
+      ) : (
+        <ArrowUpTrayIcon className="h-5 w-5" />
+      )}
       <span>{loading ? 'Uploading...' : 'Upload Invoice'}</span>
     </button>
 
@@ -2089,7 +2093,7 @@ useEffect(() => {
                       </div>
 
 
-                <h2 className="text-lg font-medium mt-8 mb-2 text-gray-800">
+                <h2 className="text-lg font-semibold mt-8 mb-2 text-gray-800">
                   Invoice Totals by Vendor
                 </h2>
                 <div className="mb-4 flex flex-wrap gap-4">
@@ -2158,7 +2162,7 @@ useEffect(() => {
                         )}
                       </div>
 
-                      <h3 className="text-lg font-medium mt-8 mb-2 text-gray-800">Top 5 Vendors This Quarter</h3>
+                      <h3 className="text-lg font-semibold mt-8 mb-2 text-gray-800">Top 5 Vendors This Quarter</h3>
                       <div className="flex items-center my-2 space-x-2 text-sm">
                         <label>Filter:</label>
                         <select
@@ -2230,7 +2234,7 @@ useEffect(() => {
                           </ResponsiveContainer>
                         )}
                       </div>
-                      <h3 className="text-lg font-medium mt-8 mb-2 text-gray-800">Spending by Tag</h3>
+                      <h3 className="text-lg font-semibold mt-8 mb-2 text-gray-800">Spending by Tag</h3>
                       <div className="h-64">
                         {loadingCharts ? (
                           <Skeleton rows={1} className="h-full" height="h-full" />
@@ -2256,8 +2260,8 @@ useEffect(() => {
 
                 {viewMode !== 'graph' && (
                   viewMode === 'table' ? (
-              <div className="overflow-x-auto mt-6 max-h-[500px] overflow-y-auto rounded border">      
-              <table className="min-w-full bg-white border border-gray-300 text-sm">
+              <div className="overflow-x-auto mt-6 max-h-[500px] overflow-y-auto rounded-lg border">
+              <table className="min-w-full bg-white border border-gray-300 text-sm rounded-lg overflow-hidden">
               <thead className="bg-gray-200 text-gray-700 sticky top-0 z-10 shadow-md">
                   <tr>
                     <th className="border px-4 py-2">
@@ -2321,7 +2325,7 @@ useEffect(() => {
                 sortedInvoices.map((inv, idx) => (
                   <tr
                           key={inv.id}
-                          className={`text-center hover:bg-indigo-50 hover:shadow ${
+                          className={`text-center hover:bg-gray-100 hover:shadow ${
                             idx % 2 === 0 ? 'bg-white' : 'bg-gray-50'
                           } ${
                             inv.archived ? '!bg-gray-200 text-gray-500 italic' : ''

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -64,7 +64,8 @@ function Archive() {
             <span>Priority</span>
           </label>
         </div>
-        <table className="min-w-full border text-sm">
+        <div className="overflow-x-auto rounded-lg">
+        <table className="min-w-full border text-sm rounded-lg overflow-hidden">
           <thead>
             <tr className="bg-gray-200 dark:bg-gray-700">
               <th className="px-2 py-1">#</th>
@@ -76,7 +77,7 @@ function Archive() {
           </thead>
           <tbody>
             {filtered.map((inv) => (
-              <tr key={inv.id} className="border-t">
+              <tr key={inv.id} className="border-t hover:bg-gray-100">
                 <td className="px-2 py-1">{inv.invoice_number}</td>
                 <td className="px-2 py-1">{new Date(inv.date).toLocaleDateString()}</td>
                 <td className="px-2 py-1">{inv.vendor}</td>
@@ -90,6 +91,7 @@ function Archive() {
             ))}
           </tbody>
         </table>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -131,8 +131,8 @@ function Dashboard() {
           </div>
           <div>
             <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Suspicious Pattern Heatmap</h2>
-            <div className="overflow-x-auto">
-              <table className="table-fixed border-collapse">
+            <div className="overflow-x-auto rounded-lg">
+              <table className="table-fixed border-collapse rounded-lg overflow-hidden">
                 <thead>
                   <tr>
                     <th></th>

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,5 +1,6 @@
 // src/Login.js
 import React, { useState } from 'react';
+import { DocumentArrowUpIcon } from '@heroicons/react/24/outline';
 
 export default function Login({ onLogin, addToast }) {
   const [username, setUsername] = useState('');
@@ -33,7 +34,10 @@ export default function Login({ onLogin, addToast }) {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-4 z-20">
-        <h1 className="text-xl font-bold">📄 Invoice Uploader AI</h1>
+        <h1 className="text-xl font-bold flex items-center space-x-1">
+          <DocumentArrowUpIcon className="w-5 h-5" />
+          <span>Invoice Uploader AI</span>
+        </h1>
       </nav>
       <div className="flex-1 flex items-center justify-center pt-20">
         <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md w-80 space-y-4">

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -94,8 +94,8 @@ function Reports() {
             {rules.map((r, i) => <li key={i}>{r.flagReason}</li>)}
           </ul>
         </div>
-        <div>
-          <table className="min-w-full border text-sm">
+        <div className="overflow-x-auto rounded-lg">
+          <table className="min-w-full border text-sm rounded-lg overflow-hidden">
             <thead>
               <tr className="bg-gray-200 dark:bg-gray-700">
                 <th className="px-2 py-1">#</th>
@@ -106,7 +106,7 @@ function Reports() {
             </thead>
             <tbody>
               {invoices.map(inv => (
-                <tr key={inv.id} className="border-t">
+                <tr key={inv.id} className="border-t hover:bg-gray-100">
                   <td className="px-2 py-1">{inv.invoice_number}</td>
                   <td className="px-2 py-1">{new Date(inv.date).toLocaleDateString()}</td>
                   <td className="px-2 py-1">{inv.vendor}</td>

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -77,7 +77,8 @@ function TeamManagement() {
           </select>
           <button onClick={addUser} className="bg-indigo-600 text-white px-3 py-1 rounded" title="Add User">Add User</button>
         </div>
-        <table className="w-full text-left border mt-4">
+        <div className="overflow-x-auto rounded-lg mt-4">
+        <table className="w-full text-left border rounded-lg overflow-hidden">
           <thead>
             <tr className="bg-gray-200 dark:bg-gray-700">
               <th className="p-2">Username</th>
@@ -87,7 +88,7 @@ function TeamManagement() {
           </thead>
           <tbody>
             {users.map(u => (
-              <tr key={u.id} className="border-t">
+              <tr key={u.id} className="border-t hover:bg-gray-100">
                 <td className="p-2">{u.username}</td>
                 <td className="p-2">
                   <select value={u.role} onChange={e => changeRole(u.id, e.target.value)} className="input p-1">
@@ -103,6 +104,7 @@ function TeamManagement() {
             ))}
           </tbody>
         </table>
+        </div>
         <div>
           <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Activity Logs</h2>
           <ul className="max-h-64 overflow-y-auto text-sm">

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -40,7 +40,8 @@ function VendorManagement() {
         <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Vendor Management</h1>
         <Link to="/" className="text-indigo-600 underline">Back to App</Link>
       </nav>
-      <table className="w-full text-left border">
+      <div className="overflow-x-auto rounded-lg">
+      <table className="w-full text-left border rounded-lg overflow-hidden">
         <thead>
           <tr className="bg-gray-200 dark:bg-gray-700">
             <th className="p-2">Vendor</th>
@@ -52,7 +53,7 @@ function VendorManagement() {
         </thead>
         <tbody>
           {vendors.map(v => (
-            <tr key={v.vendor} className="border-t">
+            <tr key={v.vendor} className="border-t hover:bg-gray-100">
               <td className="p-2">{v.vendor}</td>
               <td className="p-2">{v.last_invoice ? new Date(v.last_invoice).toLocaleDateString() : '-'}</td>
               <td className="p-2">${v.total_spend.toFixed(2)}</td>

--- a/frontend/src/components/PreviewModal.js
+++ b/frontend/src/components/PreviewModal.js
@@ -6,8 +6,8 @@ export default function PreviewModal({ open, onClose, onConfirm, data }) {
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-96 max-w-full">
         <h2 className="text-lg font-bold mb-2">Preview {data.name}</h2>
-        <div className="overflow-auto max-h-60 border">
-          <table className="table-auto text-xs w-full">
+        <div className="overflow-x-auto max-h-60 border rounded-lg">
+          <table className="table-auto text-xs w-full rounded-lg overflow-hidden">
             <thead>
               <tr>
                 {data.preview[0].map((h, i) => (
@@ -19,7 +19,7 @@ export default function PreviewModal({ open, onClose, onConfirm, data }) {
             </thead>
             <tbody>
               {data.preview.slice(1).map((row, ri) => (
-                <tr key={ri}>
+                <tr key={ri} className="hover:bg-gray-100">
                   {row.map((cell, ci) => (
                     <td key={ci} className="px-1 py-0.5 border-b">
                       {cell}


### PR DESCRIPTION
## Summary
- redesigned upload button with icon & clear feedback
- improved login header with a Heroicon
- stacked sidebar below content on mobile
- tweaked typography for headers and help text
- rounded tables, added hover styling, and enabled horizontal scroll

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684ba8967af8832e890bf13aba581d63