### PR TITLE
Fix settings & filter visibility

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -78,7 +78,7 @@ export default function Navbar({
               <span>Upload</span>
             </button>
           )}
-          {token && (
+          {token && onToggleFilters && (
             <button
               id="filterToggle"
               onClick={onToggleFilters}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -17,6 +17,7 @@ export default function SidebarNav({ notifications = [] }) {
   const location = useLocation();
   const [open, setOpen] = useState(true);
   const unread = notifications.filter(n => !n.read).length;
+  const role = localStorage.getItem('role') || '';
 
   return (
     <aside className="hidden sm:block bg-white dark:bg-gray-800 shadow-lg w-64 p-4 space-y-2">
@@ -92,13 +93,15 @@ export default function SidebarNav({ notifications = [] }) {
               <ArchiveBoxIcon className="w-5 h-5" />
               <span>Archive</span>
             </Link>
-            <Link
-              to="/settings"
-              className={`nav-link ${location.pathname === '/settings' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700' : ''}`}
-            >
-              <Cog6ToothIcon className="w-5 h-5" />
-              <span>Settings</span>
-            </Link>
+            {role === 'admin' && (
+              <Link
+                to="/settings"
+                className={`nav-link ${location.pathname === '/settings' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700' : ''}`}
+              >
+                <Cog6ToothIcon className="w-5 h-5" />
+                <span>Settings</span>
+              </Link>
+            )}
           </nav>
         )}
       <div className="mt-4 relative">


### PR DESCRIPTION
## Summary
- hide Settings item on sidebar for non-admins
- disable Filters button if no handler supplied

## Testing
- `npm test --silent --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68520909b9ec832ea9f6b6648705518f