### PR TITLE
Add troubleshooting for Node 20 ajv error

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,3 +411,16 @@ cd frontend
 rm -rf node_modules package-lock.json
 npm install --legacy-peer-deps
 ```
+
+**`Error: Unknown keyword instanceof`**
+
+This error appears when the dependencies were installed under Node 20 or
+another unsupported version. Use Node 18 and reinstall the frontend
+packages:
+
+```bash
+nvm use 18
+cd frontend
+rm -rf node_modules package-lock.json
+npm install --legacy-peer-deps
+```


### PR DESCRIPTION
## Summary
- document fix for `Error: Unknown keyword instanceof` when frontend deps are installed with Node 20

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68523c10a0d8832e967fb93feff5e85e