### PR TITLE
Add voice commands and invoice explanations

### DIFF
--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -32,6 +32,9 @@ const vendorTagMap = {
   figma: ['SaaS'],
   aws: ['Cloud'],
   zoom: ['SaaS'],
+  verizon: ['Utilities'],
+  comcast: ['Utilities'],
+  netflix: ['Subscription'],
 };
 
 const vendorPaymentMap = {
@@ -1541,6 +1544,15 @@ exports.suggestTags = async (req, res) => {
       if (vendorKey.includes(key)) {
         return res.json({ tags });
       }
+    }
+
+    const text = `${invoice.vendor || ''} ${invoice.description || ''}`.toLowerCase();
+    const simpleTags = new Set();
+    if (/utility|electric|water|power|gas/.test(text)) simpleTags.add('Utilities');
+    if (/subscription|monthly|plan/.test(text)) simpleTags.add('Subscription');
+    if (/one[- ]?time|setup|installation/.test(text)) simpleTags.add('One-time');
+    if (simpleTags.size > 0) {
+      return res.json({ tags: Array.from(simpleTags) });
     }
 
     const prompt = `You are an intelligent finance assistant. Based on the following invoice details:

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1024,38 +1024,6 @@ useEffect(() => {
     }
   };
 
-  const startVoiceUpload = () => {
-    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
-    if (!SpeechRecognition) {
-      addToast('Voice recognition not supported', 'error');
-      return;
-    }
-    const recognition = new SpeechRecognition();
-    recognition.lang = 'en-US';
-    recognition.interimResults = false;
-    recognition.onresult = async (event) => {
-      const text = Array.from(event.results).map((r) => r[0].transcript).join(' ');
-      try {
-        const res = await fetch('http://localhost:3000/api/invoices/voice-upload', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-          body: JSON.stringify({ text }),
-        });
-        const data = await res.json();
-        if (res.ok) {
-          addToast('Voice invoice created');
-          fetchInvoices(showArchived, selectedAssignee);
-        } else {
-          addToast(data.message || 'Voice upload failed', 'error');
-        }
-      } catch (err) {
-        console.error('Voice upload error:', err);
-        addToast('Voice upload failed', 'error');
-      }
-    };
-    recognition.onerror = () => addToast('Voice recognition error', 'error');
-    recognition.start();
-  };
 
   const startVoiceCommand = () => {
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,6 +35,8 @@ import SuccessAnimation from './components/SuccessAnimation';
 import Joyride from 'react-joyride';
 import ProgressBar from './components/ProgressBar';
 import FeatureWidget from './components/FeatureWidget';
+import VoiceResultModal from './components/VoiceResultModal';
+import ExplanationModal from './components/ExplanationModal';
 import { Button } from './components/ui/Button';
 import { Card } from './components/ui/Card';
 import { motion } from 'framer-motion';
@@ -157,6 +159,8 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
   const [riskScores, setRiskScores] = useState({});
   const [assistantOpen, setAssistantOpen] = useState(false);
   const [featureOpen, setFeatureOpen] = useState(false);
+  const [voiceModal, setVoiceModal] = useState(null); // { command, result }
+  const [explainModal, setExplainModal] = useState(null); // { invoice, explanation, score }
   const [chatHistory, setChatHistory] = useState(() => {
     const saved = localStorage.getItem('chatHistory');
     return saved ? JSON.parse(saved) : [];
@@ -1053,6 +1057,39 @@ useEffect(() => {
     recognition.start();
   };
 
+  const startVoiceCommand = () => {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      addToast('Voice recognition not supported', 'error');
+      return;
+    }
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'en-US';
+    recognition.interimResults = false;
+    recognition.onresult = async (event) => {
+      const command = Array.from(event.results).map((r) => r[0].transcript).join('');
+      setVoiceModal({ command, result: 'Thinking...' });
+      try {
+        const res = await fetch('http://localhost:3000/api/invoices/assistant', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ question: command }),
+        });
+        const data = await res.json();
+        if (res.ok) {
+          setVoiceModal({ command, result: data.answer });
+        } else {
+          setVoiceModal({ command, result: data.message || 'Error' });
+        }
+      } catch (err) {
+        console.error('Voice command error:', err);
+        setVoiceModal({ command, result: 'Failed to process command' });
+      }
+    };
+    recognition.onerror = () => addToast('Voice recognition error', 'error');
+    recognition.start();
+  };
+
   const handleConversationalUpload = async (text) => {
     if (!text.trim()) return;
     try {
@@ -1579,6 +1616,23 @@ useEffect(() => {
     } catch (err) {
       console.error('Risk score error:', err);
       setRiskScores((p) => ({ ...p, [invoice.id]: 'N/A' }));
+    }
+  };
+
+  const handleExplainInvoice = async (invoice) => {
+    try {
+      const res = await fetch(`http://localhost:3000/api/invoices/${invoice.id}/explain`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setExplainModal({ invoice, explanation: data.explanation, score: data.anomaly_score });
+      } else {
+        addToast(data.message || 'Failed to explain invoice', 'error');
+      }
+    } catch (err) {
+      console.error('Explain invoice error:', err);
+      addToast('Failed to explain invoice', 'error');
     }
   };
   
