### PR TITLE
Fix frontend install by upgrading typescript

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,8 +36,12 @@
         "@tailwindcss/postcss": "^4.1.5",
         "autoprefixer": "^10.4.21",
         "postcss": "^8.5.3",
+        "semver": "^7.5.4",
         "tailwindcss": "^3.4.1",
-        "typescript": "4.9.5"
+        "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=18 <21"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -18557,9 +18561,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -18567,7 +18571,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
-    "typescript": "4.9.5",
+    "typescript": "^5.4.5",
     "semver": "^7.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- update frontend devDependency typescript to version `^5.4.5`
- regenerate package-lock.json with updated dependencies

## Testing
- `npm install --legacy-peer-deps` in `frontend`
- `npm start` in `frontend` (webpack compiled with a warning)

------
https://chatgpt.com/codex/tasks/task_e_6852140e354c832e8c0a2e57c958ef0b