### PR TITLE
Implement real-time invoice feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Slack/Teams notifications for approvals or flags
 - Smart keyboard shortcuts (press **A** to archive, **F** to flag, **/** to focus search)
 - Real-time "Ops Mode" dashboard with a live feed of invoice activity
+- Live Invoice Feed shows uploads, flags and approvals in real time
 - Multi-tenant support so agencies can switch between different client accounts
 - Polite vendor notification emails for flagged or rejected invoices
 - Scenario planning to test payment delays

--- a/backend/utils/activityLogger.js
+++ b/backend/utils/activityLogger.js
@@ -1,11 +1,13 @@
 const pool = require('../config/db');
+const { broadcastActivity } = require('./chatServer');
 
 async function logActivity(userId, action, invoiceId = null, username = null) {
   try {
-    await pool.query(
-      'INSERT INTO activity_logs (user_id, username, action, invoice_id) VALUES ($1,$2,$3,$4)',
-      [userId, username, action, invoiceId]
-    );
+    const { rows } = await pool.query(
+        'INSERT INTO activity_logs (user_id, username, action, invoice_id) VALUES ($1,$2,$3,$4) RETURNING *',
+        [userId, username, action, invoiceId]
+      );
+    broadcastActivity?.(rows[0]);
   } catch (err) {
     console.error('Activity log error:', err);
   }

--- a/backend/utils/chatServer.js
+++ b/backend/utils/chatServer.js
@@ -20,4 +20,10 @@ function broadcastNotification(message) {
   }
 }
 
-module.exports = { initChat, broadcastMessage, broadcastNotification };
+function broadcastActivity(log) {
+  if (io) {
+    io.emit('activity', log);
+  }
+}
+
+module.exports = { initChat, broadcastMessage, broadcastNotification, broadcastActivity };

--- a/frontend/src/components/LiveFeed.js
+++ b/frontend/src/components/LiveFeed.js
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
+import { io } from 'socket.io-client';
 
 export default function LiveFeed({ token, tenant }) {
   const [logs, setLogs] = useState([]);
+  const socket = useMemo(() => io('http://localhost:3000'), []);
 
   useEffect(() => {
     let isMounted = true;
@@ -25,6 +27,13 @@ export default function LiveFeed({ token, tenant }) {
       clearInterval(id);
     };
   }, [token, tenant]);
+
+  useEffect(() => {
+    socket.on('activity', (log) => {
+      setLogs((prev) => [log, ...prev].slice(0, 20));
+    });
+    return () => socket.off('activity');
+  }, [socket]);
 
   return (
     <div className="p-4 bg-gray-50 dark:bg-gray-800 rounded">


### PR DESCRIPTION
## Summary
- broadcast activity events via socket.io
- log events and push them to clients
- subscribe to live activity feed in the frontend
- document live invoice feed in README

## Testing
- `npm install --prefix frontend --legacy-peer-deps`
- `npm test --prefix frontend -- -w=0` *(fails: SyntaxError in App.js)*

------
https://chatgpt.com/codex/tasks/task_e_6850a9e6c124832ea0e1504d12524772