### PR TITLE
Add adaptive dashboard with metadata and activity feed

### DIFF
--- a/backend/controllers/activityController.js
+++ b/backend/controllers/activityController.js
@@ -4,7 +4,7 @@ const archiver = require('archiver');
 
 exports.getActivityLogs = async (req, res) => {
   try {
-    const { start, end, vendor, action } = req.query;
+    const { start, end, vendor, action, limit } = req.query;
     let query = 'SELECT a.* FROM activity_logs a';
     const params = [];
     const conditions = [];
@@ -31,7 +31,9 @@ exports.getActivityLogs = async (req, res) => {
       conditions.push('i.flagged = TRUE');
     }
     const where = conditions.length ? ' WHERE ' + conditions.join(' AND ') : '';
-    const result = await pool.query(`${query}${where} ORDER BY a.created_at DESC`, params);
+    const lim = parseInt(limit, 10);
+    const limitClause = lim ? ` LIMIT ${lim}` : '';
+    const result = await pool.query(`${query}${where} ORDER BY a.created_at DESC${limitClause}`, params);
     res.json(result.rows);
   } catch (err) {
     console.error('Log fetch error:', err);

--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { getReport, exportReportPDF, getTrends, getAgingReport, predictCashFlowRisk } = require('../controllers/analyticsController');
-const { getApprovalStats } = require('../controllers/analyticsController');
+const { getReport, exportReportPDF, getTrends, getAgingReport, predictCashFlowRisk, getDashboardMetadata, getApprovalStats } = require('../controllers/analyticsController');
 const { listRules, addRule } = require('../controllers/rulesController');
 const { authMiddleware } = require('../controllers/userController');
 
@@ -13,5 +12,6 @@ router.get('/cash-flow/predict', authMiddleware, predictCashFlowRisk);
 router.get('/rules', authMiddleware, listRules);
 router.post('/rules', authMiddleware, addRule);
 router.get('/approvals/stats', authMiddleware, getApprovalStats);
+router.get('/metadata', authMiddleware, getDashboardMetadata);
 
 module.exports = router;

--- a/frontend/src/AdaptiveDashboard.js
+++ b/frontend/src/AdaptiveDashboard.js
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from 'react';
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import MainLayout from './components/MainLayout';
+import Skeleton from './components/Skeleton';
+import VendorProfilePanel from './components/VendorProfilePanel';
+
+const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
+
+export default function AdaptiveDashboard() {
+  const token = localStorage.getItem('token') || '';
+  const [meta, setMeta] = useState(null);
+  const [vendors, setVendors] = useState([]);
+  const [cashFlow, setCashFlow] = useState([]);
+  const [logs, setLogs] = useState([]);
+  const [selectedVendor, setSelectedVendor] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!token) return;
+    const headers = { Authorization: `Bearer ${token}` };
+    setLoading(true);
+    Promise.all([
+      fetch('http://localhost:3000/api/analytics/metadata', { headers }).then(r => r.json()),
+      fetch('http://localhost:3000/api/invoices/top-vendors', { headers }).then(r => r.json()),
+      fetch('http://localhost:3000/api/invoices/cash-flow?interval=monthly', { headers }).then(r => r.json()),
+      fetch('http://localhost:3000/api/invoices/logs?limit=20', { headers }).then(r => r.json()),
+    ])
+      .then(([m, v, c, l]) => {
+        setMeta(m);
+        setVendors(v.topVendors || []);
+        setCashFlow(c.data || []);
+        setLogs(Array.isArray(l) ? l : []);
+      })
+      .finally(() => setLoading(false));
+  }, [token]);
+
+  return (
+    <MainLayout title="Adaptive Dashboard">
+      <div className="space-y-8">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+          {loading ? (
+            <Skeleton rows={1} className="h-20 col-span-2 md:col-span-3" />
+          ) : (
+            <>
+              <div className="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <div className="text-sm text-gray-500">🚀 Total Vendors</div>
+                <div className="text-xl font-semibold">{meta?.totalVendors ?? 0}</div>
+              </div>
+              <div className="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <div className="text-sm text-gray-500">🚩 Flagged Invoices</div>
+                <div className="text-xl font-semibold">{meta?.flaggedItems ?? 0}</div>
+              </div>
+              <div className="p-4 bg-white dark:bg-gray-800 rounded shadow">
+                <div className="text-sm text-gray-500">⏱ Avg. Processing (hrs)</div>
+                <div className="text-xl font-semibold">{meta?.avgProcessingHours ?? 0}</div>
+              </div>
+            </>
+          )}
+        </div>
+        <div className="h-64">
+          {loading ? (
+            <Skeleton rows={1} className="h-full" />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={vendors} dataKey="total" nameKey="vendor" outerRadius={80} onClick={(d) => setSelectedVendor(d.vendor)}>
+                  {vendors.map((_, i) => (
+                    <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+        <div className="h-64">
+          {loading ? (
+            <Skeleton rows={1} className="h-full" />
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={cashFlow}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="period" tickFormatter={(v) => new Date(v).toLocaleDateString()} />
+                <YAxis />
+                <Tooltip labelFormatter={(v) => new Date(v).toLocaleDateString()} />
+                <Bar dataKey="total" fill="#3b82f6" />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Recent Activity</h2>
+          <ul className="space-y-1 text-sm">
+            {loading ? (
+              <Skeleton rows={3} />
+            ) : (
+              logs.map((log) => (
+                <li key={log.id} className="border-b pb-1">
+                  <span className="font-medium">{log.username || log.user_id}</span> {log.action}{' '}
+                  <span className="text-gray-500">{new Date(log.created_at).toLocaleString()}</span>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+        <VendorProfilePanel vendor={selectedVendor} open={!!selectedVendor} onClose={() => setSelectedVendor(null)} token={token} />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -38,6 +38,13 @@ export default function SidebarNav({ notifications = [] }) {
               <span>Dashboard</span>
             </Link>
             <Link
+              to="/adaptive"
+              className={`nav-link ${location.pathname === '/adaptive' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700' : ''}`}
+            >
+              <DocumentChartBarIcon className="w-5 h-5" />
+              <span>Adaptive</span>
+            </Link>
+            <Link
               to="/invoices"
               className={`nav-link ${location.pathname === '/invoices' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700' : ''}`}
             >

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import Dashboard from './Dashboard';
+import AdaptiveDashboard from './AdaptiveDashboard';
 import SharedDashboard from './SharedDashboard';
 import DashboardBuilder from './DashboardBuilder';
 import Reports from './Reports';
@@ -52,6 +53,7 @@ function AnimatedRoutes() {
     <AnimatePresence mode="wait">
       <Routes location={location} key={location.pathname}>
         <Route path="/dashboard" element={<PageWrapper><Dashboard /></PageWrapper>} />
+        <Route path="/adaptive" element={<PageWrapper><AdaptiveDashboard /></PageWrapper>} />
         <Route path="/dashboard/shared/:token" element={<PageWrapper><SharedDashboard /></PageWrapper>} />
         <Route path="/invoices" element={<PageWrapper><App /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><Reports /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- add dashboard metadata controller and route
- support limit parameter for activity logs
- create AdaptiveDashboard page with metadata cards, vendor/cash-flow charts and recent activity feed
- link Adaptive Dashboard in sidebar and routes

## Testing
- `npm install --legacy-peer-deps` in `frontend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d84f4930832eba5af5a2bc9a662f