### PR TITLE
Fix frontend by enforcing node 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,3 +387,15 @@ npm install
 ```
 
 This installs `react-router-dom` along with the rest of the packages.
+
+**`SyntaxError: Error parsing .../ajv/package.json`**
+
+If you see this error when running `npm start`, your dependencies may have been
+installed using a newer Node version. Use Node 18 and reinstall:
+
+```bash
+nvm use 18
+cd frontend
+rm -rf node_modules package-lock.json
+npm install --legacy-peer-deps
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=18 <21"
+    "node": "18.x"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",

--- a/frontend/scripts/check-node.js
+++ b/frontend/scripts/check-node.js
@@ -1,5 +1,5 @@
 const semver = require('semver');
-const required = '>=18 <21';
+const required = '18.x';
 if (!semver.satisfies(process.version, required)) {
   console.error(`\nError: Node.js ${required} required. Current ${process.version}.\n`);
   process.exit(1);


### PR DESCRIPTION
## Summary
- enforce node 18.x in `package.json`
- update startup node check script
- document reinstall steps when using the wrong node version

## Testing
- `npm start` (fails if not node 18)
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_685215708794832e889b428081146e21