### PR TITLE
Add unified navigation layout

### DIFF
--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
-import { Link } from 'react-router-dom';
-import SidebarNav from './components/SidebarNav';
 import HelpTooltip from './components/HelpTooltip';
+import MainLayout from './components/MainLayout';
 
 function Archive() {
   const token = localStorage.getItem('token') || '';
@@ -12,10 +11,6 @@ function Archive() {
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [priorityOnly, setPriorityOnly] = useState(false);
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   useEffect(() => {
     if (!token) return;
@@ -59,18 +54,7 @@ function Archive() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4 pt-16">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
-        <h1 className="text-3xl font-bold flex items-center gap-1">
-          Invoice Archive
-          <span className="relative group cursor-help">❓
-            <span className="hidden group-hover:block absolute z-10"><HelpTooltip topic="archive" token={token} /></span>
-          </span>
-        </h1>
-        <Link to="/invoices" className="underline">Back to App</Link>
-      </nav>
+    <MainLayout title="Invoice Archive" helpTopic="archive">
       <div className="space-y-4">
         <div className="flex flex-wrap items-end space-x-2">
           <input value={vendor} onChange={(e) => setVendor(e.target.value)} placeholder="Vendor" className="input" />
@@ -116,8 +100,7 @@ function Archive() {
         </table>
         </div>
       </div>
-    </div>
-    </div>
+    </MainLayout>
   );
 }
 

--- a/frontend/src/Board.js
+++ b/frontend/src/Board.js
@@ -1,14 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
-import SidebarNav from './components/SidebarNav';
+import MainLayout from './components/MainLayout';
 
 export default function Board() {
   const token = localStorage.getItem('token') || '';
   const [columns, setColumns] = useState({ pending: [], approved: [], flagged: [] });
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   const fetchData = async () => {
     if (!token) return;
@@ -73,18 +69,15 @@ export default function Board() {
   );
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4">
-        <h1 className="text-xl font-semibold mb-4">Approval Board</h1>
-        <DragDropContext onDragEnd={onDragEnd}>
-          <div className="flex space-x-4 overflow-x-auto">
+    <MainLayout title="Approval Board">
+      <h1 className="text-xl font-semibold mb-4">Approval Board</h1>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <div className="flex space-x-4 overflow-x-auto">
             {renderColumn('pending', 'Pending', columns.pending)}
             {renderColumn('approved', 'Approved', columns.approved)}
             {renderColumn('flagged', 'Flagged', columns.flagged)}
-          </div>
-        </DragDropContext>
-      </div>
-    </div>
+        </div>
+      </DragDropContext>
+    </MainLayout>
   );
 }

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Link } from 'react-router-dom';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import Skeleton from './components/Skeleton';
 import VendorProfilePanel from './components/VendorProfilePanel';
-import SidebarNav from './components/SidebarNav';
+import MainLayout from './components/MainLayout';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
@@ -19,10 +18,6 @@ function Dashboard() {
   const [budget, setBudget] = useState([]);
   const [selectedVendor, setSelectedVendor] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   useEffect(() => {
     if (!token) return;
@@ -87,16 +82,10 @@ function Dashboard() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4 pt-16">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
-        <h1 className="text-xl font-bold">AI Dashboard</h1>
-        <div className="space-x-2">
-          <button onClick={handleExportPDF} className="underline mr-2">Export PDF</button>
-          <Link to="/invoices" className="underline">Back to App</Link>
-        </div>
-      </nav>
+    <MainLayout title="AI Dashboard">
+      <div className="mb-4 text-right">
+        <button onClick={handleExportPDF} className="underline mr-2">Export PDF</button>
+      </div>
       {!token ? (
         <p className="text-center text-gray-600">Please log in from the main app.</p>
       ) : (
@@ -272,8 +261,7 @@ function Dashboard() {
           <VendorProfilePanel vendor={selectedVendor} open={!!selectedVendor} onClose={() => setSelectedVendor(null)} token={token} />
         </div>
       )}
-      </div>
-    </div>
+    </MainLayout>
   );
 }
 

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
-import SidebarNav from './components/SidebarNav';
+import MainLayout from './components/MainLayout';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
@@ -16,10 +16,6 @@ export default function DashboardBuilder() {
   const [vendors, setVendors] = useState([]);
   const [heatmap, setHeatmap] = useState([]);
   const [timeline, setTimeline] = useState([]);
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   useEffect(() => {
     const headers = { Authorization: `Bearer ${token}` };
@@ -66,10 +62,8 @@ export default function DashboardBuilder() {
   });
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4">
-        <h1 className="text-xl font-semibold mb-4">Dashboard Builder</h1>
+    <MainLayout title="Dashboard Builder">
+      <h1 className="text-xl font-semibold mb-4">Dashboard Builder</h1>
         <DragDropContext onDragEnd={handleDragEnd}>
           <Droppable droppableId="widgets">
             {(provided) => (
@@ -145,7 +139,7 @@ export default function DashboardBuilder() {
           </Droppable>
         </DragDropContext>
       </div>
-    </div>
+    </MainLayout>
   );
 }
 

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Skeleton from './components/Skeleton';
-import { Link } from 'react-router-dom';
-import SidebarNav from './components/SidebarNav';
 import HelpTooltip from './components/HelpTooltip';
+import MainLayout from './components/MainLayout';
 
 function Reports() {
   const token = localStorage.getItem('token') || '';
@@ -16,10 +15,6 @@ function Reports() {
   const [loadingRules, setLoadingRules] = useState(true);
   const [threshold, setThreshold] = useState(5000);
   const [rules, setRules] = useState([]);
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   const fetchReport = async () => {
     setLoadingReport(true);
@@ -82,18 +77,7 @@ function Reports() {
   }, [token]);
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4 pt-16">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
-        <h1 className="text-xl font-bold flex items-center gap-1">
-          Reports
-          <span className="relative group cursor-help">❓
-            <span className="hidden group-hover:block absolute z-10"><HelpTooltip topic="reports" token={token} /></span>
-          </span>
-        </h1>
-        <Link to="/invoices" className="underline">Back to App</Link>
-      </nav>
+    <MainLayout title="Reports" helpTopic="reports">
       <div className="space-y-4 max-w-2xl">
         <div className="grid grid-cols-2 gap-2">
           <input value={vendor} onChange={e => setVendor(e.target.value)} placeholder="Vendor" className="input" />
@@ -152,7 +136,7 @@ function Reports() {
         </div>
         </div>
       </div>
-    </div>
+    </MainLayout>
   );
 }
 

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
-import { Link } from 'react-router-dom';
-import SidebarNav from './components/SidebarNav';
 import HelpTooltip from './components/HelpTooltip';
+import MainLayout from './components/MainLayout';
 
 function TeamManagement() {
   const token = localStorage.getItem('token') || '';
@@ -17,10 +16,6 @@ function TeamManagement() {
   const [emailTone, setEmailTone] = useState('professional');
   const [csvLimit, setCsvLimit] = useState(5);
   const [pdfLimit, setPdfLimit] = useState(10);
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
@@ -102,18 +97,7 @@ function TeamManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4 pt-16">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
-        <h1 className="text-xl font-bold flex items-center gap-1">
-          Team Management
-          <span className="relative group cursor-help">❓
-            <span className="hidden group-hover:block absolute z-10"><HelpTooltip topic="team" token={token} /></span>
-          </span>
-        </h1>
-        <Link to="/invoices" className="underline">Back to App</Link>
-      </nav>
+    <MainLayout title="Team Management" helpTopic="team">
       <div className="space-y-6 max-w-xl">
         <div className="space-y-2">
           <input value={username} onChange={e => setUsername(e.target.value)} placeholder="Username" className="input w-full" />
@@ -201,8 +185,7 @@ function TeamManagement() {
           <button onClick={saveSettings} className="bg-indigo-600 text-white px-3 py-1 rounded">Save Settings</button>
         </div>
       </div>
-    </div>
-    </div>
+    </MainLayout>
   );
 }
 

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -1,18 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
-import { Link } from 'react-router-dom';
-import SidebarNav from './components/SidebarNav';
 import HelpTooltip from './components/HelpTooltip';
+import MainLayout from './components/MainLayout';
 
 function VendorManagement() {
   const token = localStorage.getItem('token') || '';
   const [vendors, setVendors] = useState([]);
   const [loading, setLoading] = useState(true);
   const [notesInput, setNotesInput] = useState({});
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
@@ -45,18 +40,7 @@ function VendorManagement() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4 pt-16">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
-        <h1 className="text-xl font-bold flex items-center gap-1">
-          Vendor Management
-          <span className="relative group cursor-help">❓
-            <span className="hidden group-hover:block absolute z-10"><HelpTooltip topic="vendors" token={token} /></span>
-          </span>
-        </h1>
-        <Link to="/invoices" className="underline">Back to App</Link>
-      </nav>
+    <MainLayout title="Vendor Management" helpTopic="vendors">
       <div className="overflow-x-auto rounded-lg">
       <table className="w-full text-left border rounded-lg overflow-hidden">
         <thead>
@@ -101,8 +85,7 @@ function VendorManagement() {
         </tbody>
       </table>
       </div>
-    </div>
-    </div>
+    </MainLayout>
   );
 }
 

--- a/frontend/src/WorkflowPage.js
+++ b/frontend/src/WorkflowPage.js
@@ -1,14 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import WorkflowBuilder from './components/WorkflowBuilder';
-import SidebarNav from './components/SidebarNav';
+import MainLayout from './components/MainLayout';
 
 export default function WorkflowPage() {
   const token = localStorage.getItem('token') || '';
   const [steps, setSteps] = useState(['Finance', 'Manager', 'Legal']);
-  const [notifications] = useState(() => {
-    const saved = localStorage.getItem('notifications');
-    return saved ? JSON.parse(saved) : [];
-  });
 
   useEffect(() => {
     fetch('http://localhost:3000/api/workflows', {
@@ -31,12 +27,8 @@ export default function WorkflowPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
-      <SidebarNav notifications={notifications} />
-      <div className="flex-1 p-4">
-        <h1 className="text-xl font-semibold mb-4">Workflow Builder</h1>
-        <WorkflowBuilder steps={steps} onChange={save} />
-      </div>
-    </div>
+    <MainLayout title="Workflow Builder">
+      <WorkflowBuilder steps={steps} onChange={save} />
+    </MainLayout>
   );
 }

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import SidebarNav from './SidebarNav';
+import TopNavbar from './TopNavbar';
+
+export default function MainLayout({ title, helpTopic, children }) {
+  const [notifications] = React.useState(() => {
+    const saved = localStorage.getItem('notifications');
+    return saved ? JSON.parse(saved) : [];
+  });
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
+      <SidebarNav notifications={notifications} />
+      <div className="flex-1 p-4 pt-16">
+        <TopNavbar title={title} helpTopic={helpTopic} />
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -2,10 +2,13 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
   HomeIcon,
+  DocumentIcon,
+  UsersIcon,
   DocumentChartBarIcon,
   Cog6ToothIcon,
   WrenchScrewdriverIcon,
   Squares2X2Icon,
+  ArchiveBoxIcon,
 } from '@heroicons/react/24/outline';
 
 export default function SidebarNav({ notifications = [] }) {
@@ -32,6 +35,20 @@ export default function SidebarNav({ notifications = [] }) {
               <span>Dashboard</span>
             </Link>
             <Link
+              to="/invoices"
+              className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/invoices' ? 'font-semibold' : ''}`}
+            >
+              <DocumentIcon className="w-5 h-5 mr-2" />
+              <span>Invoices</span>
+            </Link>
+            <Link
+              to="/vendors"
+              className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/vendors' ? 'font-semibold' : ''}`}
+            >
+              <UsersIcon className="w-5 h-5 mr-2" />
+              <span>Vendors</span>
+            </Link>
+            <Link
               to="/analytics"
               className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/analytics' ? 'font-semibold' : ''}`}
             >
@@ -51,6 +68,13 @@ export default function SidebarNav({ notifications = [] }) {
             >
               <Squares2X2Icon className="w-5 h-5 mr-2" />
               <span>Board</span>
+            </Link>
+            <Link
+              to="/archive"
+              className={`nav-link flex items-center p-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700 ${location.pathname === '/archive' ? 'font-semibold' : ''}`}
+            >
+              <ArchiveBoxIcon className="w-5 h-5 mr-2" />
+              <span>Archive</span>
             </Link>
             <Link
               to="/settings"

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import HelpTooltip from './HelpTooltip';
+
+export default function TopNavbar({ title, helpTopic }) {
+  const token = localStorage.getItem('token') || '';
+  return (
+    <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+      <h1 className="text-xl font-bold flex items-center gap-1">
+        {title}
+        {helpTopic && (
+          <span className="relative group cursor-help">❓
+            <span className="hidden group-hover:block absolute z-10">
+              <HelpTooltip topic={helpTopic} token={token} />
+            </span>
+          </span>
+        )}
+      </h1>
+      <Link to="/invoices" className="underline">Back to App</Link>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- create `TopNavbar` and `MainLayout` components
- extend `SidebarNav` with Invoices, Vendors and Archive links
- refactor dashboard and management pages to use the new layout

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d266fcc4832eb55f9f1347e9a683