### PR TITLE
Add global theme and language controls

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,8 +35,10 @@ import Joyride from 'react-joyride';
 import ProgressBar from './components/ProgressBar';
 import FeatureWidget from './components/FeatureWidget';
 import { Button } from './components/ui/Button';
+import { Card } from './components/ui/Card';
 import { motion } from 'framer-motion';
 import Fuse from 'fuse.js';
+import useDarkMode from './hooks/useDarkMode';
 import {
   ArchiveBoxIcon,
   ArrowDownTrayIcon,
@@ -177,7 +179,7 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
     const saved = localStorage.getItem('notifications');
     return saved ? JSON.parse(saved) : [];
   });
-  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
+  const [darkMode, setDarkMode] = useDarkMode();
   const [isOffline, setIsOffline] = useState(!navigator.onLine);
   const [confirmData, setConfirmData] = useState(null);
   const [filterSidebarOpen, setFilterSidebarOpen] = useState(false);
@@ -477,15 +479,6 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
     localStorage.setItem('tenant', tenant);
   }, [tenant]);
 
-  useEffect(() => {
-    if (darkMode) {
-      document.documentElement.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
-    }
-  }, [darkMode]);
 
   useEffect(() => {
     const addTitles = () => {
@@ -1833,7 +1826,7 @@ useEffect(() => {
   if (!token) {
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center text-gray-900 dark:text-gray-100">
-        <div className="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md w-full max-w-sm space-y-4">
+        <Card className="w-full max-w-sm space-y-4">
           <h2 className="text-lg font-semibold mb-4">Login</h2>
           {loginError && <p className="text-red-600 mb-2">{loginError}</p>}
           <label htmlFor="username" className="block text-sm font-medium">
@@ -1859,7 +1852,7 @@ useEffect(() => {
           <button onClick={handleLogin} className="btn btn-primary w-full">
             Log In
           </button>
-        </div>
+        </Card>
       </div>
     );
   }
@@ -1933,8 +1926,6 @@ useEffect(() => {
         onNotificationsOpen={markNotificationsRead}
         role={role}
         onLogout={handleLogout}
-        darkMode={darkMode}
-        setDarkMode={setDarkMode}
         token={token}
         onToggleFilters={() => setFilterSidebarOpen((o) => !o)}
         onUpload={() => fileInputRef.current?.click()}

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { DocumentArrowUpIcon, CheckCircleIcon, ChartBarIcon } from '@heroicons/react/24/outline';
+import LanguageSelector from './components/LanguageSelector';
+import DarkModeToggle from './components/DarkModeToggle';
+import { Card } from './components/ui/Card';
 
 export default function LandingPage() {
   return (
@@ -11,12 +14,16 @@ export default function LandingPage() {
             <DocumentArrowUpIcon className="w-6 h-6" />
             <span className="font-bold text-lg">Invoice Uploader AI</span>
           </div>
-          <Link
-            to="/invoices"
-            className="btn btn-primary bg-white text-indigo-700 hover:bg-gray-100"
-          >
-            Log In
-          </Link>
+          <div className="flex items-center space-x-2">
+            <LanguageSelector />
+            <DarkModeToggle />
+            <Link
+              to="/invoices"
+              className="btn btn-primary bg-white text-indigo-700 hover:bg-gray-100"
+            >
+              Log In
+            </Link>
+          </div>
         </div>
       </nav>
       <header className="flex-1 flex flex-col items-center justify-center text-center px-6">
@@ -31,21 +38,21 @@ export default function LandingPage() {
       </header>
       <section className="py-12 bg-gray-50 dark:bg-gray-800">
         <div className="container mx-auto grid md:grid-cols-3 gap-8 px-6">
-          <div className="text-center">
+          <Card className="text-center space-y-2">
             <CheckCircleIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
-            <h3 className="font-semibold mt-2">Automatic Validation</h3>
-            <p className="text-sm mt-1">Catch errors and duplicates before they hit your books.</p>
-          </div>
-          <div className="text-center">
+            <h3 className="font-semibold">Automatic Validation</h3>
+            <p className="text-sm">Catch errors and duplicates before they hit your books.</p>
+          </Card>
+          <Card className="text-center space-y-2">
             <ChartBarIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
-            <h3 className="font-semibold mt-2">Real-Time Analytics</h3>
-            <p className="text-sm mt-1">AI insights reveal spending trends and anomalies.</p>
-          </div>
-          <div className="text-center">
+            <h3 className="font-semibold">Real-Time Analytics</h3>
+            <p className="text-sm">AI insights reveal spending trends and anomalies.</p>
+          </Card>
+          <Card className="text-center space-y-2">
             <DocumentArrowUpIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
-            <h3 className="font-semibold mt-2">One-Click Uploads</h3>
-            <p className="text-sm mt-1">Import CSVs or PDFs and organize them instantly.</p>
-          </div>
+            <h3 className="font-semibold">One-Click Uploads</h3>
+            <p className="text-sm">Import CSVs or PDFs and organize them instantly.</p>
+          </Card>
         </div>
       </section>
       <footer className="p-6 text-center text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-900">

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,6 +1,7 @@
 // src/Login.js
 import React, { useState } from 'react';
 import { DocumentArrowUpIcon } from '@heroicons/react/24/outline';
+import { Card } from './components/ui/Card';
 
 export default function Login({ onLogin, addToast }) {
   const [username, setUsername] = useState('');
@@ -40,7 +41,7 @@ export default function Login({ onLogin, addToast }) {
         </h1>
       </nav>
       <div className="flex-1 flex items-center justify-center pt-20">
-        <div className="bg-white dark:bg-gray-800 p-8 rounded-lg shadow-md w-80 space-y-4">
+        <Card className="w-80 space-y-4">
           <h1 className="text-xl font-bold text-center">Login</h1>
 
           {error && (
@@ -66,7 +67,7 @@ export default function Login({ onLogin, addToast }) {
           <button onClick={handleLogin} className="btn btn-primary w-full" title="Log In">
             Log In
           </button>
-        </div>
+        </Card>
       </div>
     </div>
   );

--- a/frontend/src/components/DarkModeToggle.js
+++ b/frontend/src/components/DarkModeToggle.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { SunIcon, MoonIcon } from '@heroicons/react/24/outline';
+import useDarkMode from '../hooks/useDarkMode';
+
+export default function DarkModeToggle() {
+  const [darkMode, setDarkMode] = useDarkMode();
+  return (
+    <button
+      onClick={() => setDarkMode(!darkMode)}
+      className="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+      aria-label="Toggle dark mode"
+      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+    >
+      {darkMode ? <SunIcon className="h-6 w-6" /> : <MoonIcon className="h-6 w-6" />}
+    </button>
+  );
+}

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -4,6 +4,8 @@ import TenantSwitcher from './TenantSwitcher';
 import NotificationBell from './NotificationBell';
 import LanguageSelector from './LanguageSelector';
 import ThemePicker from './ThemePicker';
+import DarkModeToggle from './DarkModeToggle';
+import useDarkMode from '../hooks/useDarkMode';
 import { useTranslation } from 'react-i18next';
 import {
   Bars3Icon,
@@ -12,8 +14,6 @@ import {
   DocumentChartBarIcon,
   ArchiveBoxIcon,
   ArrowUpTrayIcon,
-  SunIcon,
-  MoonIcon,
   UsersIcon,
   UserCircleIcon,
   QuestionMarkCircleIcon,
@@ -29,8 +29,6 @@ export default function Navbar({
   onNotificationsOpen,
   role,
   onLogout,
-  darkMode,
-  setDarkMode,
   token,
   onToggleFilters,
   onUpload,
@@ -40,6 +38,7 @@ export default function Navbar({
   const [menuOpen, setMenuOpen] = useState(false);
   const [userOpen, setUserOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [darkMode, setDarkMode] = useDarkMode();
   const { t } = useTranslation();
   const location = useLocation();
 
@@ -158,18 +157,7 @@ export default function Navbar({
                 <QuestionMarkCircleIcon className="h-6 w-6 cursor-help" />
                 {helpOpen && <HelpTooltip topic="dashboard" token={token} />}
               </div>
-              <button
-                onClick={() => setDarkMode(!darkMode)}
-                className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
-                aria-label="Toggle dark mode"
-                title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-              >
-                {darkMode ? (
-                  <SunIcon className="h-6 w-6" />
-                ) : (
-                  <MoonIcon className="h-6 w-6" />
-                )}
-              </button>
+              <DarkModeToggle />
               <ThemePicker darkMode={darkMode} setDarkMode={setDarkMode} />
               <div className="relative">
                 <button

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import HelpTooltip from './HelpTooltip';
+import LanguageSelector from './LanguageSelector';
+import DarkModeToggle from './DarkModeToggle';
 
 export default function TopNavbar({ title, helpTopic }) {
   const token = localStorage.getItem('token') || '';
@@ -16,7 +18,11 @@ export default function TopNavbar({ title, helpTopic }) {
           </span>
         )}
       </h1>
-      <Link to="/invoices" className="underline">Back to App</Link>
+      <div className="flex items-center gap-2">
+        <LanguageSelector />
+        <DarkModeToggle />
+        <Link to="/invoices" className="underline">Back to App</Link>
+      </div>
     </nav>
   );
 }

--- a/frontend/src/components/ui/Card.js
+++ b/frontend/src/components/ui/Card.js
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { cn } from '../../lib/utils';
+
+const Card = React.forwardRef(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4', className)} {...props} />
+));
+Card.displayName = 'Card';
+
+export { Card };

--- a/frontend/src/hooks/useDarkMode.js
+++ b/frontend/src/hooks/useDarkMode.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export default function useDarkMode() {
+  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
+
+  useEffect(() => {
+    if (darkMode) {
+      document.documentElement.classList.add('dark');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+      localStorage.setItem('theme', 'light');
+    }
+  }, [darkMode]);
+
+  return [darkMode, setDarkMode];
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -72,4 +72,7 @@ code {
   .input {
     @apply border border-gray-300 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none;
   }
+  .card {
+    @apply bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4;
+  }
 }


### PR DESCRIPTION
## Summary
- introduce reusable `Card` component for card-style layouts
- add `useDarkMode` hook and `DarkModeToggle`
- place language selector and dark mode toggle in navbars
- style cleanup in `index.css`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6855e6d4c8ec832ea990ee57c78413f0