### PR TITLE
Implement empty state design

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import Login from './Login';
 import Spinner from './components/Spinner';
 import Toast from './components/Toast';
 import Skeleton from './components/Skeleton';
+import EmptyState from './components/EmptyState';
 import ChatSidebar from './components/ChatSidebar';
 import GraphView from './components/GraphView';
 import ConfirmModal from './components/ConfirmModal';
@@ -2611,14 +2612,8 @@ useEffect(() => {
                 </tr>
               ) : sortedInvoices.length === 0 ? (
                 <tr>
-                  <td colSpan="7" className="py-10">
-                    <motion.div
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      className="text-center text-gray-500 italic"
-                    >
-                      📄 No invoices yet — upload one to get started
-                    </motion.div>
+                  <td colSpan="7">
+                    <EmptyState />
                   </td>
                 </tr>
               ) : (

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import Skeleton from './components/Skeleton';
+import EmptyState from './components/EmptyState';
 import VendorProfilePanel from './components/VendorProfilePanel';
 import MainLayout from './components/MainLayout';
 
@@ -156,11 +157,7 @@ function Dashboard() {
               🎉 You've approved {approvalStats.total} invoices this week! Streak: {approvalStats.streak} days
             </div>
           )}
-          {vendors.length === 0 && !loading && (
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-center text-gray-500 italic py-10">
-              📄 No invoices yet — upload one to get started
-            </motion.div>
-          )}
+          {vendors.length === 0 && !loading && <EmptyState />}
           <div className="h-64">
             {loading ? (
               <Skeleton rows={1} className="h-full" height="h-full" />

--- a/frontend/src/components/EmptyState.js
+++ b/frontend/src/components/EmptyState.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { DocumentArrowUpIcon } from '@heroicons/react/24/outline';
+
+export default function EmptyState({ message = 'No invoices yet. Upload your first file to get started!' }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="text-center text-gray-500 italic py-10 flex flex-col items-center gap-2"
+    >
+      <DocumentArrowUpIcon className="w-8 h-8 text-gray-400" />
+      {message}
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `EmptyState` component using heroicons
- show empty illustration in dashboard and invoices table
- wire up new component

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6851ec48bd1c832e9ea02133496c7d2b