### PR TITLE
Fix frontend startup for Node 20

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=18 <19"
+    "node": ">=18 <21"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/frontend/scripts/check-node.js
+++ b/frontend/scripts/check-node.js
@@ -1,5 +1,5 @@
 const semver = require('semver');
-const required = '>=18 <19';
+const required = '>=18 <21';
 if (!semver.satisfies(process.version, required)) {
   console.error(`\nError: Node.js ${required} required. Current ${process.version}.\n`);
   process.exit(1);

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -138,7 +138,6 @@ export default function DashboardBuilder() {
             )}
           </Droppable>
         </DragDropContext>
-      </div>
     </MainLayout>
   );
 }

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -134,7 +134,6 @@ function Reports() {
             </tbody>
           </table>
         </div>
-        </div>
       </div>
     </MainLayout>
   );


### PR DESCRIPTION
## Summary
- allow Node 20 in frontend scripts
- fix closing tag structure in DashboardBuilder and Reports pages

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685211e5f2a8832e994e23e83d9eebbf