### PR TITLE
Fix frontend build by using Node 18 and TypeScript 4

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,10 +38,10 @@
         "postcss": "^8.5.3",
         "semver": "^7.5.4",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.4.5"
+        "typescript": "4.9.5"
       },
       "engines": {
-        "node": ">=18 <21"
+        "node": "18.x"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -18561,9 +18561,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -18571,7 +18571,7 @@
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.4.5",
+    "typescript": "4.9.5",
     "semver": "^7.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- pin TypeScript to 4.9.5 to satisfy react-scripts@5
- update lock file

## Testing
- `npm install --legacy-peer-deps`
- `npm test`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68521794bfe4832eb5f819c433f81c15