### PR TITLE
Improve mobile layout and sidebar UX

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1596,12 +1596,19 @@ useEffect(() => {
         onToggleFilters={() => setFilterSidebarOpen((o) => !o)}
       />
 
+      {filterSidebarOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/30 z-30"
+          onClick={() => setFilterSidebarOpen(false)}
+        />
+      )}
+
       <div className="pt-16 grid grid-cols-1 md:grid-cols-[250px_1fr] md:gap-4 min-h-screen">
-      {token && (
-        <aside
+        {token && (
+          <aside
           className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 ${
             filterSidebarOpen ? '' : 'hidden md:block'
-          } md:border-r md:border-gray-200 md:max-h-screen md:overflow-y-auto`}
+          } md:border-r md:border-gray-200 md:max-h-screen md:overflow-y-auto z-40`}
         >
           <div className="p-4 space-y-4 overflow-y-auto h-full">
             <button

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -49,10 +49,10 @@ function Archive() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
-      <nav className="mb-4 flex justify-between items-center">
-        <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100">Invoice Archive</h1>
-        <Link to="/" className="text-indigo-600 underline">Back to App</Link>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+        <h1 className="text-3xl font-bold">Invoice Archive</h1>
+        <Link to="/" className="underline">Back to App</Link>
       </nav>
       <div className="space-y-4">
         <div className="flex flex-wrap items-end space-x-2">

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -49,10 +49,10 @@ function Dashboard() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
-      <nav className="mb-4 flex justify-between items-center">
-        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">AI Dashboard</h1>
-        <Link to="/" className="text-indigo-600 underline">Back to App</Link>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+        <h1 className="text-xl font-bold">AI Dashboard</h1>
+        <Link to="/" className="underline">Back to App</Link>
       </nav>
       {!token ? (
         <p className="text-center text-gray-600">Please log in from the main app.</p>

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -65,10 +65,10 @@ function Reports() {
   useEffect(() => { if (token) loadRules(); }, [token]);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
-      <nav className="mb-4 flex justify-between items-center">
-        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Reports</h1>
-        <Link to="/" className="text-indigo-600 underline">Back to App</Link>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+        <h1 className="text-xl font-bold">Reports</h1>
+        <Link to="/" className="underline">Back to App</Link>
       </nav>
       <div className="space-y-4 max-w-2xl">
         <div className="grid grid-cols-2 gap-2">

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -61,10 +61,10 @@ function TeamManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
-      <nav className="mb-4 flex justify-between items-center">
-        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Team Management</h1>
-        <Link to="/" className="text-indigo-600 underline">Back to App</Link>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+        <h1 className="text-xl font-bold">Team Management</h1>
+        <Link to="/" className="underline">Back to App</Link>
       </nav>
       <div className="space-y-6 max-w-xl">
         <div className="space-y-2">

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -35,10 +35,10 @@ function VendorManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4">
-      <nav className="mb-4 flex justify-between items-center">
-        <h1 className="text-xl font-bold text-gray-800 dark:text-gray-100">Vendor Management</h1>
-        <Link to="/" className="text-indigo-600 underline">Back to App</Link>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+        <h1 className="text-xl font-bold">Vendor Management</h1>
+        <Link to="/" className="underline">Back to App</Link>
       </nav>
       <div className="overflow-x-auto rounded-lg">
       <table className="w-full text-left border rounded-lg overflow-hidden">


### PR DESCRIPTION
## Summary
- add backdrop when mobile sidebar is open
- make nav sticky with consistent spacing across pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e23bb28832eac0b3cfe2ff9a444