### PR TITLE
Add email reminders and Slack alerts

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -17,7 +17,7 @@ const settingsRoutes = require('./routes/settingsRoutes');
 const recurringRoutes = require('./routes/recurringRoutes');
 const poRoutes = require('./routes/poRoutes');
 const { runRecurringInvoices } = require('./controllers/recurringController');
-const { processFailedPayments } = require('./controllers/paymentController');
+const { processFailedPayments, sendPaymentReminders } = require('./controllers/paymentController');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
 const { initDb } = require('./utils/dbInit');
 const { initChat } = require('./utils/chatServer');
@@ -58,6 +58,8 @@ app.use(Sentry.Handlers.errorHandler());
   setInterval(runRecurringInvoices, 24 * 60 * 60 * 1000);
   processFailedPayments();
   setInterval(processFailedPayments, 60 * 60 * 1000);
+  sendPaymentReminders();
+  setInterval(sendPaymentReminders, 24 * 60 * 60 * 1000);
 
   console.log('🟢 Routes mounted');
 

--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -181,6 +181,7 @@ exports.uploadInvoice = async (req, res) => {
     });
   } catch (err) {
     console.error(err);
+    await sendSlackNotification?.(`Invoice upload failed: ${err.message}`);
     res.status(500).json({ message: 'Server error' });
   }
 };
@@ -219,6 +220,7 @@ exports.voiceUpload = async (req, res) => {
     doc.end();
   } catch (err) {
     console.error('Voice upload error:', err);
+    await sendSlackNotification?.(`Voice upload failed: ${err.message}`);
     res.status(500).json({ message: 'Failed to process voice upload' });
   }
 };

--- a/backend/controllers/purchaseOrderController.js
+++ b/backend/controllers/purchaseOrderController.js
@@ -29,6 +29,7 @@ exports.uploadPOs = async (req, res) => {
     res.json({ message: 'POs uploaded', inserted: rows.length });
   } catch (err) {
     console.error('PO upload error:', err);
+    await sendSlackNotification?.(`PO upload failed: ${err.message}`);
     res.status(500).json({ message: 'Failed to upload POs' });
   }
 };
@@ -39,6 +40,7 @@ exports.getPOs = async (_req, res) => {
     res.json({ purchase_orders: result.rows });
   } catch (err) {
     console.error('Get POs error:', err);
+    await sendSlackNotification?.(`Fetching POs failed: ${err.message}`);
     res.status(500).json({ message: 'Failed to fetch POs' });
   }
 };


### PR DESCRIPTION
## Summary
- send email payment reminders for upcoming or overdue invoices
- notify Slack on retrying payments, late fees, or payment reminders
- schedule reminder job in app start
- alert Slack when uploads fail

## Testing
- `npm test` in `backend` *(fails: Missing script)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc21c2390832e8feb0532d3242b73