### PR TITLE
Add AI invoice categorization with custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ apply custom approval rules:
 - **Legal** – auto-approves and is meant for comments only.
 - **Ops** – invoices under $100 auto-approve, others need one manager step.
 
+### Categorization Rules
+
+Define your own invoice categorization logic. Add rules via `POST /api/analytics/rules` with fields like `vendor`, `descriptionContains`, `amountGreaterThan`, and a resulting `category` or `flagReason`. All rules are returned from `GET /api/analytics/rules`.
+
+Once rules are created you can automatically tag an invoice with
+`POST /api/invoices/:id/auto-categorize`. The AI model suggests categories such
+as "Marketing", "Legal", or "Recurring" when no rule matches.
+
 ### New Endpoints
 
 - `POST /api/invoices/budgets` – create/update a monthly or quarterly budget by vendor or tag

--- a/backend/controllers/rulesController.js
+++ b/backend/controllers/rulesController.js
@@ -6,7 +6,9 @@ exports.listRules = (_req, res) => {
 
 exports.addRule = (req, res) => {
   const rule = req.body;
-  if (!rule || (!rule.vendor && !rule.amountGreaterThan)) {
+  const hasMatchField = rule && (rule.vendor || rule.amountGreaterThan || rule.descriptionContains);
+  const hasAction = rule && (rule.category || rule.flagReason);
+  if (!hasMatchField || !hasAction) {
     return res.status(400).json({ message: 'Invalid rule' });
   }
   addRule(rule);

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -47,6 +47,7 @@ const {
   explainFlaggedInvoice,
   explainInvoice,
   bulkAutoCategorize,
+  autoCategorizeInvoice,
   getVendorBio,
   getVendorScorecards,
   getRelationshipGraph,
@@ -122,6 +123,7 @@ router.patch('/bulk/approve', authMiddleware, authorizeRoles('reviewer','admin')
 router.patch('/bulk/reject', authMiddleware, authorizeRoles('reviewer','admin'), bulkRejectInvoices);
 router.post('/bulk/pdf', authMiddleware, exportPDFBundle);
 router.post('/bulk/auto-categorize', authMiddleware, bulkAutoCategorize);
+router.post('/:id/auto-categorize', authMiddleware, autoCategorizeInvoice);
 router.patch('/:id/notes', authMiddleware, authorizeRoles('admin'), updatePrivateNotes);
 router.patch('/:id/retention', authMiddleware, authorizeRoles('admin'), updateRetentionPolicy);
 router.post('/suggest-tags', authMiddleware, suggestTags);

--- a/backend/utils/rulesEngine.js
+++ b/backend/utils/rulesEngine.js
@@ -1,21 +1,30 @@
 let rules = [
   { vendor: 'X', amountGreaterThan: 500, flagReason: 'Vendor X amount > $500' },
   { amountGreaterThan: 5000, flagReason: 'Amount exceeds $5000' },
+  // Example categorization rule
+  { vendor: 'Google', category: 'Marketing' },
 ];
 
 function applyRules(invoice) {
   let flagged = false;
   let reason = null;
+  let tags = Array.isArray(invoice.tags) ? [...invoice.tags] : [];
   for (const r of rules) {
-    const matchVendor = !r.vendor || (invoice.vendor && invoice.vendor.toLowerCase() === r.vendor.toLowerCase());
-    const matchAmount = r.amountGreaterThan && parseFloat(invoice.amount) > r.amountGreaterThan;
-    if (matchVendor && matchAmount) {
-      flagged = true;
-      reason = r.flagReason || 'Rule triggered';
-      break;
+    const matchVendor = !r.vendor || (invoice.vendor && invoice.vendor.toLowerCase().includes(r.vendor.toLowerCase()));
+    const matchAmount = r.amountGreaterThan ? parseFloat(invoice.amount) > r.amountGreaterThan : true;
+    const matchDesc = !r.descriptionContains || ((invoice.description || '').toLowerCase().includes(r.descriptionContains.toLowerCase()));
+    if (matchVendor && matchAmount && matchDesc) {
+      if (r.flagReason) {
+        flagged = true;
+        reason = r.flagReason || 'Rule triggered';
+      }
+      if (r.category) {
+        tags.push(r.category);
+      }
     }
   }
-  return { ...invoice, flagged, flag_reason: reason };
+  tags = Array.from(new Set(tags));
+  return { ...invoice, flagged, flag_reason: reason, tags };
 }
 
 function getRules() {


### PR DESCRIPTION
## Summary
- extend rules engine to support assigning categories and apply them on upload
- allow user-defined rule creation for categories
- add endpoint for AI-based auto categorization of an invoice
- store tags on insert and document the feature

## Testing
- `npm install` *(backend)*
- `OPENROUTER_API_KEY=dummy npm start` *(fails: database connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_684e12fbd884832ebc91d856b450731b