### PR TITLE
Add Kanban approval board

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -56,6 +56,7 @@ const {
   getVendorScorecards,
   getRelationshipGraph,
   setReviewFlag,
+  setFlaggedStatus,
   setPaymentStatus,
   shareInvoices,
   getSharedInvoices,
@@ -150,6 +151,7 @@ router.post('/suggest-tags', authMiddleware, suggestTags);
 router.post('/suggest-tag-colors', authMiddleware, suggestTagColors);
 router.post('/:id/update-tags', authMiddleware, updateInvoiceTags);
 router.patch('/:id/review-flag', authMiddleware, authorizeRoles('admin','reviewer'), setReviewFlag);
+router.patch('/:id/flag', authMiddleware, authorizeRoles('reviewer','admin'), setFlaggedStatus);
 router.get('/logs', authMiddleware, authorizeRoles('admin'), getActivityLogs);
 router.get('/logs/export', authMiddleware, authorizeRoles('admin'), exportComplianceReport);
 router.get('/logs/invoice/:id/export', authMiddleware, authorizeRoles('admin'), exportInvoiceHistory);

--- a/frontend/src/Board.js
+++ b/frontend/src/Board.js
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import SidebarNav from './components/SidebarNav';
+
+export default function Board() {
+  const token = localStorage.getItem('token') || '';
+  const [columns, setColumns] = useState({ pending: [], approved: [], flagged: [] });
+  const [notifications] = useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
+
+  const fetchData = async () => {
+    if (!token) return;
+    const res = await fetch('http://localhost:3000/api/invoices', {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setColumns({
+        pending: data.filter(i => i.approval_status === 'Pending' && !i.flagged),
+        approved: data.filter(i => i.approval_status === 'Approved'),
+        flagged: data.filter(i => i.flagged)
+      });
+    }
+  };
+
+  useEffect(() => { fetchData(); }, [token]);
+
+  const onDragEnd = async (result) => {
+    const { source, destination, draggableId } = result;
+    if (!destination) return;
+    if (source.droppableId === destination.droppableId) return;
+    const id = draggableId;
+    let url = '';
+    let options = { method: 'PATCH', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
+
+    if (destination.droppableId === 'approved') {
+      url = `http://localhost:3000/api/invoices/${id}/approve`;
+    } else if (destination.droppableId === 'flagged') {
+      url = `http://localhost:3000/api/invoices/${id}/flag`;
+      options.body = JSON.stringify({ flagged: true });
+    } else if (destination.droppableId === 'pending') {
+      url = `http://localhost:3000/api/invoices/${id}/flag`;
+      options.body = JSON.stringify({ flagged: false });
+    }
+    if (url) {
+      await fetch(url, options).catch(() => {});
+      fetchData();
+    }
+  };
+
+  const renderColumn = (key, title, items) => (
+    <Droppable droppableId={key}>
+      {(provided) => (
+        <div ref={provided.innerRef} {...provided.droppableProps} className="bg-gray-100 dark:bg-gray-700 rounded p-2 w-72 min-h-[200px]">
+          <h2 className="text-lg font-semibold mb-2">{title}</h2>
+          {items.map((inv, index) => (
+            <Draggable key={inv.id} draggableId={String(inv.id)} index={index}>
+              {(prov) => (
+                <div ref={prov.innerRef} {...prov.draggableProps} {...prov.dragHandleProps} className="bg-white dark:bg-gray-800 p-2 mb-2 rounded shadow text-sm">
+                  <div className="font-semibold">#{inv.invoice_number}</div>
+                  <div>{inv.vendor}</div>
+                  <div>${inv.amount}</div>
+                </div>
+              )}
+            </Draggable>
+          ))}
+          {provided.placeholder}
+        </div>
+      )}
+    </Droppable>
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4">
+        <h1 className="text-xl font-semibold mb-4">Approval Board</h1>
+        <DragDropContext onDragEnd={onDragEnd}>
+          <div className="flex space-x-4 overflow-x-auto">
+            {renderColumn('pending', 'Pending', columns.pending)}
+            {renderColumn('approved', 'Approved', columns.approved)}
+            {renderColumn('flagged', 'Flagged', columns.flagged)}
+          </div>
+        </DragDropContext>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -17,6 +17,7 @@ import {
   UsersIcon,
   UserCircleIcon,
   QuestionMarkCircleIcon,
+  Squares2X2Icon,
 } from '@heroicons/react/24/outline';
 import HelpTooltip from './HelpTooltip';
 
@@ -124,6 +125,13 @@ export default function Navbar({
                     onClick={() => setMenuOpen(false)}
                   >
                     <ArchiveBoxIcon className="h-5 w-5 mr-2" /> Archive
+                  </Link>
+                  <Link
+                    to="/board"
+                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    <Squares2X2Icon className="h-5 w-5 mr-2" /> Board
                   </Link>
                   {role === 'admin' && (
                     <Link

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -5,6 +5,7 @@ import {
   DocumentChartBarIcon,
   Cog6ToothIcon,
   WrenchScrewdriverIcon,
+  Squares2X2Icon,
 } from '@heroicons/react/24/outline';
 
 export default function SidebarNav({ notifications = [] }) {
@@ -43,6 +44,13 @@ export default function SidebarNav({ notifications = [] }) {
             >
               <WrenchScrewdriverIcon className="w-5 h-5 mr-2" />
               <span>Builder</span>
+            </Link>
+            <Link
+              to="/board"
+              className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/board' ? 'font-semibold' : ''}`}
+            >
+              <Squares2X2Icon className="w-5 h-5 mr-2" />
+              <span>Board</span>
             </Link>
             <Link
               to="/settings"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -8,6 +8,7 @@ import Archive from './Archive';
 import TeamManagement from './TeamManagement';
 import VendorManagement from './VendorManagement';
 import WorkflowPage from './WorkflowPage';
+import Board from './Board';
 import NotFound from './NotFound';
 import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -52,6 +53,7 @@ function AnimatedRoutes() {
         <Route path="/archive" element={<PageWrapper><Archive /></PageWrapper>} />
         <Route path="/vendors" element={<PageWrapper><VendorManagement /></PageWrapper>} />
         <Route path="/workflow" element={<PageWrapper><WorkflowPage /></PageWrapper>} />
+        <Route path="/board" element={<PageWrapper><Board /></PageWrapper>} />
         <Route path="/builder" element={<PageWrapper><DashboardBuilder /></PageWrapper>} />
         <Route path="/" element={<Navigate to="/dashboard" replace />} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- implement PATCH `/api/invoices/:id/flag` API for toggling invoice flags
- add Kanban board React page to drag invoices between columns
- wire board into router and navigation

## Testing
- `npm test --prefix frontend --silent -- --watchAll=false` *(fails: Unexpected token parsing App.js)*

------
https://chatgpt.com/codex/tasks/task_e_6850a71e9ea8832ea2f2657e80b706a9