### PR TITLE
Add RBAC and refresh token support

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -4,7 +4,7 @@ const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
 const { exportFilteredInvoices, exportAllInvoices } = require('../controllers/invoiceController');
 
-const { login, authMiddleware, authorizeRoles } = require('../controllers/userController');
+const { login, refreshToken, logout, authMiddleware, authorizeRoles } = require('../controllers/userController');
 
 const {
   uploadInvoice,
@@ -23,6 +23,7 @@ const {
   getSpendingByTag,
   getUploadHeatmap,
   getQuickStats,
+  getDashboardData,
   exportDashboardPDF,
   checkRecurringInvoice,
   getRecurringInsights,
@@ -49,6 +50,7 @@ const {
   getVendorBio,
   getVendorScorecards,
   getRelationshipGraph,
+  setReviewFlag,
 } = require('../controllers/invoiceController');
 
 
@@ -70,7 +72,7 @@ const { scenarioCashFlow } = require('../controllers/scenarioController');
 
 
 router.get('/export-archived', authMiddleware, exportArchivedInvoicesCSV);
-router.post('/:id/mark-paid', authMiddleware, markInvoicePaid);
+router.post('/:id/mark-paid', authMiddleware, authorizeRoles('finance','admin'), markInvoicePaid);
 router.post('/suggest-vendor', suggestVendor);
 router.post('/send-email', sendSummaryEmail);
 router.post('/upload', authMiddleware, authorizeRoles('admin'), upload.single('invoiceFile'), uploadInvoice);
@@ -85,6 +87,8 @@ router.post('/payment-risk', authMiddleware, paymentRiskScore);
 router.post('/assistant', authMiddleware, assistantQuery);
 router.post('/summarize-errors', summarizeUploadErrors);
 router.post('/login', login);
+router.post('/refresh', refreshToken);
+router.post('/logout', logout);
 router.post('/export-filtered', authMiddleware, exportFilteredInvoicesCSV);
 router.get('/export-all', authMiddleware, exportAllInvoices);
 router.post('/summarize-vendor-data', summarizeVendorData);
@@ -95,6 +99,7 @@ router.get('/top-vendors', authMiddleware, getTopVendors);
 router.get('/spending-by-tag', authMiddleware, getSpendingByTag);
 router.get('/upload-heatmap', authMiddleware, getUploadHeatmap);
 router.get('/quick-stats', authMiddleware, getQuickStats);
+router.get('/dashboard', authMiddleware, getDashboardData);
 router.get('/recurring/insights', authMiddleware, getRecurringInsights);
 router.get('/vendor-profile/:vendor', authMiddleware, getVendorProfile);
 router.get('/vendor-bio/:vendor', authMiddleware, getVendorBio);
@@ -107,14 +112,14 @@ router.post('/:id/unarchive', authMiddleware, unarchiveInvoice);
 router.post('/suggest-vendor', authMiddleware, handleSuggestion);
 router.patch('/:id/update', authMiddleware, updateInvoiceField);
 router.patch('/:id/assign', authMiddleware, assignInvoice);
-router.patch('/:id/approve', authMiddleware, authorizeRoles('approver','admin'), approveInvoice);
-router.patch('/:id/reject', authMiddleware, authorizeRoles('approver','admin'), rejectInvoice);
-router.post('/:id/comments', authMiddleware, authorizeRoles('approver','admin'), addComment);
-router.post('/:id/vendor-reply', authMiddleware, authorizeRoles('approver','admin'), vendorReply);
+router.patch('/:id/approve', authMiddleware, authorizeRoles('reviewer','admin'), approveInvoice);
+router.patch('/:id/reject', authMiddleware, authorizeRoles('reviewer','admin'), rejectInvoice);
+router.post('/:id/comments', authMiddleware, authorizeRoles('reviewer','admin'), addComment);
+router.post('/:id/vendor-reply', authMiddleware, authorizeRoles('reviewer','admin'), vendorReply);
 router.patch('/bulk/archive', authMiddleware, authorizeRoles('admin'), bulkArchiveInvoices);
 router.patch('/bulk/assign', authMiddleware, authorizeRoles('admin'), bulkAssignInvoices);
-router.patch('/bulk/approve', authMiddleware, authorizeRoles('approver','admin'), bulkApproveInvoices);
-router.patch('/bulk/reject', authMiddleware, authorizeRoles('approver','admin'), bulkRejectInvoices);
+router.patch('/bulk/approve', authMiddleware, authorizeRoles('reviewer','admin'), bulkApproveInvoices);
+router.patch('/bulk/reject', authMiddleware, authorizeRoles('reviewer','admin'), bulkRejectInvoices);
 router.post('/bulk/pdf', authMiddleware, exportPDFBundle);
 router.post('/bulk/auto-categorize', authMiddleware, bulkAutoCategorize);
 router.patch('/:id/notes', authMiddleware, authorizeRoles('admin'), updatePrivateNotes);
@@ -122,6 +127,7 @@ router.patch('/:id/retention', authMiddleware, authorizeRoles('admin'), updateRe
 router.post('/suggest-tags', authMiddleware, suggestTags);
 router.post('/suggest-tag-colors', authMiddleware, suggestTagColors);
 router.post('/:id/update-tags', authMiddleware, updateInvoiceTags);
+router.patch('/:id/review-flag', authMiddleware, authorizeRoles('admin','reviewer'), setReviewFlag);
 router.get('/logs', authMiddleware, authorizeRoles('admin'), getActivityLogs);
 router.get('/logs/export', authMiddleware, authorizeRoles('admin'), exportComplianceReport);
 router.get('/:id/timeline', authMiddleware, getInvoiceTimeline);

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -19,6 +19,8 @@ async function initDb() {
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS delete_at TIMESTAMP");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS tenant_id TEXT DEFAULT 'default'");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS department TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS review_flag BOOLEAN DEFAULT FALSE");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS review_notes TEXT");
 
     await pool.query(`CREATE TABLE IF NOT EXISTS activity_logs (
       id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- support `review_flag` invoice field in DB
- allow tagging invoices for internal review via `/review-flag`
- add refresh token login flow and new roles
- filter invoices by vendor, team, and status
- provide dashboard summary endpoint
- protect mark-paid route with `finance` role
- update role names in approval routes

## Testing
- `npm test --silent` in `backend` *(no tests defined)*
- `npm test --silent` in `frontend` *(failed: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e05e65c34832ea4b615ea7e87f0c3