### PR TITLE
Add sidebar navigation and improve accessibility

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { io } from 'socket.io-client';
 import LiveFeed from './components/LiveFeed';
 import Navbar from './components/Navbar';
+import SidebarNav from './components/SidebarNav';
 import {
   BarChart,
   Bar,
@@ -143,7 +144,10 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
   const [downloadingId, setDownloadingId] = useState(null);
   const [paymentRequestId, setPaymentRequestId] = useState(null);
   const [toasts, setToasts] = useState([]);
-  const [notifications, setNotifications] = useState([]);
+  const [notifications, setNotifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
   const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
   const [tagInputs, setTagInputs] = useState({});
@@ -193,6 +197,10 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
     const n = { id: Date.now(), text, read: false };
     setNotifications((prev) => [n, ...prev]);
   };
+
+  useEffect(() => {
+    localStorage.setItem('notifications', JSON.stringify(notifications));
+  }, [notifications]);
 
   const markNotificationsRead = () => {
     setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
@@ -1663,6 +1671,7 @@ useEffect(() => {
       )}
 
       <div className="pt-16 flex flex-col md:flex-row md:gap-4 min-h-screen">
+        <SidebarNav notifications={notifications} />
         {token && (
           <aside
           className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 md:flex-shrink-0 ${

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
 import { Link } from 'react-router-dom';
+import SidebarNav from './components/SidebarNav';
 
 function Archive() {
   const token = localStorage.getItem('token') || '';
@@ -10,6 +11,10 @@ function Archive() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [priorityOnly, setPriorityOnly] = useState(false);
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
 
   useEffect(() => {
     if (!token) return;
@@ -53,7 +58,9 @@ function Archive() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4 pt-16">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
         <h1 className="text-3xl font-bold">Invoice Archive</h1>
         <Link to="/" className="underline">Back to App</Link>

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import Skeleton from './components/Skeleton';
 import VendorProfilePanel from './components/VendorProfilePanel';
+import SidebarNav from './components/SidebarNav';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
@@ -18,6 +19,10 @@ function Dashboard() {
   const [budget, setBudget] = useState([]);
   const [selectedVendor, setSelectedVendor] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
 
   useEffect(() => {
     if (!token) return;
@@ -82,7 +87,9 @@ function Dashboard() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4 pt-16">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
         <h1 className="text-xl font-bold">AI Dashboard</h1>
         <div className="space-x-2">
@@ -265,6 +272,7 @@ function Dashboard() {
           <VendorProfilePanel vendor={selectedVendor} open={!!selectedVendor} onClose={() => setSelectedVendor(null)} token={token} />
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Skeleton from './components/Skeleton';
 import { Link } from 'react-router-dom';
+import SidebarNav from './components/SidebarNav';
 
 function Reports() {
   const token = localStorage.getItem('token') || '';
@@ -14,6 +15,10 @@ function Reports() {
   const [loadingRules, setLoadingRules] = useState(true);
   const [threshold, setThreshold] = useState(5000);
   const [rules, setRules] = useState([]);
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
 
   const fetchReport = async () => {
     setLoadingReport(true);
@@ -76,7 +81,9 @@ function Reports() {
   }, [token]);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4 pt-16">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
         <h1 className="text-xl font-bold">Reports</h1>
         <Link to="/" className="underline">Back to App</Link>

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
 import { Link } from 'react-router-dom';
+import SidebarNav from './components/SidebarNav';
 
 function TeamManagement() {
   const token = localStorage.getItem('token') || '';
@@ -11,6 +12,10 @@ function TeamManagement() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [newRole, setNewRole] = useState('viewer');
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
 
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
@@ -68,7 +73,9 @@ function TeamManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4 pt-16">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
         <h1 className="text-xl font-bold">Team Management</h1>
         <Link to="/" className="underline">Back to App</Link>

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -1,12 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
 import { Link } from 'react-router-dom';
+import SidebarNav from './components/SidebarNav';
 
 function VendorManagement() {
   const token = localStorage.getItem('token') || '';
   const [vendors, setVendors] = useState([]);
   const [loading, setLoading] = useState(true);
   const [notesInput, setNotesInput] = useState({});
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
 
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
@@ -39,7 +44,9 @@ function VendorManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-4 pt-16">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4 pt-16">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
         <h1 className="text-xl font-bold">Vendor Management</h1>
         <Link to="/" className="underline">Back to App</Link>

--- a/frontend/src/WorkflowPage.js
+++ b/frontend/src/WorkflowPage.js
@@ -1,9 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import WorkflowBuilder from './components/WorkflowBuilder';
+import SidebarNav from './components/SidebarNav';
 
 export default function WorkflowPage() {
   const token = localStorage.getItem('token') || '';
   const [steps, setSteps] = useState(['Finance', 'Manager', 'Legal']);
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
 
   useEffect(() => {
     fetch('http://localhost:3000/api/workflows', {
@@ -26,9 +31,12 @@ export default function WorkflowPage() {
   };
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-semibold mb-4">Workflow Builder</h1>
-      <WorkflowBuilder steps={steps} onChange={save} />
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4">
+        <h1 className="text-xl font-semibold mb-4">Workflow Builder</h1>
+        <WorkflowBuilder steps={steps} onChange={save} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+export default function SidebarNav({ notifications = [] }) {
+  const location = useLocation();
+  const [open, setOpen] = useState(true);
+  const unread = notifications.filter(n => !n.read).length;
+
+  return (
+    <aside className="bg-white dark:bg-gray-800 shadow-lg w-48 md:w-56 p-4 space-y-2">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full text-left font-semibold mb-2 focus:outline-none focus:ring-2 focus:ring-indigo-400"
+        aria-expanded={open}
+      >
+        Menu
+      </button>
+      {open && (
+        <nav className="space-y-1">
+          <Link
+            to="/dashboard"
+            className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/dashboard' ? 'font-semibold' : ''}`}
+          >
+            <span className="mr-2">📄</span>Dashboard
+          </Link>
+          <Link
+            to="/analytics"
+            className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/analytics' ? 'font-semibold' : ''}`}
+          >
+            <span className="mr-2">📊</span>Reports
+          </Link>
+          <Link
+            to="/settings"
+            className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/settings' ? 'font-semibold' : ''}`}
+          >
+            <span className="mr-2">⚙️</span>Settings
+          </Link>
+        </nav>
+      )}
+      <div className="mt-4 relative">
+        <button
+          className="focus:outline-none focus:ring-2 focus:ring-indigo-400"
+          title="Notifications"
+        >
+          🔔
+          {unread > 0 && (
+            <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full px-1 text-xs">
+              {unread}
+            </span>
+          )}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,7 +4,7 @@
 @tailwind utilities;
 
 :root {
-  --accent-color: #4f46e5;
+  --accent-color: #4338ca;
   --font-base: 'Inter', ui-sans-serif, system-ui;
 }
 
@@ -64,7 +64,10 @@ code {
     @apply bg-red-500 text-white hover:bg-red-600;
   }
   .btn-warning {
-    @apply bg-yellow-500 text-white hover:bg-yellow-600;
+    @apply bg-yellow-400 text-black hover:bg-yellow-500;
+  }
+  .nav-link {
+    @apply focus:outline-none focus:ring-2 focus:ring-indigo-400;
   }
   .input {
     @apply border border-gray-300 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-700 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none;


### PR DESCRIPTION
## Summary
- implement reusable `<SidebarNav>` with icons and notification badges
- include sidebar navigation on major pages
- persist notifications in `localStorage`
- adjust button colors for accessibility and add focus styles

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fac4aacfc832ebfe0692101258e55