### PR TITLE
Fix navbar dropdown contrast and system theme

### DIFF
--- a/frontend/src/components/LanguageSelector.js
+++ b/frontend/src/components/LanguageSelector.js
@@ -5,7 +5,11 @@ export default function LanguageSelector() {
   const { i18n } = useTranslation();
   const change = (e) => i18n.changeLanguage(e.target.value);
   return (
-    <select onChange={change} value={i18n.language} className="border rounded px-1 text-sm">
+    <select
+      onChange={change}
+      value={i18n.language}
+      className="input px-1 text-sm"
+    >
       <option value="en">EN</option>
       <option value="es">ES</option>
       <option value="fr">FR</option>

--- a/frontend/src/components/ThemePicker.js
+++ b/frontend/src/components/ThemePicker.js
@@ -8,13 +8,21 @@ export default function ThemePicker({ darkMode, setDarkMode }) {
   const [font, setFont] = useState(() => localStorage.getItem('fontFamily') || 'Inter');
 
   useEffect(() => {
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const applySystem = () => setDarkMode(mq.matches);
+
     if (mode === 'system') {
-      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      setDarkMode(isDark);
+      applySystem();
+      mq.addEventListener('change', applySystem);
     } else {
       setDarkMode(mode === 'dark');
     }
+
     localStorage.setItem('themeMode', mode);
+
+    return () => {
+      mq.removeEventListener('change', applySystem);
+    };
   }, [mode, setDarkMode]);
 
   useEffect(() => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -70,6 +70,6 @@ code {
     @apply focus:outline-none focus:ring-2 focus:ring-indigo-400;
   }
   .input {
-    @apply border border-gray-300 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-700 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none;
+    @apply border border-gray-300 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none;
   }
 }


### PR DESCRIPTION
## Summary
- improve select styling to stay visible in navbar
- listen for system theme changes so system mode actually works

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc3f22da4832e97eb5d80f369d4e0