### PR TITLE
Allow configurable API base

### DIFF
--- a/frontend/src/AdaptiveDashboard.js
+++ b/frontend/src/AdaptiveDashboard.js
@@ -3,6 +3,7 @@ import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Toolti
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
 import VendorProfilePanel from './components/VendorProfilePanel';
+import { API_BASE } from './api';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
@@ -20,10 +21,10 @@ export default function AdaptiveDashboard() {
     const headers = { Authorization: `Bearer ${token}` };
     setLoading(true);
     Promise.all([
-      fetch('http://localhost:3000/api/analytics/metadata', { headers }).then(r => r.json()),
-      fetch('http://localhost:3000/api/invoices/top-vendors', { headers }).then(r => r.json()),
-      fetch('http://localhost:3000/api/invoices/cash-flow?interval=monthly', { headers }).then(r => r.json()),
-      fetch('http://localhost:3000/api/invoices/logs?limit=20', { headers }).then(r => r.json()),
+      fetch(`${API_BASE}/api/analytics/metadata`, { headers }).then(r => r.json()),
+      fetch(`${API_BASE}/api/invoices/top-vendors`, { headers }).then(r => r.json()),
+      fetch(`${API_BASE}/api/invoices/cash-flow?interval=monthly`, { headers }).then(r => r.json()),
+      fetch(`${API_BASE}/api/invoices/logs?limit=20`, { headers }).then(r => r.json()),
     ])
       .then(([m, v, c, l]) => {
         setMeta(m);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-use-before-define */
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { io } from 'socket.io-client';
+import { API_BASE } from './api';
 import LiveFeed from './components/LiveFeed';
 import Navbar from './components/Navbar';
 import SidebarNav from './components/SidebarNav';
@@ -118,7 +119,7 @@ const [role, setRole] = useState(localStorage.getItem('role') || '');
 const [loginError, setLoginError] = useState('');
 const [vendorSummary, setVendorSummary] = useState('');
 const [monthlyInsights, setMonthlyInsights] = useState(null);
-const socket = useMemo(() => io('http://localhost:3000'), []);
+const socket = useMemo(() => io(API_BASE), []);
   const [vendorSuggestions, setVendorSuggestions] = useState({});
   const [suspicionFlags] = useState({});
   const [duplicateFlags, setDuplicateFlags] = useState({});
@@ -501,6 +502,11 @@ const socket = useMemo(() => io('http://localhost:3000'), []);
   useEffect(() => {
     const orig = window.fetch;
     window.fetch = async (url, options = {}) => {
+      if (url.startsWith('http://localhost:3000')) {
+        url = url.replace('http://localhost:3000', API_BASE);
+      } else if (url.startsWith('/')) {
+        url = `${API_BASE}${url}`;
+      }
       const headers = { 'X-Tenant-Id': tenant, ...(options.headers || {}) };
       if (token && !headers.Authorization) {
         headers.Authorization = `Bearer ${token}`;

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 function Archive() {
   const token = localStorage.getItem('token') || '';
@@ -14,7 +15,7 @@ function Archive() {
   useEffect(() => {
     if (!token) return;
     setLoading(true);
-    fetch('http://localhost:3000/api/invoices?includeArchived=true', {
+    fetch(`${API_BASE}/api/invoices?includeArchived=true`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
@@ -43,7 +44,7 @@ function Archive() {
   });
 
   const handleRestore = async (id) => {
-    const res = await fetch(`http://localhost:3000/api/invoices/${id}/unarchive`, {
+    const res = await fetch(`${API_BASE}/api/invoices/${id}/unarchive`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${token}` },
     });

--- a/frontend/src/AuditDashboard.js
+++ b/frontend/src/AuditDashboard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
+import { API_BASE } from './api';
 
 export default function AuditDashboard() {
   const token = localStorage.getItem('token') || '';
@@ -20,7 +21,7 @@ export default function AuditDashboard() {
     if (action) params.append('action', action);
     if (start) params.append('start', start);
     if (end) params.append('end', end);
-    const res = await fetch(`http://localhost:3000/api/invoices/logs?${params.toString()}`, {
+    const res = await fetch(`${API_BASE}/api/invoices/logs?${params.toString()}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     const data = await res.json();

--- a/frontend/src/Board.js
+++ b/frontend/src/Board.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 export default function Board() {
   const token = localStorage.getItem('token') || '';
@@ -8,7 +9,7 @@ export default function Board() {
 
   const fetchData = useCallback(async () => {
     if (!token) return;
-    const res = await fetch('http://localhost:3000/api/invoices', {
+    const res = await fetch(`${API_BASE}/api/invoices`, {
       headers: { Authorization: `Bearer ${token}` }
     });
     const data = await res.json();
@@ -32,12 +33,12 @@ export default function Board() {
     let options = { method: 'PATCH', headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` } };
 
     if (destination.droppableId === 'approved') {
-      url = `http://localhost:3000/api/invoices/${id}/approve`;
+      url = `${API_BASE}/api/invoices/${id}/approve`;
     } else if (destination.droppableId === 'flagged') {
-      url = `http://localhost:3000/api/invoices/${id}/flag`;
+      url = `${API_BASE}/api/invoices/${id}/flag`;
       options.body = JSON.stringify({ flagged: true });
     } else if (destination.droppableId === 'pending') {
-      url = `http://localhost:3000/api/invoices/${id}/flag`;
+      url = `${API_BASE}/api/invoices/${id}/flag`;
       options.body = JSON.stringify({ flagged: false });
     }
     if (url) {

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -5,6 +5,7 @@ import Skeleton from './components/Skeleton';
 import EmptyState from './components/EmptyState';
 import VendorProfilePanel from './components/VendorProfilePanel';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
@@ -26,42 +27,42 @@ function Dashboard() {
     const headers = { Authorization: `Bearer ${token}` };
     setLoading(true);
     Promise.all([
-      fetch('http://localhost:3000/api/invoices/top-vendors', { headers })
+      fetch(`${API_BASE}/api/invoices/top-vendors`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setVendors(d.topVendors || []);
         }),
-      fetch('http://localhost:3000/api/invoices/spending-by-tag', { headers })
+      fetch(`${API_BASE}/api/invoices/spending-by-tag`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setCategories(d.byTag || []);
         }),
-      fetch('http://localhost:3000/api/invoices/cash-flow?interval=monthly', { headers })
+      fetch(`${API_BASE}/api/invoices/cash-flow?interval=monthly`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setCashFlow(d.data || []);
         }),
-      fetch('http://localhost:3000/api/invoices/anomalies', { headers })
+      fetch(`${API_BASE}/api/invoices/anomalies`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setAnomalies(d.anomalies || []);
         }),
-      fetch('http://localhost:3000/api/invoices/budgets/department-report', { headers })
+      fetch(`${API_BASE}/api/invoices/budgets/department-report`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setBudget(d.data || []);
         }),
-      fetch('http://localhost:3000/api/invoices/upload-heatmap', { headers })
+      fetch(`${API_BASE}/api/invoices/upload-heatmap`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setHeatmap(d.heatmap || []);
         }),
-      fetch('http://localhost:3000/api/invoices/quick-stats', { headers })
+      fetch(`${API_BASE}/api/invoices/quick-stats`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setStats(d);
         }),
-      fetch('http://localhost:3000/api/analytics/approvals/stats', { headers })
+      fetch(`${API_BASE}/api/analytics/approvals/stats`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
           if (ok) setApprovalStats(d);
@@ -71,7 +72,7 @@ function Dashboard() {
 
   const handleExportPDF = async () => {
     const headers = { Authorization: `Bearer ${token}` };
-    const res = await fetch('http://localhost:3000/api/invoices/dashboard/pdf', { headers });
+    const res = await fetch(`${API_BASE}/api/invoices/dashboard/pdf`, { headers });
     const blob = await res.blob();
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -83,7 +84,7 @@ function Dashboard() {
 
   const handleShare = async () => {
     const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-    const res = await fetch('http://localhost:3000/api/invoices/dashboard/share', { method: 'POST', headers, body: JSON.stringify({}) });
+    const res = await fetch(`${API_BASE}/api/invoices/dashboard/share`, { method: 'POST', headers, body: JSON.stringify({}) });
     if (res.ok) {
       const { url } = await res.json();
       const full = `http://localhost:3001/dashboard/shared/${url.split('/').pop()}`;

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
@@ -19,24 +20,24 @@ export default function DashboardBuilder() {
 
   useEffect(() => {
     const headers = { Authorization: `Bearer ${token}` };
-    fetch('http://localhost:3000/api/invoices/top-vendors', { headers })
+    fetch(`${API_BASE}/api/invoices/top-vendors`, { headers })
       .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
       .then(({ ok, d }) => {
         if (ok) setVendors(d.topVendors || []);
       })
       .catch(() => {});
-    fetch('http://localhost:3000/api/invoices/upload-heatmap', { headers })
+    fetch(`${API_BASE}/api/invoices/upload-heatmap`, { headers })
       .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
       .then(({ ok, d }) => {
         if (ok) setHeatmap(d.heatmap || []);
       })
       .catch(() => {});
-    fetch('http://localhost:3000/api/invoices')
+    fetch(`${API_BASE}/api/invoices`)
       .then((r) => r.json())
       .then((list) => {
         if (list && list[0]) {
           const id = list[0].id;
-          fetch(`http://localhost:3000/api/invoices/${id}/timeline`, { headers })
+          fetch(`${API_BASE}/api/invoices/${id}/timeline`, { headers })
             .then((res) => res.json())
             .then((data) => setTimeline(data))
             .catch(() => {});

--- a/frontend/src/FraudReport.js
+++ b/frontend/src/FraudReport.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 function FraudReport() {
   const token = localStorage.getItem('token') || '';

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,6 +1,7 @@
 // src/Login.js
 import React, { useState } from 'react';
 import { Card } from './components/ui/Card';
+import { API_BASE } from './api';
 
 export default function Login({ onLogin, addToast }) {
   const [username, setUsername] = useState('');
@@ -9,7 +10,7 @@ export default function Login({ onLogin, addToast }) {
 
   const handleLogin = async () => {
     try {
-      const res = await fetch('http://localhost:3000/api/invoices/login', {
+      const res = await fetch(`${API_BASE}/api/invoices/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/frontend/src/OnboardingWizard.js
+++ b/frontend/src/OnboardingWizard.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import MainLayout from './components/MainLayout';
 import { Button } from './components/ui/Button';
+import { API_BASE } from './api';
 
 export default function OnboardingWizard() {
   const token = localStorage.getItem('token') || '';
@@ -16,7 +17,7 @@ export default function OnboardingWizard() {
     const formData = new FormData();
     formData.append('invoiceFile', file);
     try {
-      const res = await fetch('http://localhost:3000/api/invoices/parse-sample', {
+      const res = await fetch(`${API_BASE}/api/invoices/parse-sample`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: formData,

--- a/frontend/src/Reports.js
+++ b/frontend/src/Reports.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 function Reports() {
   const token = localStorage.getItem('token') || '';
@@ -23,7 +24,7 @@ function Reports() {
     if (endDate) params.append('endDate', endDate);
     if (minAmount) params.append('minAmount', minAmount);
     if (maxAmount) params.append('maxAmount', maxAmount);
-    const res = await fetch(`http://localhost:3000/api/analytics/report?${params.toString()}`, {
+    const res = await fetch(`${API_BASE}/api/analytics/report?${params.toString()}`, {
       headers: { Authorization: `Bearer ${token}` }
     });
     const data = await res.json();
@@ -38,7 +39,7 @@ function Reports() {
     if (endDate) params.append('endDate', endDate);
     if (minAmount) params.append('minAmount', minAmount);
     if (maxAmount) params.append('maxAmount', maxAmount);
-    const res = await fetch(`http://localhost:3000/api/analytics/report/pdf?${params.toString()}`, {
+    const res = await fetch(`${API_BASE}/api/analytics/report/pdf?${params.toString()}`, {
       headers: { Authorization: `Bearer ${token}` }
     });
     const blob = await res.blob();
@@ -51,7 +52,7 @@ function Reports() {
   };
 
   const loadRules = useCallback(async () => {
-    const res = await fetch('http://localhost:3000/api/analytics/rules', {
+    const res = await fetch(`${API_BASE}/api/analytics/rules`, {
       headers: { Authorization: `Bearer ${token}` }
     });
     const data = await res.json();
@@ -60,7 +61,7 @@ function Reports() {
   }, [token]);
 
   const addAmountRule = async () => {
-    await fetch('http://localhost:3000/api/analytics/rules', {
+    await fetch(`${API_BASE}/api/analytics/rules`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({ amountGreaterThan: parseFloat(threshold), flagReason: `Amount over $${threshold}` })

--- a/frontend/src/SharedDashboard.js
+++ b/frontend/src/SharedDashboard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 function SharedDashboard() {
   const { token } = useParams();
@@ -9,7 +10,7 @@ function SharedDashboard() {
 
   useEffect(() => {
     setLoading(true);
-    fetch(`http://localhost:3000/api/invoices/dashboard/shared/${token}`)
+    fetch(`${API_BASE}/api/invoices/dashboard/shared/${token}`)
       .then((r) => r.json())
       .then((d) => setData(d))
       .catch(() => {})

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 function TeamManagement() {
   const token = localStorage.getItem('token') || '';
@@ -23,19 +24,19 @@ function TeamManagement() {
   );
 
   const fetchUsers = useCallback(async () => {
-    const res = await fetch('http://localhost:3000/api/users', { headers });
+    const res = await fetch(`${API_BASE}/api/users`, { headers });
     const data = await res.json();
     if (res.ok) setUsers(data);
   }, [headers]);
 
   const fetchLogs = useCallback(async () => {
-    const res = await fetch('http://localhost:3000/api/invoices/logs', { headers });
+    const res = await fetch(`${API_BASE}/api/invoices/logs`, { headers });
     const data = await res.json();
     if (res.ok) setLogs(data);
   }, [headers]);
 
   const fetchSettings = useCallback(async () => {
-    const res = await fetch('http://localhost:3000/api/settings', { headers });
+    const res = await fetch(`${API_BASE}/api/settings`, { headers });
     const data = await res.json();
     if (res.ok) {
       setAutoArchive(data.autoArchive);
@@ -54,7 +55,7 @@ function TeamManagement() {
   }, [fetchUsers, fetchLogs, fetchSettings, token]);
 
   const addUser = async () => {
-    await fetch('http://localhost:3000/api/users', {
+    await fetch(`${API_BASE}/api/users`, {
       method: 'POST',
       headers,
       body: JSON.stringify({ username, password, role: newRole })
@@ -66,12 +67,12 @@ function TeamManagement() {
   };
 
   const deleteUser = async (id) => {
-    await fetch(`http://localhost:3000/api/users/${id}`, { method: 'DELETE', headers });
+    await fetch(`${API_BASE}/api/users/${id}`, { method: 'DELETE', headers });
     fetchUsers();
   };
 
   const changeRole = async (id, role) => {
-    await fetch(`http://localhost:3000/api/users/${id}/role`, {
+    await fetch(`${API_BASE}/api/users/${id}/role`, {
       method: 'PATCH',
       headers,
       body: JSON.stringify({ role })
@@ -80,7 +81,7 @@ function TeamManagement() {
   };
 
   const saveSettings = async () => {
-    await fetch('http://localhost:3000/api/settings', {
+    await fetch(`${API_BASE}/api/settings`, {
       method: 'PATCH',
       headers,
       body: JSON.stringify({

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import { API_BASE } from './api';
 
 function VendorManagement() {
   const token = localStorage.getItem('token') || '';
@@ -15,7 +16,7 @@ function VendorManagement() {
 
   const fetchVendors = useCallback(async () => {
     setLoading(true);
-    const res = await fetch('http://localhost:3000/api/vendors', { headers });
+    const res = await fetch(`${API_BASE}/api/vendors`, { headers });
     const data = await res.json();
     if (res.ok) setVendors(data.vendors || []);
     setLoading(false);
@@ -25,7 +26,7 @@ function VendorManagement() {
 
   const saveNotes = async (vendor) => {
     const notes = notesInput[vendor] ?? '';
-    await fetch(`http://localhost:3000/api/vendors/${encodeURIComponent(vendor)}/notes`, {
+    await fetch(`${API_BASE}/api/vendors/${encodeURIComponent(vendor)}/notes`, {
       method: 'PATCH',
       headers,
       body: JSON.stringify({ notes })

--- a/frontend/src/WorkflowBuilderPage.js
+++ b/frontend/src/WorkflowBuilderPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_BASE } from './api';
 import WorkflowBuilder from './components/WorkflowBuilder';
 import RuleBuilder from './components/RuleBuilder';
 import ExpressionBuilder from './components/ExpressionBuilder';
@@ -19,7 +20,7 @@ export default function WorkflowBuilderPage() {
   const [expression, setExpression] = useState([]);
 
   useEffect(() => {
-    fetch('http://localhost:3000/api/workflows', {
+    fetch(`${API_BASE}/api/workflows`, {
       headers: { Authorization: `Bearer ${token}` },
     })
       .then((r) => r.json())
@@ -31,7 +32,7 @@ export default function WorkflowBuilderPage() {
 
   const save = async (newSteps) => {
     setSteps(newSteps);
-    await fetch('http://localhost:3000/api/workflows', {
+    await fetch(`${API_BASE}/api/workflows`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -51,7 +52,7 @@ export default function WorkflowBuilderPage() {
     expression.forEach((c) => {
       payload[c.field] = c.value;
     });
-    const resp = await fetch('http://localhost:3000/api/workflows/evaluate', {
+    const resp = await fetch(`${API_BASE}/api/workflows/evaluate`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/WorkflowPage.js
+++ b/frontend/src/WorkflowPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_BASE } from './api';
 import WorkflowBuilder from './components/WorkflowBuilder';
 import RuleBuilder from './components/RuleBuilder';
 import MainLayout from './components/MainLayout';
@@ -17,7 +18,7 @@ export default function WorkflowPage() {
   });
 
   useEffect(() => {
-    fetch('http://localhost:3000/api/workflows', {
+    fetch(`${API_BASE}/api/workflows`, {
       headers: { Authorization: `Bearer ${token}` }
     }).then(r => r.json()).then(d => {
       if (d.workflows && d.workflows[0]) setSteps(d.workflows[0].approval_chain);
@@ -26,7 +27,7 @@ export default function WorkflowPage() {
 
   const save = async (newSteps) => {
     setSteps(newSteps);
-    await fetch('http://localhost:3000/api/workflows', {
+    await fetch(`${API_BASE}/api/workflows`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,1 @@
+export const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3000';

--- a/frontend/src/components/FeatureWidget.js
+++ b/frontend/src/components/FeatureWidget.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { LightBulbIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { API_BASE } from '../api';
 
 export default function FeatureWidget({ open, onClose }) {
   const [text, setText] = useState('');

--- a/frontend/src/components/FeedbackButtons.js
+++ b/frontend/src/components/FeedbackButtons.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { HandThumbUpIcon, HandThumbDownIcon } from '@heroicons/react/24/outline';
+import { API_BASE } from '../api';
 
 export default function FeedbackButtons({ endpoint }) {
   const [rating, setRating] = useState(0);

--- a/frontend/src/components/GraphView.js
+++ b/frontend/src/components/GraphView.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import ForceGraph2D from 'react-force-graph-2d';
+import { API_BASE } from '../api';
 
 const GraphView = ({ token, tenant }) => {
   const [data, setData] = useState({ nodes: [], links: [] });

--- a/frontend/src/components/HelpTooltip.js
+++ b/frontend/src/components/HelpTooltip.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { API_BASE } from '../api';
 
 export default function HelpTooltip({ topic, token }) {
   const [guide, setGuide] = useState('');

--- a/frontend/src/components/InvoiceDetailModal.js
+++ b/frontend/src/components/InvoiceDetailModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import TagEditor from './TagEditor';
+import { API_BASE } from '../api';
 
 export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate, token }) {
   const [editMode, setEditMode] = useState(false);

--- a/frontend/src/components/LiveFeed.js
+++ b/frontend/src/components/LiveFeed.js
@@ -1,9 +1,10 @@
 import { useEffect, useState, useMemo } from 'react';
 import { io } from 'socket.io-client';
+import { API_BASE } from '../api';
 
 export default function LiveFeed({ token, tenant }) {
   const [logs, setLogs] = useState([]);
-  const socket = useMemo(() => io('http://localhost:3000'), []);
+  const socket = useMemo(() => io(API_BASE), []);
 
   useEffect(() => {
     let isMounted = true;

--- a/frontend/src/components/VendorProfilePanel.js
+++ b/frontend/src/components/VendorProfilePanel.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { API_BASE } from '../api';
 
 export default function VendorProfilePanel({ vendor, open, onClose, token }) {
   const [history, setHistory] = useState([]);

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -23,6 +23,20 @@ import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
 import './i18n';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
+import { API_BASE } from './api';
+
+// Global fetch wrapper to route API requests to configured backend
+const originalFetch = window.fetch;
+window.fetch = async (url, options) => {
+  if (typeof url === 'string') {
+    if (url.startsWith('http://localhost:3000')) {
+      url = url.replace('http://localhost:3000', API_BASE);
+    } else if (url.startsWith('/')) {
+      url = `${API_BASE}${url}`;
+    }
+  }
+  return originalFetch(url, options);
+};
 
 const currentTenant = localStorage.getItem('tenant') || 'default';
 const savedTheme = localStorage.getItem(`themeMode_${currentTenant}`);
@@ -34,9 +48,8 @@ if (savedAccent) document.documentElement.style.setProperty('--accent-color', sa
 const savedFont = localStorage.getItem(`fontFamily_${currentTenant}`);
 if (savedFont) document.documentElement.style.setProperty('--font-base', savedFont);
 
-const apiBase = process.env.REACT_APP_API_BASE_URL || '';
-if (apiBase) {
-  fetch(`${apiBase}/api/invoices`).catch((err) => {
+if (API_BASE) {
+  fetch(`${API_BASE}/api/invoices`).catch((err) => {
     console.error('API connection failed', err);
   });
 }


### PR DESCRIPTION
## Summary
- add `API_BASE` constant for configurable backend URL
- hook global `fetch` to rewrite requests to `API_BASE`
- use `API_BASE` for socket connection and some calls

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dbfc0034832e9ad6054290731da0