### PR TITLE
Add invoice snapshot view with keyboard and voice actions

### DIFF
--- a/frontend/src/components/FloatingActionPanel.js
+++ b/frontend/src/components/FloatingActionPanel.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { ChatBubbleLeftRightIcon, ArrowUpTrayIcon } from '@heroicons/react/24/outline';
+import { ChatBubbleLeftRightIcon, ArrowUpTrayIcon, MicrophoneIcon } from '@heroicons/react/24/outline';
 
-export default function FloatingActionPanel({ onUpload, onAsk }) {
+export default function FloatingActionPanel({ onUpload, onAsk, onVoice }) {
   return (
     <div className="fixed bottom-4 right-4 flex flex-col items-end space-y-2 z-30">
       <button
@@ -22,6 +22,17 @@ export default function FloatingActionPanel({ onUpload, onAsk }) {
         <ChatBubbleLeftRightIcon className="w-6 h-6" />
         <span className="text-xs mt-1">Ask AI</span>
       </button>
+      {onVoice && (
+        <button
+          onClick={onVoice}
+          className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white flex flex-col items-center"
+          title="Voice Upload"
+          aria-label="Voice upload"
+        >
+          <MicrophoneIcon className="w-6 h-6" />
+          <span className="text-xs mt-1">Voice</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/InvoiceSnapshotView.js
+++ b/frontend/src/components/InvoiceSnapshotView.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import GraphView from './GraphView';
+
+export default function InvoiceSnapshotView({ open, invoice, onClose, token, tenant, onAddComment }) {
+  const [comment, setComment] = useState('');
+  if (!open || !invoice) return null;
+  return (
+    <div className="fixed inset-0 z-40">
+      <div className="absolute inset-0 bg-black bg-opacity-50" onClick={onClose}></div>
+      <div className={`absolute right-0 top-0 h-full w-96 max-w-full bg-white dark:bg-gray-800 shadow-lg transform transition-transform ${open ? 'translate-x-0' : 'translate-x-full'}`}>\
+        <div className="p-4 space-y-3 h-full overflow-y-auto">
+          <div className="flex justify-between items-center">
+            <h2 className="text-lg font-semibold">Invoice #{invoice.invoice_number}</h2>
+            <button
+              onClick={onClose}
+              className="text-sm px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+              aria-label="Close snapshot"
+            >
+              Close
+            </button>
+          </div>
+          <div className="text-sm space-y-1">
+            <div><span className="font-medium">Vendor:</span> {invoice.vendor}</div>
+            <div><span className="font-medium">Amount:</span> {invoice.amount}</div>
+            <div><span className="font-medium">Date:</span> {invoice.date ? new Date(invoice.date).toLocaleDateString() : ''}</div>
+            <div><span className="font-medium">Status:</span> {invoice.approval_status || 'Pending'}</div>
+          </div>
+          <GraphView token={token} tenant={tenant} />
+          <div>
+            <h3 className="font-semibold text-sm mb-1">Comments</h3>
+            <div className="space-y-1 max-h-40 overflow-y-auto">
+              {invoice.comments?.length ? (
+                invoice.comments.map((c, i) => (
+                  <div key={i} className="text-xs bg-gray-100 rounded p-1">{c.text}</div>
+                ))
+              ) : (
+                <em className="text-xs text-gray-500">No comments</em>
+              )}
+            </div>
+            <div className="flex mt-1">
+              <input
+                type="text"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                className="input text-xs flex-1 px-1"
+                placeholder="Add comment"
+              />
+              <button
+                onClick={() => { onAddComment(invoice.id, comment); setComment(''); }}
+                className="bg-indigo-600 text-white text-xs px-2 py-1 ml-1 rounded"
+              >
+                Post
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `InvoiceSnapshotView` slide-over panel
- extend `FloatingActionPanel` with microphone button for voice uploads
- implement global keyboard navigation and highlight tracking
- wire up voice-to-upload feature and snapshot comment posting

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850b003e404832ea8a9829fec948877