### PR TITLE
Add public dashboard sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Analytics and reports page with filtering and PDF export
 - Trend reports for monthly spend and aging invoices
 - Customizable dashboards with date filters and export options
+- Public shareable dashboards accessible via secure link
 - ML predictions highlight cash-flow problem areas
 - Private notes on invoices
 - Shared comment threads for team discussion
@@ -261,6 +262,8 @@ as "Marketing", "Legal", or "Recurring" when no rule matches.
 - `POST /api/invoices/suggest-voucher` – recommend a voucher description
 - `POST /api/invoices/share` – generate a share link for selected invoices
 - `GET /api/invoices/shared/:token` – access a shared invoice view
+- `POST /api/invoices/dashboard/share` – generate a public dashboard link
+- `GET /api/invoices/dashboard/shared/:token` – view a restricted dashboard
 - `GET /api/invoices/:id/versions` – list prior versions of an invoice
 - `POST /api/invoices/:id/versions/:versionId/restore` – restore a previous version
 - `POST /api/payments/:id/link` – generate a payment link for an invoice

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -26,6 +26,8 @@ const {
   getUploadHeatmap,
   getQuickStats,
   getDashboardData,
+  shareDashboard,
+  getSharedDashboard,
   exportDashboardPDF,
   checkRecurringInvoice,
   getRecurringInsights,
@@ -129,6 +131,8 @@ router.get('/recurring/insights', authMiddleware, getRecurringInsights);
 router.get('/vendor-profile/:vendor', authMiddleware, getVendorProfile);
 router.get('/vendor-bio/:vendor', authMiddleware, getVendorBio);
 router.get('/dashboard/pdf', authMiddleware, exportDashboardPDF);
+router.post('/dashboard/share', authMiddleware, authorizeRoles('admin','reviewer'), shareDashboard);
+router.get('/dashboard/shared/:token', getSharedDashboard);
 router.post('/flag-suspicious', authMiddleware, flagSuspiciousInvoice);
 router.post('/check-similarity', authMiddleware, checkInvoiceSimilarity);
 router.get('/:id/flag-explanation', authMiddleware, explainFlaggedInvoice);

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -96,6 +96,12 @@ async function initDb() {
       created_at TIMESTAMP DEFAULT NOW()
     )`);
 
+    await pool.query(`CREATE TABLE IF NOT EXISTS shared_dashboards (
+      token TEXT PRIMARY KEY,
+      filters JSONB,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+
     await pool.query(`CREATE TABLE IF NOT EXISTS recurring_templates (
       id SERIAL PRIMARY KEY,
       vendor TEXT NOT NULL,

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -74,6 +74,17 @@ function Dashboard() {
     window.URL.revokeObjectURL(url);
   };
 
+  const handleShare = async () => {
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+    const res = await fetch('http://localhost:3000/api/invoices/dashboard/share', { method: 'POST', headers, body: JSON.stringify({}) });
+    if (res.ok) {
+      const { url } = await res.json();
+      const full = `http://localhost:3001/dashboard/shared/${url.split('/').pop()}`;
+      try { await navigator.clipboard.writeText(full); } catch (_) {}
+      alert('Share link copied to clipboard');
+    }
+  };
+
   const grid = Array.from({ length: 7 }, () => Array(24).fill(0));
   let max = 0;
   heatmap.forEach(({ day, hour, count }) => {
@@ -85,6 +96,7 @@ function Dashboard() {
     <MainLayout title="AI Dashboard">
       <div className="mb-4 text-right">
         <button onClick={handleExportPDF} className="underline mr-2">Export PDF</button>
+        <button onClick={handleShare} className="underline">Share Link</button>
       </div>
       {!token ? (
         <p className="text-center text-gray-600">Please log in from the main app.</p>

--- a/frontend/src/SharedDashboard.js
+++ b/frontend/src/SharedDashboard.js
@@ -1,0 +1,36 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import MainLayout from './components/MainLayout';
+
+function SharedDashboard() {
+  const { token } = useParams();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`http://localhost:3000/api/invoices/dashboard/shared/${token}`)
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  if (loading) return <MainLayout title="Shared Dashboard"><p>Loading...</p></MainLayout>;
+  if (!data) return <MainLayout title="Shared Dashboard"><p>Failed to load dashboard.</p></MainLayout>;
+
+  return (
+    <MainLayout title="Shared Dashboard">
+      <div className="space-y-4">
+        <div>Total Invoices: {data.totalInvoices}</div>
+        <div>Total Amount: {data.totalAmount}</div>
+        <div>Total Invoiced This Month: {data.totalInvoicedThisMonth}</div>
+        <div>Invoices Pending: {data.invoicesPending}</div>
+        <div>Anomalies Found: {data.anomaliesFound}</div>
+        <div>AI Suggestions: {data.aiSuggestions}</div>
+      </div>
+    </MainLayout>
+  );
+}
+
+export default SharedDashboard;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import Dashboard from './Dashboard';
+import SharedDashboard from './SharedDashboard';
 import DashboardBuilder from './DashboardBuilder';
 import Reports from './Reports';
 import Archive from './Archive';
@@ -47,6 +48,7 @@ function AnimatedRoutes() {
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
         <Route path="/dashboard" element={<PageWrapper><Dashboard /></PageWrapper>} />
+        <Route path="/dashboard/shared/:token" element={<PageWrapper><SharedDashboard /></PageWrapper>} />
         <Route path="/invoices" element={<PageWrapper><App /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><Reports /></PageWrapper>} />
         <Route path="/settings" element={<PageWrapper><TeamManagement /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- allow sharing dashboards via secure link
- create backend API endpoints and DB table for `shared_dashboards`
- expose share actions on dashboard and a read-only view
- document new feature and endpoints

## Testing
- `npm install --legacy-peer-deps`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6850d56f91c4832e9412d8c0a7fbb950