### PR TITLE
Add vendor behavior analytics

### DIFF
--- a/backend/controllers/vendorPortalController.js
+++ b/backend/controllers/vendorPortalController.js
@@ -5,6 +5,7 @@ const pool = require('../config/db');
 const { parseCSV } = require('../utils/csvParser');
 const { parsePDF } = require('../utils/pdfParser');
 const { parseImage } = require('../utils/imageParser');
+const { logActivity } = require('../utils/activityLogger');
 
 const VENDORS = [
   { id: 1, name: 'Acme', password: 'acme123' },
@@ -45,8 +46,13 @@ exports.listInvoices = async (req, res) => {
   }
 };
 
-exports.updateBankInfo = (req, res) => {
+exports.updateBankInfo = async (req, res) => {
   BANK_INFO[req.vendor] = req.body.bank || '';
+  try {
+    await logActivity(null, 'change_bank_info', null, req.vendor);
+  } catch (err) {
+    console.error('Bank info log error:', err);
+  }
   res.json({ message: 'Bank info updated' });
 };
 

--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -8,6 +8,7 @@ const {
   predictVendorBehavior,
   exportVendorsCSV,
   importVendorsCSV,
+  getBehaviorFlags,
 } = require('../controllers/vendorController');
 const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
@@ -17,6 +18,7 @@ router.get('/', authMiddleware, listVendors);
 router.get('/export', authMiddleware, authorizeRoles('admin'), exportVendorsCSV);
 router.post('/import', authMiddleware, authorizeRoles('admin'), upload.single('file'), importVendorsCSV);
 router.get('/match', authMiddleware, matchVendors);
+router.get('/behavior-flags', authMiddleware, authorizeRoles('admin'), getBehaviorFlags);
 router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
 router.get('/:vendor/info', authMiddleware, getVendorInfo);
 router.get('/:vendor/predict', authMiddleware, predictVendorBehavior);


### PR DESCRIPTION
## Summary
- log vendor bank info changes in activity logs
- implement deep vendor behavior analytics to flag vendors who exceed budgets, delay payments, or change bank info
- expose new `GET /api/vendors/behavior-flags` endpoint

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685097b26350832e9cb0112eabe853a1