### PR TITLE
Improve chat feedback & accessibility

### DIFF
--- a/frontend/src/components/ChatSidebar.js
+++ b/frontend/src/components/ChatSidebar.js
@@ -3,6 +3,7 @@ import {
   ChatBubbleLeftRightIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline';
+import Spinner from './Spinner';
 import SuggestionChips from './SuggestionChips';
 import {
   BarChart,
@@ -14,7 +15,7 @@ import {
   CartesianGrid,
 } from 'recharts';
 
-export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, history }) {
+export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, history, loading }) {
   const [question, setQuestion] = useState('');
   const [chartQ, setChartQ] = useState('');
   const [billingQ, setBillingQ] = useState('');
@@ -43,13 +44,21 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, 
 
   return (
     <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="chat-title"
       className={`fixed bottom-4 right-4 w-80 h-96 max-w-full bg-white dark:bg-gray-800 shadow-lg rounded-lg transform transition-transform z-30 ${
         open ? 'translate-y-0' : 'translate-y-full'
       }`}
     >
       <div className="p-2 border-b flex justify-between items-center">
-        <h2 className="text-lg font-semibold">AI Assistant</h2>
-        <button onClick={onClose} title="Close">
+        <h2 id="chat-title" className="text-lg font-semibold">AI Assistant</h2>
+        <button
+          onClick={onClose}
+          title="Close"
+          aria-label="Close chat"
+          className="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+        >
           <XMarkIcon className="w-5 h-5" />
         </button>
       </div>
@@ -80,14 +89,28 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, 
       </div>
       <div className="p-2 space-y-2 border-t">
         <SuggestionChips suggestions={suggestions} onClick={handleSuggestion} />
+        {loading && (
+          <div className="flex justify-center py-2">
+            <Spinner className="h-4 w-4" />
+          </div>
+        )}
         <div className="flex space-x-1">
           <input
             value={question}
             onChange={(e) => setQuestion(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && submitAsk()}
             placeholder="Ask AI..."
+            aria-label="Ask AI"
             className="input flex-1 text-sm"
+            disabled={loading}
           />
-          <button onClick={submitAsk} className="btn btn-primary text-sm" title="Ask">
+          <button
+            onClick={submitAsk}
+            className="btn btn-primary text-sm"
+            title="Ask"
+            aria-label="Submit question"
+            disabled={loading}
+          >
             <ChatBubbleLeftRightIcon className="w-4 h-4" />
           </button>
         </div>
@@ -95,13 +118,18 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, 
           <input
             value={chartQ}
             onChange={(e) => setChartQ(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && submitChart()}
             placeholder="Chart query..."
+            aria-label="Chart query"
             className="input flex-1 text-sm"
+            disabled={loading}
           />
           <button
             onClick={submitChart}
             className="btn bg-green-600 hover:bg-green-700 text-white text-sm"
             title="Chart"
+            aria-label="Submit chart query"
+            disabled={loading}
           >
             Chart
           </button>
@@ -110,13 +138,18 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, 
           <input
             value={billingQ}
             onChange={(e) => setBillingQ(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && submitBilling()}
             placeholder="Billing question..."
+            aria-label="Billing question"
             className="input flex-1 text-sm"
+            disabled={loading}
           />
           <button
             onClick={submitBilling}
             className="btn bg-indigo-500 hover:bg-indigo-600 text-white text-sm"
             title="Billing"
+            aria-label="Submit billing question"
+            disabled={loading}
           >
             Billing
           </button>

--- a/frontend/src/components/FloatingActionPanel.js
+++ b/frontend/src/components/FloatingActionPanel.js
@@ -6,16 +6,18 @@ export default function FloatingActionPanel({ onUpload, onAsk }) {
     <div className="fixed bottom-4 right-4 flex flex-col items-end space-y-2 z-30">
       <button
         onClick={onUpload}
-        className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none flex flex-col items-center"
+        className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white flex flex-col items-center"
         title="Upload Invoice"
+        aria-label="Upload invoice"
       >
         <ArrowUpTrayIcon className="w-6 h-6" />
         <span className="text-xs mt-1">Upload</span>
       </button>
       <button
         onClick={onAsk}
-        className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none flex flex-col items-center"
+        className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white flex flex-col items-center"
         title="Ask AI"
+        aria-label="Ask AI"
       >
         <ChatBubbleLeftRightIcon className="w-6 h-6" />
         <span className="text-xs mt-1">Ask AI</span>

--- a/frontend/src/components/InvoiceDetailModal.js
+++ b/frontend/src/components/InvoiceDetailModal.js
@@ -98,7 +98,14 @@ export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate })
           ) : (
             <button onClick={() => setEditMode(true)} className="bg-indigo-600 text-white px-3 py-1 rounded" title="Edit">Edit</button>
           )}
-          <button onClick={onClose} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700" title="Close">Close</button>
+          <button
+            onClick={onClose}
+            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+            title="Close"
+            aria-label="Close details"
+          >
+            Close
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -12,6 +12,8 @@ import {
   DocumentChartBarIcon,
   ArchiveBoxIcon,
   ArrowUpTrayIcon,
+  SunIcon,
+  MoonIcon,
   UsersIcon,
   UserCircleIcon,
   QuestionMarkCircleIcon,
@@ -76,8 +78,9 @@ export default function Navbar({
           {token && (
             <button
               onClick={onToggleFilters}
-              className="focus:outline-none"
+              className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
               title="Filters"
+              aria-label="Toggle filters"
             >
               <AdjustmentsHorizontalIcon className="h-6 w-6" />
             </button>
@@ -85,7 +88,7 @@ export default function Navbar({
           {token && (
             <>
               <button
-                className="focus:outline-none"
+                className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
                 onClick={() => setMenuOpen((o) => !o)}
                 title="Menu"
                 aria-label="Menu"
@@ -137,12 +140,25 @@ export default function Navbar({
                 <QuestionMarkCircleIcon className="h-6 w-6 cursor-help" />
                 {helpOpen && <HelpTooltip topic="dashboard" token={token} />}
               </div>
+              <button
+                onClick={() => setDarkMode(!darkMode)}
+                className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
+                aria-label="Toggle dark mode"
+                title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+              >
+                {darkMode ? (
+                  <SunIcon className="h-6 w-6" />
+                ) : (
+                  <MoonIcon className="h-6 w-6" />
+                )}
+              </button>
               <ThemePicker darkMode={darkMode} setDarkMode={setDarkMode} />
               <div className="relative">
                 <button
                   onClick={() => setUserOpen((o) => !o)}
-                  className="flex items-center space-x-1 focus:outline-none"
+                  className="flex items-center space-x-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
                   title="Account"
+                  aria-label="Account"
                 >
                   <UserCircleIcon className="h-6 w-6" />
                   <span className="text-sm">Bini</span>

--- a/frontend/src/components/PreviewModal.js
+++ b/frontend/src/components/PreviewModal.js
@@ -42,8 +42,9 @@ export default function PreviewModal({ open, onClose, onConfirm, data }) {
           )}
           <button
             onClick={onClose}
-            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-sm"
+            className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
             title="Close"
+            aria-label="Close preview"
           >
             Close
           </button>

--- a/frontend/src/components/ThemePicker.js
+++ b/frontend/src/components/ThemePicker.js
@@ -44,7 +44,12 @@ export default function ThemePicker({ darkMode, setDarkMode }) {
 
   return (
     <div className="relative">
-      <button onClick={() => setOpen(o => !o)} className="focus:outline-none" title="Theme Picker">
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+        title="Theme Picker"
+        aria-label="Theme Picker"
+      >
         <PaintBrushIcon className="h-6 w-6" />
       </button>
       {open && (

--- a/frontend/src/components/VendorProfilePanel.js
+++ b/frontend/src/components/VendorProfilePanel.js
@@ -36,7 +36,14 @@ export default function VendorProfilePanel({ vendor, open, onClose, token }) {
         <div className="p-4 space-y-2 h-full overflow-y-auto">
           <div className="flex justify-between items-center mb-2">
             <h2 className="text-lg font-semibold">{vendor}</h2>
-            <button onClick={onClose} className="text-sm px-2 py-1 rounded bg-gray-200 dark:bg-gray-700" title="Close">Close</button>
+            <button
+              onClick={onClose}
+              className="text-sm px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              title="Close"
+              aria-label="Close profile"
+            >
+              Close
+            </button>
           </div>
           {loading ? (
             <p className="text-sm">Loading...</p>


### PR DESCRIPTION
## Summary
- add loading spinner and ARIA labels to chat sidebar
- toast notifications for AI query success/failure
- add dark/light toggle and keyboard focus rings in navbar
- improve theme picker accessibility
- ensure buttons across modals have focus styles

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685072efb4ec832ea891c7d92c4bd126