### PR TITLE
Implement invoice auto-categorization and vendor profiles

### DIFF
--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -9,6 +9,7 @@ const {
   exportVendorsCSV,
   importVendorsCSV,
   getBehaviorFlags,
+  getVendorAnalytics,
 } = require('../controllers/vendorController');
 const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
@@ -22,5 +23,6 @@ router.get('/behavior-flags', authMiddleware, authorizeRoles('admin'), getBehavi
 router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
 router.get('/:vendor/info', authMiddleware, getVendorInfo);
 router.get('/:vendor/predict', authMiddleware, predictVendorBehavior);
+router.get('/:vendor/profile', authMiddleware, getVendorAnalytics);
 
 module.exports = router;

--- a/backend/utils/categorize.js
+++ b/backend/utils/categorize.js
@@ -1,0 +1,18 @@
+const CATEGORY_KEYWORDS = {
+  Software: ['software', 'saas', 'license', 'cloud', 'aws', 'zoom', 'notion', 'figma'],
+  Marketing: ['marketing', 'advertising', 'ads', 'campaign', 'google', 'facebook'],
+  Travel: ['flight', 'hotel', 'airline', 'uber', 'lyft', 'airbnb', 'travel'],
+  Office: ['office', 'supplies', 'stationery', 'printer', 'staples'],
+};
+
+function categorizeInvoice({ vendor = '', description = '' }) {
+  const text = `${vendor} ${description}`.toLowerCase();
+  for (const [cat, keys] of Object.entries(CATEGORY_KEYWORDS)) {
+    for (const k of keys) {
+      if (text.includes(k.toLowerCase())) return cat;
+    }
+  }
+  return 'Other';
+}
+
+module.exports = { categorizeInvoice };

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -9,6 +9,7 @@ async function initDb() {
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS priority BOOLEAN DEFAULT FALSE");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS flagged BOOLEAN DEFAULT FALSE");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS flag_reason TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS category TEXT");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS approval_chain JSONB DEFAULT '[\"Manager\",\"Finance\",\"CFO\"]'");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS current_step INTEGER DEFAULT 0");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS payment_terms TEXT");


### PR DESCRIPTION
## Summary
- add simple keyword based categorization utility
- store invoice category on upload
- expose vendor analytics with invoices, spend, and scores
- expose new vendor profile endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851f6110f4c832e9f9f11bdaf1fa332