### PR TITLE
Implement workflow builder and evaluation API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Node CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: invoices
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Install backend deps
+        run: cd backend && npm ci --legacy-peer-deps
+      - name: Lint backend
+        run: cd backend && npm run lint || true
+      - name: Install frontend deps
+        run: cd frontend && npm ci --legacy-peer-deps
+      - name: Build frontend
+        run: cd frontend && npm run build

--- a/README.md
+++ b/README.md
@@ -258,6 +258,15 @@ as "Marketing", "Legal", or "Recurring" when no rule matches.
 - `POST /api/invoices/budgets` – create/update a monthly or quarterly budget by vendor or tag
 - `GET /api/invoices/budgets/warnings` – check if spending has exceeded 90% of a budget
 - `GET /api/invoices/anomalies` – list vendors with unusual spending spikes
+- `GET /api/workflows` – list saved workflows
+- `POST /api/workflows` – create or update a workflow
+- `POST /api/workflows/evaluate` – test workflow rules against a payload
+
+### Workflow Builder
+
+The `/workflow-builder` page lets admins design approval chains and rules with an
+interactive expression builder. Test expressions are sent to `POST /api/workflows/evaluate`
+to see how rules would route a sample invoice.
 - `GET /api/invoices/fraud/flagged` – list flagged invoices with reasons
 - `GET /api/invoices/:id/timeline` – view a timeline of state changes for an invoice
 - `PATCH /api/invoices/:id/retention` – update an invoice retention policy (6m, 2y, forever)

--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -23,6 +23,7 @@ const { encrypt } = require('../utils/encryption');
 const levenshtein = require('fast-levenshtein');
 const { categorizeInvoice } = require('../utils/categorize');
 const { applyCorrections, loadCorrections } = require('../utils/parserTrainer');
+const { updateWeights } = require('../utils/parserTrainer');
 
 // Basic vendor -> tag mapping for quick suggestions
 const vendorTagMap = {
@@ -1319,6 +1320,7 @@ exports.updateInvoiceField = async (req, res) => {
         'INSERT INTO ocr_corrections (invoice_id, field, old_value, new_value, user_id) VALUES ($1,$2,$3,$4,$5)',
         [id, field, String(before.rows[0][field]), String(value), req.user?.userId || null]
       );
+      updateWeights(field, value);
     }
     await pool.query(`UPDATE invoices SET ${field} = $1 WHERE id = $2`, [value, id]);
     await loadCorrections();

--- a/backend/controllers/workflowController.js
+++ b/backend/controllers/workflowController.js
@@ -1,4 +1,5 @@
 const pool = require('../config/db');
