### PR TITLE
Add predictive vendor analytics and voice upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - AI explanations for why an invoice was flagged
 - "Why did AI say this?" links show confidence and reasoning
 - AI-powered bulk categorization of uploaded invoices
+- Predictive vendor behavior suggestions
+- Anomaly warnings before upload
+- Voice-to-upload for quick invoice creation
+- Natural language invoice search
 - Hoverable vendor bios with website and industry info
 - AI fraud detection heatmaps (color-coded anomaly maps)
 - Automatic vendor bios + risk scores from public data

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -178,6 +178,8 @@ exports.naturalLanguageQuery = async (req, res) => {
   }
 };
 
+exports.naturalLanguageSearch = exports.naturalLanguageQuery;
+
 // Invoice quality scoring
 exports.invoiceQualityScore = async (req, res) => {
   try {

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -8,6 +8,7 @@ const { login, refreshToken, logout, authMiddleware, authorizeRoles } = require(
 
 const {
   uploadInvoice,
+  voiceUpload,
   getAllInvoices,
   clearAllInvoices,
   deleteInvoiceById,
@@ -64,7 +65,7 @@ const router = express.Router();
 const { sendSummaryEmail } = require('../controllers/emailController');
 const { summarizeVendorData } = require('../controllers/aiController');
 const { suggestVendor } = require('../controllers/aiController');
-const { naturalLanguageQuery } = require("../controllers/aiController");
+const { naturalLanguageQuery, naturalLanguageSearch } = require("../controllers/aiController");
 const { flagSuspiciousInvoice } = require('../controllers/invoiceController');
 const { getActivityLogs, getInvoiceTimeline, exportComplianceReport } = require('../controllers/activityController');
 const { setBudget, getBudgets, checkBudgetWarnings, getBudgetVsActual } = require('../controllers/budgetController');
@@ -81,11 +82,13 @@ router.post('/:id/mark-paid', authMiddleware, authorizeRoles('finance','admin'),
 router.post('/suggest-vendor', suggestVendor);
 router.post('/send-email', sendSummaryEmail);
 router.post('/upload', authMiddleware, authorizeRoles('admin'), upload.single('invoiceFile'), uploadInvoice);
+router.post('/voice-upload', authMiddleware, authorizeRoles('admin'), voiceUpload);
 router.get('/', getAllInvoices);
 router.delete('/clear', authMiddleware, authorizeRoles('admin'), clearAllInvoices);
 router.delete('/:id', authMiddleware, authorizeRoles('admin'), deleteInvoiceById);
 router.get('/search', searchInvoicesByVendor);
 router.post('/nl-query', authMiddleware, naturalLanguageQuery);
+router.post('/nl-search', authMiddleware, naturalLanguageSearch);
 router.post('/nl-chart', authMiddleware, nlChartQuery);
 router.post('/quality-score', authMiddleware, invoiceQualityScore);
 router.post('/payment-risk', authMiddleware, paymentRiskScore);

--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const router = express.Router();
-const { listVendors, updateVendorNotes, getVendorInfo, matchVendors } = require('../controllers/vendorController');
+const { listVendors, updateVendorNotes, getVendorInfo, matchVendors, predictVendorBehavior } = require('../controllers/vendorController');
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
 
 router.get('/', authMiddleware, listVendors);
 router.get('/match', authMiddleware, matchVendors);
 router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
 router.get('/:vendor/info', authMiddleware, getVendorInfo);
+router.get('/:vendor/predict', authMiddleware, predictVendorBehavior);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add predictive vendor analytics endpoint
- warn on vendor spend spikes when uploading invoices
- implement voice-to-upload helper with CSV/PDF output
- expose natural language search alias
- document the new AI features

## Testing
- `npm --version`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684fb3d407a4832ea43da78ce4107708