### PR TITLE
Add fraud detection report

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This is a full-stack invoice uploader tool with AI-powered CSV error summarizati
 - Natural language invoice search
 - Hoverable vendor bios with website and industry info
 - AI fraud detection heatmaps (color-coded anomaly maps)
+- Fraud detection reports listing flagged invoices with reasons
 - Automatic vendor bios + risk scores from public data
 - Real-time invoice chat thread with collaborators
 - Multi-language support (Spanish and French)
@@ -235,6 +236,7 @@ as "Marketing", "Legal", or "Recurring" when no rule matches.
 - `POST /api/invoices/budgets` – create/update a monthly or quarterly budget by vendor or tag
 - `GET /api/invoices/budgets/warnings` – check if spending has exceeded 90% of a budget
 - `GET /api/invoices/anomalies` – list vendors with unusual spending spikes
+- `GET /api/invoices/fraud/flagged` – list flagged invoices with reasons
 - `GET /api/invoices/:id/timeline` – view a timeline of state changes for an invoice
 - `PATCH /api/invoices/:id/retention` – update an invoice retention policy (6m, 2y, forever)
 - `POST /api/invoices/payment-risk` – predict payment delay risk for a vendor

--- a/backend/controllers/fraudController.js
+++ b/backend/controllers/fraudController.js
@@ -64,3 +64,15 @@ exports.fraudHeatmap = async (_req, res) => {
     res.status(500).json({ message: 'Failed to build fraud heatmap' });
   }
 };
+
+exports.flaggedInvoices = async (_req, res) => {
+  try {
+    const result = await pool.query(
+      'SELECT id, invoice_number, vendor, amount, date, flag_reason FROM invoices WHERE flagged = true ORDER BY id DESC'
+    );
+    res.json({ invoices: result.rows });
+  } catch (err) {
+    console.error('Flagged invoices fetch error:', err);
+    res.status(500).json({ message: 'Failed to fetch flagged invoices' });
+  }
+};

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -175,6 +175,7 @@ router.get('/budgets/department-report', authMiddleware, getBudgetVsActual);
 router.get('/anomalies', authMiddleware, getAnomalies);
 router.get('/fraud/patterns', authMiddleware, authorizeRoles('admin'), detectPatterns);
 router.get('/fraud/heatmap', authMiddleware, authorizeRoles('admin'), fraudHeatmap);
+router.get('/fraud/flagged', authMiddleware, authorizeRoles('admin','reviewer'), require('../controllers/fraudController').flaggedInvoices);
 router.get('/:id/check-recurring', authMiddleware, checkRecurringInvoice);
 router.get('/vendor-scorecards', authMiddleware, getVendorScorecards);
 router.get('/graph', authMiddleware, getRelationshipGraph);

