### PR TITLE
Add persistent AI chat history

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -133,7 +133,10 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
   const [qualityScores, setQualityScores] = useState({});
   const [riskScores, setRiskScores] = useState({});
   const [assistantOpen, setAssistantOpen] = useState(false);
-  const [chatHistory, setChatHistory] = useState([]);
+  const [chatHistory, setChatHistory] = useState(() => {
+    const saved = localStorage.getItem('chatHistory');
+    return saved ? JSON.parse(saved) : [];
+  });
   const [loadingVendor, setLoadingVendor] = useState(false);
   const [loadingInsights, setLoadingInsights] = useState(false);
   const [loadingAssistant, setLoadingAssistant] = useState(false);
@@ -205,6 +208,10 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
   useEffect(() => {
     localStorage.setItem('notifications', JSON.stringify(notifications));
   }, [notifications]);
+
+  useEffect(() => {
+    localStorage.setItem('chatHistory', JSON.stringify(chatHistory));
+  }, [chatHistory]);
 
   const markNotificationsRead = () => {
     setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));


### PR DESCRIPTION
## Summary
- persist sidebar chat history in localStorage so conversations survive reloads

## Testing
- `npm --prefix frontend install --legacy-peer-deps`
- `CI=true npm --prefix frontend test --silent` *(fails: SyntaxError in App.js)*

------
https://chatgpt.com/codex/tasks/task_e_6850ac8d759c832e811c18af2405db6c