### PR TITLE
Implement audit logging and duplicate flagging

### DIFF
--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -35,6 +35,7 @@ async function initDb() {
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS late_fee NUMERIC DEFAULT 0");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS currency TEXT DEFAULT 'USD'");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS encrypted_payload TEXT");
+    await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS file_name TEXT");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS original_amount NUMERIC");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS exchange_rate NUMERIC");
     await pool.query("ALTER TABLE invoices ADD COLUMN IF NOT EXISTS vat_percent NUMERIC");


### PR DESCRIPTION
## Summary
- add file_name column initialization
- implement AI-based duplicate/suspicious invoice check
- store uploaded filename
- record invoice versions for retention, auto categorize/tag, and bulk edits

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520072676c832eacd9ec3e387872be