### PR TITLE
Add invoice detail modal and inline tag editing

### DIFF
--- a/frontend/src/components/TagEditor.js
+++ b/frontend/src/components/TagEditor.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+export default function TagEditor({ tags = [], onAddTag, onRemoveTag, colorMap = {} }) {
+  const [input, setInput] = useState('');
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && input.trim()) {
+      onAddTag && onAddTag(input.trim());
+      setInput('');
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap gap-1 items-center">
+      {tags.map((tag, idx) => (
+        <span
+          key={idx}
+          className="flex items-center text-xs px-2 py-0.5 rounded text-white"
+          style={{ backgroundColor: colorMap[tag] || '#6366f1' }}
+        >
+          {tag}
+          {onRemoveTag && (
+            <button
+              onClick={() => onRemoveTag(tag)}
+              className="ml-1 text-white focus:outline-none"
+            >
+              ×
+            </button>
+          )}
+        </span>
+      ))}
+      {onAddTag && (
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add tag"
+          className="input text-xs w-20 px-1"
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- expand InvoiceDetailModal with timeline, comments and tag management
- create reusable `TagEditor` for inline tag chips
- open InvoiceDetailModal when invoice rows or cards are clicked
- support adding and removing tags inline

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_6851ee6b8bfc832e85a9a12c6a420903