### PR TITLE
Add gamification feedback and feature suggestion

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -18,6 +18,7 @@ const settingsRoutes = require('./routes/settingsRoutes');
 const recurringRoutes = require('./routes/recurringRoutes');
 const poRoutes = require('./routes/poRoutes');
 const integrationRoutes = require('./routes/integrationRoutes');
+const featureRoutes = require('./routes/featureRoutes');
 const { runRecurringInvoices } = require('./controllers/recurringController');
 const { processFailedPayments, sendPaymentReminders } = require('./controllers/paymentController');
 const { sendApprovalReminders } = require('./controllers/reminderController');
@@ -48,6 +49,7 @@ app.use('/api/workflows', workflowRoutes);
 app.use('/api/settings', settingsRoutes);
 app.use('/api/recurring', recurringRoutes);
 app.use('/api/integrations', integrationRoutes);
+app.use('/api/features', featureRoutes);
 
 app.use(Sentry.Handlers.errorHandler());
 

--- a/backend/controllers/featureController.js
+++ b/backend/controllers/featureController.js
@@ -1,0 +1,23 @@
+const pool = require('../config/db');
+
+exports.submitFeature = async (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ message: 'text required' });
+  try {
+    await pool.query('INSERT INTO feature_requests (text) VALUES ($1)', [text]);
+    res.json({ message: 'Feature suggestion submitted' });
+  } catch (err) {
+    console.error('Feature submit error:', err);
+    res.status(500).json({ message: 'Failed to submit suggestion' });
+  }
+};
+
+exports.listFeatures = async (_req, res) => {
+  try {
+    const result = await pool.query('SELECT * FROM feature_requests ORDER BY created_at DESC');
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Feature list error:', err);
+    res.status(500).json({ message: 'Failed to fetch suggestions' });
+  }
+};

--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { getReport, exportReportPDF, getTrends, getAgingReport, predictCashFlowRisk } = require('../controllers/analyticsController');
+const { getApprovalStats } = require('../controllers/analyticsController');
 const { listRules, addRule } = require('../controllers/rulesController');
 const { authMiddleware } = require('../controllers/userController');
 
@@ -11,5 +12,6 @@ router.get('/aging', authMiddleware, getAgingReport);
 router.get('/cash-flow/predict', authMiddleware, predictCashFlowRisk);
 router.get('/rules', authMiddleware, listRules);
 router.post('/rules', authMiddleware, addRule);
+router.get('/approvals/stats', authMiddleware, getApprovalStats);
 
 module.exports = router;

--- a/backend/routes/featureRoutes.js
+++ b/backend/routes/featureRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { submitFeature, listFeatures } = require('../controllers/featureController');
+const { authMiddleware } = require('../controllers/userController');
+
+router.post('/', authMiddleware, submitFeature);
+router.get('/', authMiddleware, listFeatures);
+
+module.exports = router;

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -124,6 +124,12 @@ async function initDb() {
       status TEXT DEFAULT 'Open',
       created_at TIMESTAMP DEFAULT NOW()
     )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS feature_requests (
+      id SERIAL PRIMARY KEY,
+      text TEXT NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
   } catch (err) {
     console.error('Database init error:', err);
   }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -31,6 +31,7 @@ import FloatingActionPanel from './components/FloatingActionPanel';
 import InvoiceSnapshotView from './components/InvoiceSnapshotView';
 import TourModal from './components/TourModal';
 import ProgressBar from './components/ProgressBar';
+import FeatureWidget from './components/FeatureWidget';
 import { Button } from './components/ui/Button';
 import { motion } from 'framer-motion';
 import Fuse from 'fuse.js';
@@ -137,6 +138,7 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
   const [qualityScores, setQualityScores] = useState({});
   const [riskScores, setRiskScores] = useState({});
   const [assistantOpen, setAssistantOpen] = useState(false);
