### PR TITLE
Add AI suggestion endpoints

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -72,7 +72,19 @@ const {
 
 
 const { summarizeUploadErrors } = require('../controllers/aiController');
-const { invoiceQualityScore, assistantQuery, billingQuery, onboardingHelp, paymentRiskScore, paymentLikelihood, nlChartQuery, suggestTagColors, paymentBehaviorByVendor } = require('../controllers/aiController');
+const {
+  invoiceQualityScore,
+  assistantQuery,
+  billingQuery,
+  onboardingHelp,
+  paymentRiskScore,
+  paymentLikelihood,
+  nlChartQuery,
+  suggestTagColors,
+  paymentBehaviorByVendor,
+  thinkSuggestion,
+  overdueEmailTemplate,
+} = require('../controllers/aiController');
 const router = express.Router();
 const { sendSummaryEmail } = require('../controllers/emailController');
 const { smartDraftEmail } = require('../controllers/emailController');
@@ -114,6 +126,8 @@ router.post('/payment-likelihood', authMiddleware, paymentLikelihood);
 router.post('/payment-behavior', authMiddleware, paymentBehaviorByVendor);
 router.post('/assistant', authMiddleware, assistantQuery);
 router.post('/billing-query', authMiddleware, billingQuery);
+router.post('/:id/think-suggestion', authMiddleware, thinkSuggestion);
+router.post('/:id/overdue-email', authMiddleware, overdueEmailTemplate);
 router.get('/help/onboarding', authMiddleware, onboardingHelp);
 router.post('/summarize-errors', summarizeUploadErrors);
 router.post('/login', login);


### PR DESCRIPTION
## Summary
- implement `thinkSuggestion` and `overdueEmailTemplate` helpers in `aiController`
- expose `/invoices/:id/think-suggestion` and `/invoices/:id/overdue-email` routes

## Testing
- `node --check backend/controllers/aiController.js`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6855f33f4b6c832e8761fb9d3edae12a