### PR TITLE
Fix eslint warnings across frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -49,7 +49,6 @@ import {
   FlagIcon,
   DocumentArrowDownIcon,
   LightBulbIcon,
-  PlusCircleIcon,
   TagIcon,
   EyeIcon,
   TrashIcon,
@@ -364,8 +363,8 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
       } finally {
         setLoadingInvoices(false);
       }
-    },
-    [token]
+  },
+  [token, socket]
   );
 
   const handleArchive = useCallback(

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
-import HelpTooltip from './components/HelpTooltip';
 import MainLayout from './components/MainLayout';
 
 function Archive() {

--- a/frontend/src/AuditDashboard.js
+++ b/frontend/src/AuditDashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
 
@@ -12,7 +12,7 @@ export default function AuditDashboard() {
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
 
-  const fetchLogs = async () => {
+  const fetchLogs = useCallback(async () => {
     if (!token) return;
     setLoading(true);
     const params = new URLSearchParams();
@@ -26,9 +26,9 @@ export default function AuditDashboard() {
     const data = await res.json();
     if (res.ok) setLogs(data);
     setLoading(false);
-  };
+  }, [token, vendor, action, start, end]);
 
-  useEffect(() => { fetchLogs(); }, [token]);
+  useEffect(() => { fetchLogs(); }, [fetchLogs]);
 
   if (!['admin','finance','legal'].includes(role)) {
     return <div className="min-h-screen flex items-center justify-center">Access denied.</div>;

--- a/frontend/src/Board.js
+++ b/frontend/src/Board.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import MainLayout from './components/MainLayout';
 
@@ -6,7 +6,7 @@ export default function Board() {
   const token = localStorage.getItem('token') || '';
   const [columns, setColumns] = useState({ pending: [], approved: [], flagged: [] });
 
-  const fetchData = async () => {
+  const fetchData = useCallback(async () => {
     if (!token) return;
     const res = await fetch('http://localhost:3000/api/invoices', {
       headers: { Authorization: `Bearer ${token}` }
@@ -19,9 +19,9 @@ export default function Board() {
         flagged: data.filter(i => i.flagged)
       });
     }
-  };
+  }, [token]);
 
-  useEffect(() => { fetchData(); }, [token]);
+  useEffect(() => { fetchData(); }, [fetchData]);
 
   const onDragEnd = async (result) => {
     const { source, destination, draggableId } = result;

--- a/frontend/src/FraudReport.js
+++ b/frontend/src/FraudReport.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
 
@@ -8,7 +8,7 @@ function FraudReport() {
   const [loading, setLoading] = useState(true);
   const [explanations, setExplanations] = useState({});
 
-  const fetchFlagged = async () => {
+  const fetchFlagged = useCallback(async () => {
     if (!token) return;
     setLoading(true);
     const res = await fetch('http://localhost:3000/api/invoices/fraud/flagged', {
@@ -17,7 +17,7 @@ function FraudReport() {
     const data = await res.json();
     if (res.ok) setInvoices(data.invoices || []);
     setLoading(false);
-  };
+  }, [token]);
 
   const loadExplanation = async (id) => {
     const res = await fetch(`http://localhost:3000/api/invoices/${id}/flag-explanation`, {
@@ -29,7 +29,7 @@ function FraudReport() {
     }
   };
 
-  useEffect(() => { fetchFlagged(); }, [token]);
+  useEffect(() => { fetchFlagged(); }, [fetchFlagged]);
 
   return (
     <MainLayout title="Fraud Reports" helpTopic="fraud">

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -1,6 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
-import HelpTooltip from './components/HelpTooltip';
 import MainLayout from './components/MainLayout';
 
 function Reports() {
@@ -51,14 +50,14 @@ function Reports() {
     window.URL.revokeObjectURL(url);
   };
 
-  const loadRules = async () => {
+  const loadRules = useCallback(async () => {
     const res = await fetch('http://localhost:3000/api/analytics/rules', {
       headers: { Authorization: `Bearer ${token}` }
     });
     const data = await res.json();
     if (res.ok) setRules(data.rules || []);
     setLoadingRules(false);
-  };
+  }, [token]);
 
   const addAmountRule = async () => {
     await fetch('http://localhost:3000/api/analytics/rules', {
@@ -74,7 +73,7 @@ function Reports() {
       setLoadingRules(true);
       loadRules();
     }
-  }, [token]);
+  }, [loadRules, token]);
 
   return (
     <MainLayout title="Reports" helpTopic="reports">

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
-import HelpTooltip from './components/HelpTooltip';
 import MainLayout from './components/MainLayout';
 
 function TeamManagement() {
@@ -20,19 +19,19 @@ function TeamManagement() {
 
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
-  const fetchUsers = async () => {
+  const fetchUsers = useCallback(async () => {
     const res = await fetch('http://localhost:3000/api/users', { headers });
     const data = await res.json();
     if (res.ok) setUsers(data);
-  };
+  }, [token]);
 
-  const fetchLogs = async () => {
+  const fetchLogs = useCallback(async () => {
     const res = await fetch('http://localhost:3000/api/invoices/logs', { headers });
     const data = await res.json();
     if (res.ok) setLogs(data);
-  };
+  }, [token]);
 
-  const fetchSettings = async () => {
+  const fetchSettings = useCallback(async () => {
     const res = await fetch('http://localhost:3000/api/settings', { headers });
     const data = await res.json();
     if (res.ok) {
@@ -42,14 +41,14 @@ function TeamManagement() {
       setPdfLimit(data.pdfSizeLimitMB);
       if (data.defaultRetention) setDefaultRetention(data.defaultRetention);
     }
-  };
+  }, [token]);
 
   useEffect(() => {
     if (token) {
       setLoading(true);
       Promise.all([fetchUsers(), fetchLogs(), fetchSettings()]).finally(() => setLoading(false));
     }
-  }, [token]);
+  }, [fetchUsers, fetchLogs, fetchSettings, token]);
 
   const addUser = async () => {
     await fetch('http://localhost:3000/api/users', {

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
-import HelpTooltip from './components/HelpTooltip';
 import MainLayout from './components/MainLayout';
 
 function VendorManagement() {
@@ -11,15 +10,15 @@ function VendorManagement() {
 
   const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` };
 
-  const fetchVendors = async () => {
+  const fetchVendors = useCallback(async () => {
     setLoading(true);
     const res = await fetch('http://localhost:3000/api/vendors', { headers });
     const data = await res.json();
     if (res.ok) setVendors(data.vendors || []);
     setLoading(false);
-  };
+  }, [token]);
 
-  useEffect(() => { if (token) fetchVendors(); }, [token]);
+  useEffect(() => { if (token) fetchVendors(); }, [fetchVendors, token]);
 
   const saveNotes = async (vendor) => {
     const notes = notesInput[vendor] ?? '';

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -14,7 +14,7 @@ import WorkflowPage from './WorkflowPage';
 import Board from './Board';
 import NotFound from './NotFound';
 import LandingPage from './LandingPage';
-import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
 import './i18n';


### PR DESCRIPTION
## Summary
- clean up unused imports
- add missing dependencies to hooks
- convert fetch functions to `useCallback`

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853433421c0832ea10244d2522a7945