### PR TITLE
Add smart reminders engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ SLACK_WEBHOOK_URL=
 TEAMS_WEBHOOK_URL=
 # External risk scoring service
 RISK_SCORE_URL=
+
+# Reminder settings
+DUE_REMINDER_DAYS=3
+APPROVAL_REMINDER_DAYS=2

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Private notes on invoices
 - Shared comment threads for team discussion
 - Approver reminders with escalation
+- Smart reminders for overdue invoices and pending approvals (email, Slack/Teams & in-app)
 - Batch actions with bulk approval and PDF export
 - Bulk edit/delete/archive options for faster table management
 - AI explanations for why an invoice was flagged
@@ -88,6 +89,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 cd backend
 npm install
 cp .env.example .env   # Make sure to add your DATABASE_URL and OPENAI_API_KEY
+# Optional: adjust DUE_REMINDER_DAYS and APPROVAL_REMINDER_DAYS in .env to tweak reminder timing
 npm start
 ```
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -20,6 +20,7 @@ const poRoutes = require('./routes/poRoutes');
 const integrationRoutes = require('./routes/integrationRoutes');
 const { runRecurringInvoices } = require('./controllers/recurringController');
 const { processFailedPayments, sendPaymentReminders } = require('./controllers/paymentController');
+const { sendApprovalReminders } = require('./controllers/reminderController');
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices } = require('./controllers/invoiceController');
 const { initDb } = require('./utils/dbInit');
 const { initChat } = require('./utils/chatServer');
@@ -64,6 +65,8 @@ app.use(Sentry.Handlers.errorHandler());
   setInterval(processFailedPayments, 60 * 60 * 1000);
   sendPaymentReminders();
   setInterval(sendPaymentReminders, 24 * 60 * 60 * 1000);
+  sendApprovalReminders();
+  setInterval(sendApprovalReminders, 24 * 60 * 60 * 1000);
 
   console.log('🟢 Routes mounted');
 

--- a/backend/controllers/reminderController.js
+++ b/backend/controllers/reminderController.js
@@ -1,0 +1,48 @@
+const nodemailer = require('nodemailer');
+const pool = require('../config/db');
+const { sendSlackNotification, sendTeamsNotification } = require('../utils/notify');
+const { broadcastNotification } = require('../utils/chatServer');
+require('dotenv').config();
+
+async function sendApprovalReminders() {
+  const days = parseInt(process.env.APPROVAL_REMINDER_DAYS || '2', 10);
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  try {
+    const { rows } = await pool.query(
+      `SELECT id, invoice_number, vendor
+       FROM invoices
+       WHERE approval_status IN ('Pending','In Progress')
+         AND created_at <= $1`,
+      [cutoff]
+    );
+    if (!rows.length) return;
+
+    const transporter = nodemailer.createTransport({
+      host: 'smtp.gmail.com',
+      port: 465,
+      secure: true,
+      auth: { user: process.env.EMAIL_USER, pass: process.env.EMAIL_PASS },
+    });
+
+    for (const inv of rows) {
+      const msg = `Invoice ${inv.invoice_number} from ${inv.vendor} is awaiting approval.`;
+      try {
+        await transporter.sendMail({
+          from: process.env.EMAIL_USER,
+          to: process.env.EMAIL_TO,
+          subject: 'Approval reminder',
+          text: msg,
+        });
+        await sendSlackNotification?.(`Approval reminder sent: ${inv.invoice_number}`);
+        await sendTeamsNotification?.(`Approval reminder sent: ${inv.invoice_number}`);
+        broadcastNotification?.(msg);
+      } catch (err) {
+        console.error('Approval reminder email error:', err);
+      }
+    }
+  } catch (err) {
+    console.error('Approval reminder error:', err);
+  }
+}
+
+module.exports = { sendApprovalReminders };

--- a/backend/utils/chatServer.js
+++ b/backend/utils/chatServer.js
@@ -3,8 +3,8 @@ let io;
 
 function initChat(server) {
   io = new Server(server, { cors: { origin: '*' } });
-  io.on('connection', socket => {
-    socket.on('joinInvoice', id => socket.join(`invoice-${id}`));
+  io.on('connection', (socket) => {
+    socket.on('joinInvoice', (id) => socket.join(`invoice-${id}`));
   });
 }
 
@@ -14,4 +14,10 @@ function broadcastMessage(invoiceId, message) {
   }
 }
 
-module.exports = { initChat, broadcastMessage };
+function broadcastNotification(message) {
+  if (io) {
+    io.emit('notification', { text: message });
+  }
+}
+
+module.exports = { initChat, broadcastMessage, broadcastNotification };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -692,6 +692,13 @@ useEffect(() => {
     });
     return () => socket.off('chatMessage');
   }, [socket]);
+
+  useEffect(() => {
+    socket.on('notification', (n) => {
+      if (n && n.text) addNotification(n.text);
+    });
+    return () => socket.off('notification');
+  }, [socket]);
   
   
 


### PR DESCRIPTION
## Summary
- implement a smart reminders engine for pending approvals
- broadcast notifications via WebSocket
- notify Slack and Teams from reminder emails
- expose reminder settings in `.env.example`
- update docs for new feature

## Testing
- `node -e "require('./backend/controllers/reminderController')"` *(fails: Cannot find module 'nodemailer')*

------
https://chatgpt.com/codex/tasks/task_e_685091bcac6c832ebdf5b8992d70542e