+  const [featureOpen, setFeatureOpen] = useState(false);
   const [chatHistory, setChatHistory] = useState(() => {
     const saved = localStorage.getItem('chatHistory');
     return saved ? JSON.parse(saved) : [];
@@ -3133,6 +3135,7 @@ useEffect(() => {
             onUpload={openUploadPreview}
             onAsk={() => setAssistantOpen(true)}
             onVoice={startVoiceUpload}
+            onFeature={() => setFeatureOpen(true)}
           />
           <ChatSidebar
             open={assistantOpen}
@@ -3159,6 +3162,7 @@ useEffect(() => {
             open={showTour}
             onClose={() => { setShowTour(false); localStorage.setItem('seenTour','1'); }}
           />
+          <FeatureWidget open={featureOpen} onClose={() => setFeatureOpen(false)} />
         </>
       )}
       </div>

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -13,6 +13,7 @@ function Dashboard() {
   const [cashFlow, setCashFlow] = useState([]);
   const [heatmap, setHeatmap] = useState([]);
   const [stats, setStats] = useState(null);
+  const [approvalStats, setApprovalStats] = useState(null);
   const [categories, setCategories] = useState([]);
   const [anomalies, setAnomalies] = useState([]);
   const [budget, setBudget] = useState([]);
@@ -58,6 +59,11 @@ function Dashboard() {
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setStats(d);
+        }),
+      fetch('http://localhost:3000/api/analytics/approvals/stats', { headers })
+        .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+        .then(({ ok, d }) => {
+          if (ok) setApprovalStats(d);
         }),
     ]).finally(() => setLoading(false));
   }, [token]);
@@ -145,6 +151,11 @@ function Dashboard() {
               </>
             )}
           </div>