+const { evaluateWorkflowRules } = require('../utils/workflowRulesEngine');
 
 exports.getWorkflows = async (req, res) => {
   try {
@@ -26,5 +27,20 @@ exports.setWorkflow = async (req, res) => {
   } catch (err) {
     console.error('Set workflow error:', err);
     res.status(500).json({ message: 'Failed to save workflow' });
+  }
+};
+
+exports.evaluateWorkflow = async (req, res) => {
+  const payload = req.body || {};
+  try {
+    const result = await evaluateWorkflowRules(payload);
+    await pool.query(
+      'INSERT INTO workflow_evaluations (payload, result) VALUES ($1,$2)',
+      [JSON.stringify(payload), JSON.stringify(result)]
+    );
+    res.json({ result });
+  } catch (err) {
+    console.error('Evaluate workflow error:', err);
+    res.status(500).json({ message: 'Failed to evaluate workflow rules' });
   }
 };

--- a/backend/routes/workflowRoutes.js
+++ b/backend/routes/workflowRoutes.js
@@ -1,9 +1,10 @@
 const express = require('express');
 const router = express.Router();
-const { getWorkflows, setWorkflow } = require('../controllers/workflowController');
+const { getWorkflows, setWorkflow, evaluateWorkflow } = require('../controllers/workflowController');
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
 
 router.get('/', authMiddleware, authorizeRoles('admin'), getWorkflows);
 router.post('/', authMiddleware, authorizeRoles('admin'), setWorkflow);
+router.post('/evaluate', authMiddleware, authorizeRoles('admin'), evaluateWorkflow);
 
 module.exports = router;

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -156,6 +156,13 @@ async function initDb() {
       active BOOLEAN DEFAULT TRUE,
       created_at TIMESTAMP DEFAULT NOW()
     )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS workflow_evaluations (
+      id SERIAL PRIMARY KEY,
+      payload JSONB,
+      result JSONB,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
   } catch (err) {
     console.error('Database init error:', err);
   }

--- a/frontend/src/WorkflowBuilderPage.js
+++ b/frontend/src/WorkflowBuilderPage.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import WorkflowBuilder from './components/WorkflowBuilder';
+import RuleBuilder from './components/RuleBuilder';
+import ExpressionBuilder from './components/ExpressionBuilder';
+import MainLayout from './components/MainLayout';
+
+export default function WorkflowBuilderPage() {
+  const token = localStorage.getItem('token') || '';
+  const [steps, setSteps] = useState(['Finance', 'Manager', 'Legal']);
+  const [rules, setRules] = useState(() => {
+    const saved = localStorage.getItem('workflowRules');
+    return saved
+      ? JSON.parse(saved)
+      : [
+          { condition: 'Amount > $500', action: 'require approver', active: true },
+          { condition: 'PDF + OCR', action: 'auto-suggest tags', active: true },
+        ];
+  });
+  const [expression, setExpression] = useState([]);
+
+  useEffect(() => {
+    fetch('http://localhost:3000/api/workflows', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        if (d.workflows && d.workflows[0]) setSteps(d.workflows[0].approval_chain);
+      })
+      .catch(() => {});
+  }, [token]);
+
+  const save = async (newSteps) => {
+    setSteps(newSteps);
+    await fetch('http://localhost:3000/api/workflows', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ department: 'default', approval_chain: newSteps }),
+    });
+  };
+
+  const saveRules = (newRules) => {
+    setRules(newRules);
+    localStorage.setItem('workflowRules', JSON.stringify(newRules));
+  };
+
+  const evaluate = async () => {
+    const payload = {};
+    expression.forEach((c) => {
+      payload[c.field] = c.value;
+    });
+    const resp = await fetch('http://localhost:3000/api/workflows/evaluate', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    }).catch(() => {});
+    if (!resp) return;
+    const data = await resp.json().catch(() => {});
+    if (data && data.result) {
+      alert(JSON.stringify(data.result));
+    }
+  };
+
+  return (
+    <MainLayout title="Workflow Builder">
+      <div className="space-y-6 max-w-md">
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Approval Chain</h2>
+          <WorkflowBuilder steps={steps} onChange={save} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Rules</h2>
+          <RuleBuilder rules={rules} onChange={saveRules} />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Test Expression</h2>
+          <ExpressionBuilder expression={expression} onChange={setExpression} />
+          <button className="mt-2 px-3 py-1 bg-green-600 text-white rounded" onClick={evaluate}>Evaluate</button>
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/ExpressionBuilder.js
+++ b/frontend/src/components/ExpressionBuilder.js
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react';
+
+const FIELDS = [
+  { value: 'vendor', label: 'Vendor' },
+  { value: 'amount', label: 'Amount' },
+  { value: 'department', label: 'Department' },
+];
+
+const OPS = [
+  { value: 'equals', label: '=' },
+  { value: 'contains', label: 'contains' },
+  { value: 'gt', label: '>' },
+  { value: 'lt', label: '<' },
+];
+
+export default function ExpressionBuilder({ expression = [], onChange }) {
+  const [conditions, setConditions] = useState(expression);
+
+  useEffect(() => {
+    onChange && onChange(conditions);
+  }, [conditions, onChange]);
+
+  const addCondition = () => {
+    setConditions([...conditions, { field: 'vendor', op: 'equals', value: '' }]);
+  };
+
+  const update = (idx, key, value) => {
+    const updated = conditions.map((c, i) =>
+      i === idx ? { ...c, [key]: value } : c
+    );
+    setConditions(updated);
+  };
+
+  const remove = (idx) => {
+    const updated = conditions.filter((_, i) => i !== idx);
+    setConditions(updated);
+  };
+
+  return (
+    <div className="space-y-2">
+      {conditions.map((c, i) => (
+        <div key={i} className="flex space-x-2 items-center">
+          <select
+            className="border rounded p-1 bg-white dark:bg-gray-800"
+            value={c.field}
+            onChange={(e) => update(i, 'field', e.target.value)}
+          >
+            {FIELDS.map((f) => (
+              <option key={f.value} value={f.value}>
+                {f.label}
+              </option>
+            ))}
+          </select>
+          <select
+            className="border rounded p-1 bg-white dark:bg-gray-800"
+            value={c.op}
+            onChange={(e) => update(i, 'op', e.target.value)}
+          >
+            {OPS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+          <input
+            className="border rounded p-1 flex-1 bg-white dark:bg-gray-800"
+            value={c.value}
+            onChange={(e) => update(i, 'value', e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => remove(i)}
+            className="text-red-600 px-2"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addCondition}
+        className="px-2 py-1 bg-blue-500 text-white rounded"
+      >
+        Add Condition
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -12,6 +12,7 @@ import Archive from './Archive';
 import TeamManagement from './TeamManagement';
 import VendorManagement from './VendorManagement';
 import WorkflowPage from './WorkflowPage';
+import WorkflowBuilderPage from './WorkflowBuilderPage';
 import Board from './Board';
 import NotFound from './NotFound';
 import LandingPage from './LandingPage';
@@ -63,6 +64,7 @@ function AnimatedRoutes() {
         <Route path="/archive" element={<PageWrapper><Archive /></PageWrapper>} />
         <Route path="/vendors" element={<PageWrapper><VendorManagement /></PageWrapper>} />
         <Route path="/workflow" element={<PageWrapper><WorkflowPage /></PageWrapper>} />
+        <Route path="/workflow-builder" element={<PageWrapper><WorkflowBuilderPage /></PageWrapper>} />
         <Route path="/board" element={<PageWrapper><Board /></PageWrapper>} />
         <Route path="/builder" element={<PageWrapper><DashboardBuilder /></PageWrapper>} />
         <Route path="/onboarding" element={<PageWrapper><OnboardingWizard /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- add a Workflow Builder page with ExpressionBuilder UI
- implement workflow evaluation endpoint and tracking table
- store OCR correction weights when updating invoices
- include CI workflow
- document new endpoints and page

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f58e4480832e8ae3deb30217e4c9