--- a/frontend/src/FraudReport.js
+++ b/frontend/src/FraudReport.js
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import Skeleton from './components/Skeleton';
+import MainLayout from './components/MainLayout';
+
+function FraudReport() {
+  const token = localStorage.getItem('token') || '';
+  const [invoices, setInvoices] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [explanations, setExplanations] = useState({});
+
+  const fetchFlagged = async () => {
+    if (!token) return;
+    setLoading(true);
+    const res = await fetch('http://localhost:3000/api/invoices/fraud/flagged', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    if (res.ok) setInvoices(data.invoices || []);
+    setLoading(false);
+  };
+
+  const loadExplanation = async (id) => {
+    const res = await fetch(`http://localhost:3000/api/invoices/${id}/flag-explanation`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    if (res.ok) {
+      setExplanations((e) => ({ ...e, [id]: data.explanation }));
+    }
+  };
+
+  useEffect(() => { fetchFlagged(); }, [token]);
+
+  return (
+    <MainLayout title="Fraud Reports" helpTopic="fraud">
+      <div className="space-y-4">
+        <div className="overflow-x-auto rounded-lg">
+          <table className="min-w-full border text-sm rounded-lg overflow-hidden">
+            <thead>
+              <tr className="bg-gray-200 dark:bg-gray-700">
+                <th className="px-2 py-1">#</th>
+                <th className="px-2 py-1">Date</th>
+                <th className="px-2 py-1">Vendor</th>
+                <th className="px-2 py-1">Amount</th>
+                <th className="px-2 py-1">Reason</th>
+                <th className="px-2 py-1">Explain</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan="6" className="p-4"><Skeleton rows={5} height="h-4" /></td>
+                </tr>
+              ) : (
+                invoices.map(inv => (
+                  <tr key={inv.id} className="border-t hover:bg-gray-100">
+                    <td className="px-2 py-1">{inv.invoice_number}</td>
+                    <td className="px-2 py-1">{new Date(inv.date).toLocaleDateString()}</td>
+                    <td className="px-2 py-1">{inv.vendor}</td>
+                    <td className="px-2 py-1">${inv.amount}</td>
+                    <td className="px-2 py-1">{explanations[inv.id] || inv.flag_reason || '-'}</td>
+                    <td className="px-2 py-1">
+                      <button onClick={() => loadExplanation(inv.id)} className="btn btn-primary text-xs px-2 py-1" title="Explain">AI</button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </MainLayout>
+  );
+}
+
+export default FraudReport;

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -18,6 +18,7 @@ import {
   UserCircleIcon,
   QuestionMarkCircleIcon,
   Squares2X2Icon,
+  FlagIcon,
 } from '@heroicons/react/24/outline';
 import HelpTooltip from './HelpTooltip';
 
@@ -134,6 +135,13 @@ export default function Navbar({
                     onClick={() => setMenuOpen(false)}
                   >
                     <Squares2X2Icon className="h-5 w-5 mr-2" /> Board
+                  </Link>
+                  <Link
+                    to="/fraud"
+                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    <FlagIcon className="h-5 w-5 mr-2" /> Fraud
                   </Link>
                   {role === 'admin' && (
                     <Link

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -10,6 +10,7 @@ import {
   WrenchScrewdriverIcon,
   Squares2X2Icon,
   ArchiveBoxIcon,
+  FlagIcon,
 } from '@heroicons/react/24/outline';
 
 export default function SidebarNav({ notifications = [] }) {
@@ -76,6 +77,13 @@ export default function SidebarNav({ notifications = [] }) {
             >
               <Squares2X2Icon className="w-5 h-5" />
               <span>Board</span>
+            </Link>
+            <Link
+              to="/fraud"
+              className={`nav-link ${location.pathname === '/fraud' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700' : ''}`}
+            >
+              <FlagIcon className="w-5 h-5" />
+              <span>Fraud</span>
             </Link>
             <Link
               to="/archive"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,7 @@ import SharedDashboard from './SharedDashboard';
 import DashboardBuilder from './DashboardBuilder';
 import Reports from './Reports';
 import AuditDashboard from './AuditDashboard';
+import FraudReport from './FraudReport';
 import Archive from './Archive';
 import TeamManagement from './TeamManagement';
 import VendorManagement from './VendorManagement';
@@ -53,6 +54,7 @@ function AnimatedRoutes() {
         <Route path="/invoices" element={<PageWrapper><App /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><Reports /></PageWrapper>} />
         <Route path="/audit" element={<PageWrapper><AuditDashboard /></PageWrapper>} />
+        <Route path="/fraud" element={<PageWrapper><FraudReport /></PageWrapper>} />
         <Route path="/settings" element={<PageWrapper><TeamManagement /></PageWrapper>} />
         <Route path="/archive" element={<PageWrapper><Archive /></PageWrapper>} />
         <Route path="/vendors" element={<PageWrapper><VendorManagement /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- list flagged invoices from the backend
- expose new fraud report endpoint and add UI page
- link new Fraud tab in navigation
- document new endpoint in README

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685203524280832e8462f2e8192e67d8