### PR TITLE
Fix README troubleshooting for json-schema error

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,3 +399,15 @@ cd frontend
 rm -rf node_modules package-lock.json
 npm install --legacy-peer-deps
 ```
+
+**`SyntaxError: .../json-schema-draft-07.json: Unexpected end of JSON input`**
+
+This indicates the install was done with an incompatible Node version and
+corrupted some dependencies. Switch to Node 18 and reinstall:
+
+```bash
+nvm use 18
+cd frontend
+rm -rf node_modules package-lock.json
+npm install --legacy-peer-deps
+```


### PR DESCRIPTION
## Summary
- document how to resolve `json-schema-draft-07.json` errors when running the frontend

## Testing
- `npm test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685239e0ffac832ea0826b122fc71341