### PR TITLE
Fix VendorManagement JSX syntax error

### DIFF
--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -77,6 +77,7 @@ function VendorManagement() {
           ))}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- fix missing closing div in `VendorManagement.js`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684bacf057d8832ebdfbb5263e69ad96