+          {approvalStats && (
+            <div className="text-center text-sm text-gray-700 dark:text-gray-300">
+              🎉 You've approved {approvalStats.total} invoices this week! Streak: {approvalStats.streak} days
+            </div>
+          )}
           {vendors.length === 0 && !loading && (
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center text-gray-500 italic py-10">
               📄 No invoices yet — upload one to get started

--- a/frontend/src/components/ChatSidebar.js
+++ b/frontend/src/components/ChatSidebar.js
@@ -5,6 +5,7 @@ import {
 } from '@heroicons/react/24/outline';
 import Spinner from './Spinner';
 import SuggestionChips from './SuggestionChips';
+import FeedbackButtons from './FeedbackButtons';
 import {
   BarChart,
   Bar,
@@ -73,7 +74,10 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, 
               {item.type === 'chart' ? 'Chart:' : 'Q:'} {item.question}
             </div>
             {item.type === 'chat' && (
-              <div className="mt-1 whitespace-pre-wrap">{item.answer}</div>
+              <div className="mt-1 whitespace-pre-wrap">
+                {item.answer}
+                <FeedbackButtons endpoint="chat" />
+              </div>
             )}
             {item.type === 'chart' && item.chartData && item.chartData.length > 0 && (
               <div className="h-32 mt-1">
@@ -86,6 +90,7 @@ export default function ChatSidebar({ open, onClose, onAsk, onChart, onBilling, 
                     <Bar dataKey={Object.keys(item.chartData[0])[1]} fill="#10B981" />
                   </BarChart>
                 </ResponsiveContainer>
+                <FeedbackButtons endpoint="chart" />
               </div>
             )}
           </div>

--- a/frontend/src/components/FeatureWidget.js
+++ b/frontend/src/components/FeatureWidget.js
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { LightBulbIcon, XMarkIcon } from '@heroicons/react/24/outline';
+
+export default function FeatureWidget({ open, onClose }) {
+  const [text, setText] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    if (!text.trim()) return;
+    try {
+      await fetch('http://localhost:3000/api/features', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+      });
+      setSubmitted(true);
+      setText('');
+    } catch (e) {
+      console.error('Suggest feature failed:', e);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg max-w-sm w-full">
+        <div className="flex justify-between items-center mb-2">
+          <h3 className="font-semibold text-sm flex items-center gap-1">
+            <LightBulbIcon className="w-4 h-4" /> Suggest a Feature
+          </h3>
+          <button onClick={onClose} aria-label="Close">
+            <XMarkIcon className="w-5 h-5" />
+          </button>
+        </div>
+        {submitted ? (
+          <div className="text-sm">Thanks for your idea!</div>
+        ) : (
+          <>
+            <textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              className="w-full border rounded p-1 text-sm dark:bg-gray-700"
+              rows={3}
+              placeholder="Your idea..."
+            />
+            <div className="flex justify-end mt-2 space-x-2">
+              <button
+                onClick={onClose}
+                className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-100"
+              >
+                Cancel
+              </button>
+              <button onClick={submit} className="px-3 py-1 rounded bg-indigo-600 text-white">
+                Submit
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FeedbackButtons.js
+++ b/frontend/src/components/FeedbackButtons.js
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { HandThumbUpIcon, HandThumbDownIcon } from '@heroicons/react/24/outline';
+
+export default function FeedbackButtons({ endpoint }) {
+  const [rating, setRating] = useState(0);
+
+  const send = async (value) => {
+    setRating(value);
+    try {
+      await fetch('http://localhost:3000/api/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endpoint, rating: value }),
+      });
+    } catch (e) {
+      console.error('Feedback failed:', e);
+    }
+  };
+
+  return (
+    <div className="flex space-x-1 mt-1">
+      <button
+        onClick={() => send(1)}
+        className={`p-1 rounded ${rating === 1 ? 'bg-green-200 dark:bg-green-700' : ''}`}
+        aria-label="Thumbs up"
+      >
+        <HandThumbUpIcon className="w-4 h-4" />
+      </button>
+      <button
+        onClick={() => send(-1)}
+        className={`p-1 rounded ${rating === -1 ? 'bg-red-200 dark:bg-red-700' : ''}`}
+        aria-label="Thumbs down"
+      >
+        <HandThumbDownIcon className="w-4 h-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/FloatingActionPanel.js
+++ b/frontend/src/components/FloatingActionPanel.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { ChatBubbleLeftRightIcon, ArrowUpTrayIcon, MicrophoneIcon } from '@heroicons/react/24/outline';
-
-export default function FloatingActionPanel({ onUpload, onAsk, onVoice }) {
+import { ChatBubbleLeftRightIcon, ArrowUpTrayIcon, MicrophoneIcon, LightBulbIcon } from '@heroicons/react/24/outline';
+export default function FloatingActionPanel({ onUpload, onAsk, onVoice, onFeature }) {
   return (
     <div className="fixed bottom-4 right-4 flex flex-col items-end space-y-2 z-30">
       <button
@@ -22,6 +21,17 @@ export default function FloatingActionPanel({ onUpload, onAsk, onVoice }) {
         <ChatBubbleLeftRightIcon className="w-6 h-6" />
         <span className="text-xs mt-1">Ask AI</span>
       </button>
+      {onFeature && (
+        <button
+          onClick={onFeature}
+          className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white flex flex-col items-center"
+          title="Suggest Feature"
+          aria-label="Suggest feature"
+        >
+          <LightBulbIcon className="w-6 h-6" />
+          <span className="text-xs mt-1">Suggest</span>
+        </button>
+      )}
       {onVoice && (
         <button
           onClick={onVoice}


### PR DESCRIPTION
## Summary
- track feature requests in the DB
- expose approval stats endpoint in analytics
- allow submitting feature suggestions
- add floating action button for suggestions
- collect thumbs up/down on AI responses
- show weekly approval stats on the dashboard

## Testing
- `npm test` (fails: react-scripts not found)
- `npm test` in backend (no tests)

------
https://chatgpt.com/codex/tasks/task_e_6850da5266f0832e99573513aea2fc64