### PR TITLE
Improve upload UI with Tailwind and shadcn

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@radix-ui/react-progress": "^1.0.3",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "class-variance-authority": "^0.7.1",
         "framer-motion": "^11.0.0",
         "fuse.js": "^7.1.0",
         "i18next": "^25.2.1",
@@ -26,6 +28,7 @@
         "react-scripts": "5.0.1",
         "recharts": "^2.15.3",
         "socket.io-client": "^4.8.1",
+        "tailwind-merge": "^3.3.1",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3127,6 +3130,110 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+      "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+      "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+      "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.0.3.tgz",
+      "integrity": "sha512-5G6Om/tYSxjSeEdrb1VfKkfZfn/1IlPWd731h2RfPuSbIfNUgfqAwbKfJCg/PP6nuUCTrYzalwHSpSinoWoCag==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+      "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-compose-refs": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.15.3",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
@@ -6176,6 +6283,18 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "license": "MIT"
+    },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -17648,6 +17767,16 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.1.tgz",
+      "integrity": "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,14 +4,17 @@
   "private": true,
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@radix-ui/react-progress": "^1.0.3",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "class-variance-authority": "^0.7.1",
     "framer-motion": "^11.0.0",
     "fuse.js": "^7.1.0",
     "i18next": "^25.2.1",
     "react": "^18.2.0",
+    "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
     "react-force-graph": "^1.47.6",
     "react-force-graph-2d": "^1.27.1",
@@ -20,8 +23,8 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.15.3",
     "socket.io-client": "^4.8.1",
-    "web-vitals": "^2.1.4",
-    "react-beautiful-dnd": "^13.1.1"
+    "tailwind-merge": "^3.3.1",
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "PORT=3001 react-scripts start",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -30,6 +30,8 @@ import BulkSummary from './components/BulkSummary';
 import FloatingActionPanel from './components/FloatingActionPanel';
 import InvoiceSnapshotView from './components/InvoiceSnapshotView';
 import TourModal from './components/TourModal';
+import ProgressBar from './components/ProgressBar';
+import { Button } from './components/ui/Button';
 import { motion } from 'framer-motion';
 import Fuse from 'fuse.js';
 import {
@@ -1849,7 +1851,7 @@ useEffect(() => {
           <aside
           className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 md:flex-shrink-0 ${
             filterSidebarOpen ? '' : 'hidden md:block'
-          } md:border-r md:border-gray-200 dark:md:border-gray-700 md:max-h-screen md:overflow-y-auto z-40`}
+          } md:border-r md:border-gray-200 dark:md:border-gray-700 md:max-h-screen md:overflow-y-auto md:sticky md:top-16 z-40`}
         >
           <div className="p-4 space-y-4 overflow-y-auto h-full">
             <SidebarNav notifications={notifications} />
@@ -2006,13 +2008,14 @@ useEffect(() => {
         <span>Confirm Upload</span>
       </li>
     </ol>
-    <div
+    <motion.div
       className={`border-2 border-dashed rounded-md p-4 cursor-pointer ${dragActive ? 'bg-indigo-50 dark:bg-indigo-900/20 border-indigo-500' : 'bg-gray-50 dark:bg-gray-700 border-gray-300 dark:border-gray-600'}`}
       onDragOver={(e) => e.preventDefault()}
       onDragEnter={(e) => { e.preventDefault(); setDragActive(true); }}
       onDragLeave={(e) => { e.preventDefault(); setDragActive(false); }}
       onDrop={(e) => { e.preventDefault(); setDragActive(false); handleFiles(e.dataTransfer.files); }}
       onClick={() => fileInputRef.current.click()}
+      whileHover={{ scale: 1.02 }}
     >
       <p className="text-sm text-gray-500 dark:text-gray-300">Drag & drop CSV/PDF/Image here or tap to select or capture</p>
       <input
@@ -2025,7 +2028,7 @@ useEffect(() => {
         onChange={(e) => handleFiles(e.target.files)}
         className="hidden"
       />
-    </div>
+    </motion.div>
     {filePreviews.length > 0 && (
       <div className="flex flex-wrap gap-2 mt-2">
         {filePreviews.map((f, idx) => (
@@ -2054,18 +2057,13 @@ useEffect(() => {
     )}
 
     {uploadProgress > 0 && (
-      <div className="w-full bg-gray-200 dark:bg-gray-700 h-2 rounded mt-2">
-        <div
-          className="bg-indigo-600 dark:bg-indigo-500 h-2 rounded"
-          style={{ width: `${uploadProgress}%` }}
-        ></div>
-      </div>
+      <ProgressBar value={uploadProgress} />
     )}
 
-    <button
+    <Button
       onClick={openUploadPreview}
       disabled={!token || !files.length}
-      className="btn btn-primary w-full flex items-center justify-center space-x-2 mt-4 disabled:opacity-60"
+      className="w-full flex items-center justify-center space-x-2 mt-4"
     >
       {loading ? (
         <Spinner className="h-4 w-4" />
@@ -2073,7 +2071,7 @@ useEffect(() => {
         <ArrowUpTrayIcon className="h-5 w-5" />
       )}
       <span>{loading ? 'Uploading...' : 'Upload Invoice'}</span>
-    </button>
+    </Button>
 
     {recentUploads.length > 0 && (
       <div className="mt-2 text-xs">

--- a/frontend/src/components/ProgressBar.js
+++ b/frontend/src/components/ProgressBar.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import * as Progress from '@radix-ui/react-progress';
+import { motion } from 'framer-motion';
+
+export default function ProgressBar({ value }) {
+  return (
+    <Progress.Root className="relative overflow-hidden bg-gray-200 dark:bg-gray-700 rounded h-2 w-full">
+      <Progress.Indicator asChild style={{ width: `${value}%` }}>
+        <motion.div
+          className="bg-indigo-600 dark:bg-indigo-500 w-full h-full"
+          initial={{ width: 0 }}
+          animate={{ width: `${value}%` }}
+          transition={{ ease: 'easeOut', duration: 0.3 }}
+        />
+      </Progress.Indicator>
+    </Progress.Root>
+  );
+}

--- a/frontend/src/components/ui/Button.js
+++ b/frontend/src/components/ui/Button.js
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-indigo-600 text-white hover:bg-indigo-700',
+        secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+const Button = React.forwardRef(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button';
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+});
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- swap plain progress bar for `@radix-ui/react-progress`
- add shadcn-styled `Button` component
- animate file drop zone with Framer Motion
- make filters sidebar sticky to avoid overlap

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850cf763894832e87d5fbba972cb627