### PR TITLE
Add payment link generation endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ EMAIL_PASS=
 EMAIL_TO=
 # Stripe secret key for billing
 STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
 # Sentry DSN for error monitoring
 SENTRY_DSN=
 # Webhook URLs for notifications

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ as "Marketing", "Legal", or "Recurring" when no rule matches.
 - `PATCH /api/invoices/:id/payment-status` – update payment status
 - `POST /api/invoices/share` – generate a share link for selected invoices
 - `GET /api/invoices/shared/:token` – access a shared invoice view
+- `POST /api/payments/:id/link` – generate a payment link for an invoice
+- `POST /api/payments/stripe/webhook` – Stripe webhook endpoint for status updates
 
 ### Vendor Reply Drafts
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -11,6 +11,7 @@ const analyticsRoutes = require('./routes/analyticsRoutes');
 const userRoutes = require('./routes/userRoutes');
 const vendorRoutes = require('./routes/vendorRoutes');
 const billingRoutes = require('./routes/billingRoutes');
+const paymentRoutes = require('./routes/paymentRoutes');
 const workflowRoutes = require('./routes/workflowRoutes');
 const settingsRoutes = require('./routes/settingsRoutes');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
@@ -33,6 +34,7 @@ app.use('/api/analytics', analyticsRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/vendors', vendorRoutes);
 app.use('/api/billing', billingRoutes);
+app.use('/api/payments', paymentRoutes);
 app.use('/api/workflows', workflowRoutes);
 app.use('/api/settings', settingsRoutes);
 

--- a/backend/controllers/paymentController.js
+++ b/backend/controllers/paymentController.js
@@ -1,0 +1,68 @@
+const pool = require('../config/db');
+const axios = require('axios');
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+
+async function createPaymentLink(req, res) {
+  const { id } = req.params;
+  const { method, successUrl, cancelUrl } = req.body;
+  try {
+    const result = await pool.query('SELECT invoice_number, amount FROM invoices WHERE id = $1', [id]);
+    if (result.rows.length === 0) {
+      return res.status(404).json({ message: 'Invoice not found' });
+    }
+    const invoice = result.rows[0];
+    let link; let provider;
+    if (method === 'paypal') {
+      const auth = Buffer.from(`${process.env.PAYPAL_CLIENT_ID}:${process.env.PAYPAL_CLIENT_SECRET}`).toString('base64');
+      const tokenRes = await axios.post('https://api-m.paypal.com/v1/oauth2/token', 'grant_type=client_credentials', {
+        headers: { Authorization: `Basic ${auth}` },
+      });
+      const access = tokenRes.data.access_token;
+      const orderRes = await axios.post('https://api-m.paypal.com/v2/checkout/orders', {
+        intent: 'CAPTURE',
+        purchase_units: [{ amount: { currency_code: 'USD', value: invoice.amount } }],
+        application_context: { return_url: successUrl, cancel_url: cancelUrl },
+      }, { headers: { Authorization: `Bearer ${access}` } });
+      const approve = orderRes.data.links.find(l => l.rel === 'approve');
+      link = approve.href;
+      provider = 'PayPal';
+    } else {
+      const session = await stripe.checkout.sessions.create({
+        payment_method_types: method === 'ach' ? ['us_bank_account'] : ['card'],
+        mode: 'payment',
+        line_items: [{
+          price_data: {
+            currency: 'usd',
+            product_data: { name: `Invoice ${invoice.invoice_number}` },
+            unit_amount: Math.round(Number(invoice.amount) * 100),
+          },
+          quantity: 1,
+        }],
+        success_url: successUrl,
+        cancel_url: cancelUrl,
+      });
+      link = session.url;
+      provider = 'Stripe';
+    }
+    await pool.query('UPDATE invoices SET payment_link = $1, payment_status = $2 WHERE id = $3', [link, 'Pending', id]);
+    res.json({ paymentLink: link, provider });
+  } catch (err) {
+    console.error('Payment link error:', err);
+    res.status(500).json({ message: 'Failed to create payment link' });
+  }
+}
+
+async function stripeWebhook(req, res) {
+  const event = req.body;
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object;
+    try {
+      await pool.query('UPDATE invoices SET payment_status = $1 WHERE payment_link = $2', ['Paid', session.url]);
+    } catch (err) {
+      console.error('Webhook update error:', err);
+    }
+  }
+  res.json({ received: true });
+}
+
+module.exports = { createPaymentLink, stripeWebhook };

--- a/backend/routes/paymentRoutes.js
+++ b/backend/routes/paymentRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { createPaymentLink, stripeWebhook } = require('../controllers/paymentController');
+
+router.post('/:id/link', createPaymentLink);
+router.post('/stripe/webhook', express.json({ type: 'application/json' }), stripeWebhook);
+
+module.exports = router;

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -22,6 +22,7 @@ async function initDb() {
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS review_flag BOOLEAN DEFAULT FALSE");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS review_notes TEXT");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS payment_status TEXT DEFAULT 'Pending'");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS payment_link TEXT");
 
     await pool.query(`CREATE TABLE IF NOT EXISTS activity_logs (
       id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- integrate payment links with Stripe and PayPal
- expose new `/api/payments` routes
- store `payment_link` on invoices
- add configuration examples for PayPal/Stripe webhook

## Testing
- `node -v`
- `node -e "console.log('test run')"`
- `npm install --package-lock-only` *(failed: No matching version found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb82cc3c0832e869f92e21a16865a