@@ -3005,6 +3059,13 @@ useEffect(() => {
                       >
                         <TagIcon className="w-4 h-4" />
                       </button>
+                      <button
+                        onClick={() => handleExplainInvoice(inv)}
+                        className="bg-indigo-500 text-white px-2 py-1 rounded hover:bg-indigo-600 text-xs w-full"
+                        title="Explain"
+                      >
+                        🧠
+                      </button>
                       {tagSuggestions[inv.id] && (
                         <SuggestionChips
                           suggestions={tagSuggestions[inv.id]}
@@ -3186,6 +3247,13 @@ useEffect(() => {
                               <CurrencyDollarIcon className="w-4 h-4" />
                             )}
                           </button>
+                          <button
+                            onClick={(e) => { e.stopPropagation(); handleExplainInvoice(inv); }}
+                            className="bg-indigo-500 text-white px-2 py-1 rounded text-xs hover:bg-indigo-600"
+                            title="Explain"
+                          >
+                            🧠
+                          </button>
                         </>
                       )}
                     </div>
@@ -3279,7 +3347,7 @@ useEffect(() => {
           <FloatingActionPanel
             onUpload={openUploadPreview}
             onAsk={() => setAssistantOpen(true)}
-            onVoice={startVoiceUpload}
+            onVoice={startVoiceCommand}
             onFeature={() => setFeatureOpen(true)}
           />
           <ChatSidebar
@@ -3302,6 +3370,19 @@ useEffect(() => {
             open={!!bulkSummary}
             summary={bulkSummary}
             onClose={() => setBulkSummary(null)}
+          />
+          <VoiceResultModal
+            open={!!voiceModal}
+            command={voiceModal?.command}
+            result={voiceModal?.result}
+            onClose={() => setVoiceModal(null)}
+          />
+          <ExplanationModal
+            open={!!explainModal}
+            invoice={explainModal?.invoice}
+            explanation={explainModal?.explanation}
+            score={explainModal?.score}
+            onClose={() => setExplainModal(null)}
           />
           <Joyride
             steps={tourSteps}

--- a/frontend/src/components/ExplanationModal.js
+++ b/frontend/src/components/ExplanationModal.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function ExplanationModal({ open, invoice, explanation, score, onClose }) {
+  if (!open || !invoice) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-96 max-w-full">
+        <h2 className="text-lg font-semibold mb-2">Invoice #{invoice.invoice_number}</h2>
+        <div className="text-sm whitespace-pre-wrap mb-2">{explanation}</div>
+        {score !== undefined && (
+          <div className="text-sm mb-2">Anomaly Score: {score}</div>
+        )}
+        <div className="flex justify-end">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-indigo-600 text-white text-sm">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FloatingActionPanel.js
+++ b/frontend/src/components/FloatingActionPanel.js
@@ -40,8 +40,8 @@ export default function FloatingActionPanel({ onUpload, onAsk, onVoice, onFeatur
         <button
           onClick={onVoice}
           className="p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white flex flex-col items-center"
-          title="Voice Upload"
-          aria-label="Voice upload"
+          title="Voice Command"
+          aria-label="Voice command"
         >
           <MicrophoneIcon className="w-6 h-6" />
           <span className="text-xs mt-1">Voice</span>

--- a/frontend/src/components/VoiceResultModal.js
+++ b/frontend/src/components/VoiceResultModal.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function VoiceResultModal({ open, command, result, onClose }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-96 max-w-full">
+        <h2 className="text-lg font-semibold mb-2">Voice Command</h2>
+        <div className="text-sm mb-2"><strong>You said:</strong> {command}</div>
+        <div className="text-sm whitespace-pre-wrap">{result}</div>
+        <div className="flex justify-end mt-2">
+          <button onClick={onClose} className="px-3 py-1 rounded bg-indigo-600 text-white text-sm">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement voice command modal using Web Speech API
- add invoice explanation modal per row
- enhance backend tag suggestions with simple keyword rules
- update floating action panel for voice commands

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_6856189a40b4832ebd5b48b69270135e