### PR TITLE
Add rule builder with drag & drop toggles

### DIFF
--- a/frontend/src/WorkflowPage.js
+++ b/frontend/src/WorkflowPage.js
@@ -1,10 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import WorkflowBuilder from './components/WorkflowBuilder';
+import RuleBuilder from './components/RuleBuilder';
 import MainLayout from './components/MainLayout';
 
 export default function WorkflowPage() {
   const token = localStorage.getItem('token') || '';
   const [steps, setSteps] = useState(['Finance', 'Manager', 'Legal']);
+  const [rules, setRules] = useState(() => {
+    const saved = localStorage.getItem('workflowRules');
+    return saved
+      ? JSON.parse(saved)
+      : [
+          { condition: 'Amount > $500', action: 'require approver', active: true },
+          { condition: 'PDF + OCR', action: 'auto-suggest tags', active: true },
+        ];
+  });
 
   useEffect(() => {
     fetch('http://localhost:3000/api/workflows', {
@@ -26,9 +36,23 @@ export default function WorkflowPage() {
     });
   };
 
+  const saveRules = (newRules) => {
+    setRules(newRules);
+    localStorage.setItem('workflowRules', JSON.stringify(newRules));
+  };
+
   return (
     <MainLayout title="Workflow Builder">
-      <WorkflowBuilder steps={steps} onChange={save} />
+      <div className="space-y-6 max-w-md">
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Approval Chain</h2>
+          <WorkflowBuilder steps={steps} onChange={save} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Rules</h2>
+          <RuleBuilder rules={rules} onChange={saveRules} />
+        </div>
+      </div>
     </MainLayout>
   );
 }

--- a/frontend/src/components/RuleBuilder.js
+++ b/frontend/src/components/RuleBuilder.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+
+export default function RuleBuilder({ rules = [], onChange }) {
+  const [items, setItems] = useState(rules);
+
+  const handleDragEnd = result => {
+    if (!result.destination) return;
+    const reordered = Array.from(items);
+    const [moved] = reordered.splice(result.source.index, 1);
+    reordered.splice(result.destination.index, 0, moved);
+    setItems(reordered);
+    onChange && onChange(reordered);
+  };
+
+  const toggleActive = index => {
+    const updated = [...items];
+    updated[index] = { ...updated[index], active: !updated[index].active };
+    setItems(updated);
+    onChange && onChange(updated);
+  };
+
+  return (
+    <DragDropContext onDragEnd={handleDragEnd}>
+      <Droppable droppableId="rules">
+        {provided => (
+          <ul ref={provided.innerRef} {...provided.droppableProps} className="space-y-2">
+            {items.map((rule, index) => (
+              <Draggable key={index} draggableId={`rule-${index}`} index={index}>
+                {prov => (
+                  <li
+                    ref={prov.innerRef}
+                    {...prov.draggableProps}
+                    {...prov.dragHandleProps}
+                    className="p-2 bg-gray-100 dark:bg-gray-700 rounded flex justify-between items-center"
+                  >
+                    <span className="text-sm mr-2">{rule.condition} → {rule.action}</span>
+                    <label className="flex items-center space-x-1">
+                      <input
+                        type="checkbox"
+                        checked={rule.active}
+                        onChange={() => toggleActive(index)}
+                        className="form-checkbox"
+                      />
+                      <span className="text-xs">{rule.active ? 'Active' : 'Inactive'}</span>
+                    </label>
+                  </li>
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </ul>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+}


### PR DESCRIPTION
## Summary
- create `RuleBuilder` component for drag-and-drop rule management with active/inactive toggles
- enhance `WorkflowPage` to include workflow rules section

## Testing
- `CI=true npm test --silent --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_6855e3f8d9e8832e86db3a88732d6d03