### PR TITLE
Implement onboarding wizard

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -9,6 +9,7 @@ const { login, refreshToken, logout, authMiddleware, authorizeRoles } = require(
 const {
   uploadInvoice,
   voiceUpload,
+  parseInvoiceSample,
   conversationalUpload,
   getAllInvoices,
   clearAllInvoices,
@@ -95,6 +96,7 @@ router.post('/suggest-voucher', suggestVoucher);
 router.post('/send-email', sendSummaryEmail);
 router.post('/draft-smart-email', authMiddleware, smartDraftEmail);
 router.post('/upload', authMiddleware, authorizeRoles('admin'), upload.single('invoiceFile'), uploadInvoice);
+router.post('/parse-sample', authMiddleware, upload.single('invoiceFile'), parseInvoiceSample);
 router.post('/import-csv', authMiddleware, authorizeRoles('admin'), upload.single('file'), importInvoicesCSV);
 router.post('/voice-upload', authMiddleware, authorizeRoles('admin'), voiceUpload);
 router.post('/nl-upload', authMiddleware, authorizeRoles('admin'), conversationalUpload);

--- a/frontend/src/OnboardingWizard.js
+++ b/frontend/src/OnboardingWizard.js
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import MainLayout from './components/MainLayout';
+import { Button } from './components/ui/Button';
+
+export default function OnboardingWizard() {
+  const token = localStorage.getItem('token') || '';
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState(null);
+  const [parsed, setParsed] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [template, setTemplate] = useState({ vendor: '', assignee: '' });
+
+  const uploadSample = async () => {
+    if (!file) return;
+    setLoading(true);
+    const formData = new FormData();
+    formData.append('invoiceFile', file);
+    try {
+      const res = await fetch('http://localhost:3000/api/invoices/parse-sample', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setParsed(data);
+        setTemplate(t => ({ ...t, vendor: data.invoice.vendor }));
+        setStep(2);
+      } else {
+        alert(data.message || 'Failed to parse');
+      }
+    } catch (err) {
+      alert('Upload failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const saveTemplate = () => {
+    const templates = JSON.parse(localStorage.getItem('vendorTemplates') || '{}');
+    if (template.vendor) {
+      templates[template.vendor] = template.assignee;
+      localStorage.setItem('vendorTemplates', JSON.stringify(templates));
+    }
+    setStep(4);
+  };
+
+  return (
+    <MainLayout title="Getting Started" helpTopic="onboarding">
+      <div className="max-w-2xl mx-auto space-y-6">
+        {step === 1 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <h2 className="text-lg font-semibold">1. Upload an invoice sample</h2>
+            <input
+              type="file"
+              onChange={e => setFile(e.target.files[0])}
+              className="block w-full text-sm text-gray-900 border border-gray-300 rounded cursor-pointer focus:outline-none"
+            />
+            <Button onClick={uploadSample} disabled={!file || loading} className="mt-2">
+              {loading ? 'Uploading...' : 'Next'}
+            </Button>
+          </div>
+        )}
+
+        {step === 2 && parsed && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <h2 className="text-lg font-semibold">2. Review parsed fields</h2>
+            <div className="text-sm space-y-1">
+              <div><span className="font-medium">Invoice #:</span> {parsed.invoice.invoice_number}</div>
+              <div><span className="font-medium">Date:</span> {parsed.invoice.date}</div>
+              <div><span className="font-medium">Amount:</span> {parsed.invoice.amount}</div>
+              <div><span className="font-medium">Vendor:</span> {parsed.invoice.vendor}</div>
+              <div><span className="font-medium">Suggested Tags:</span> {(parsed.tags || []).join(', ') || 'None'}</div>
+            </div>
+            <Button onClick={() => setStep(3)} className="mt-2">Next</Button>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <h2 className="text-lg font-semibold">3. Save vendor template</h2>
+            <div className="space-y-2 text-sm">
+              <div>
+                <label className="block font-medium mb-1">Vendor</label>
+                <input
+                  className="input w-full"
+                  value={template.vendor}
+                  onChange={e => setTemplate({ ...template, vendor: e.target.value })}
+                />
+              </div>
+              <div>
+                <label className="block font-medium mb-1">Default Assignee</label>
+                <input
+                  className="input w-full"
+                  value={template.assignee}
+                  onChange={e => setTemplate({ ...template, assignee: e.target.value })}
+                />
+              </div>
+            </div>
+            <Button onClick={saveTemplate} className="mt-2">Save Template</Button>
+          </div>
+        )}
+
+        {step === 4 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow text-center">
+            <h2 className="text-lg font-semibold">All set!</h2>
+            <p className="text-sm">Your template has been saved. You're ready to start uploading invoices.</p>
+            <Button onClick={() => (window.location.href = '/invoices')}>Go to App</Button>
+          </div>
+        )}
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -14,6 +14,7 @@ import WorkflowPage from './WorkflowPage';
 import Board from './Board';
 import NotFound from './NotFound';
 import LandingPage from './LandingPage';
+import OnboardingWizard from './OnboardingWizard';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
@@ -62,6 +63,7 @@ function AnimatedRoutes() {
         <Route path="/workflow" element={<PageWrapper><WorkflowPage /></PageWrapper>} />
         <Route path="/board" element={<PageWrapper><Board /></PageWrapper>} />
         <Route path="/builder" element={<PageWrapper><DashboardBuilder /></PageWrapper>} />
+        <Route path="/onboarding" element={<PageWrapper><OnboardingWizard /></PageWrapper>} />
         <Route path="/" element={<PageWrapper><LandingPage /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>


### PR DESCRIPTION
## Summary
- add `/parse-sample` API endpoint to parse invoice without saving
- expose new backend handler in routes
- create **OnboardingWizard** component with multi-step wizard
- wire onboarding route into the React router

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ccdd850c832ea50ca7ae52b8b96c