### PR TITLE
Add multi-step upload wizard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm install --legacy-peer-deps
 - Smart reminders for overdue invoices and pending approvals (email, Slack/Teams & in-app)
 - Batch actions with bulk approval and PDF export
 - Bulk edit/delete/archive options for faster table management
+- Multi-step upload wizard guides file selection, review, tagging and final confirmation
 - AI explanations for why an invoice was flagged
 - Admin settings panel with auto-archive toggle, custom AI tone and upload limits
 - Invoice expiration auto-closes past-due invoices or flags them for review

--- a/frontend/src/UploadWizard.js
+++ b/frontend/src/UploadWizard.js
@@ -1,0 +1,174 @@
+import React, { useState, useEffect } from 'react';
+import MainLayout from './components/MainLayout';
+import PreviewModal from './components/PreviewModal';
+import TagEditor from './components/TagEditor';
+import SuggestionChips from './components/SuggestionChips';
+import { Button } from './components/ui/Button';
+import ProgressBar from './components/ProgressBar';
+import { API_BASE } from './api';
+
+export default function UploadWizard() {
+  const token = localStorage.getItem('token') || '';
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState(null);
+  const [rows, setRows] = useState([]);
+  const [headers, setHeaders] = useState([]);
+  const [errors, setErrors] = useState([]);
+  const [previewModal, setPreviewModal] = useState(false);
+  const [tagSuggestions, setTagSuggestions] = useState({});
+  const [uploading, setUploading] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const required = ['invoice_number', 'date', 'amount', 'vendor'];
+
+  const parseCSV = async (fileObj) => {
+    const text = await fileObj.text();
+    const lines = text.trim().split(/\r?\n/);
+    const heads = lines[0].split(',').map(h => h.trim());
+    setHeaders(heads);
+    const missing = required.filter(h => !heads.includes(h));
+    if (missing.length) setErrors([`Missing: ${missing.join(', ')}`]);
+    const parsedRows = lines.slice(1).map(l => {
+      const vals = l.split(',');
+      const obj = {};
+      heads.forEach((h, idx) => { obj[h] = vals[idx] || ''; });
+      return obj;
+    });
+    setRows(parsedRows);
+  };
+
+  const handleFile = (f) => {
+    setErrors([]);
+    setFile(f);
+    parseCSV(f);
+  };
+
+  const handleSuggest = async (rowIdx) => {
+    const invoice = rows[rowIdx];
+    try {
+      const res = await fetch(`${API_BASE}/api/invoices/suggest-tags`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ invoice })
+      });
+      const data = await res.json();
+      if (res.ok && data.tags) {
+        setTagSuggestions(prev => ({ ...prev, [rowIdx]: data.tags }));
+      }
+    } catch (e) {
+      console.error('Suggest tags failed', e);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    const csv = [headers.join(',')].concat(rows.map(r => headers.map(h => r[h]).join(','))).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const formData = new FormData();
+    formData.append('invoiceFile', blob, file.name);
+    setUploading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/invoices/upload`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData,
+      });
+      await res.json();
+    } catch (e) {
+      console.error('Upload failed', e);
+    } finally {
+      setUploading(false);
+      setUploadProgress(100);
+    }
+  };
+
+  const totalAmount = rows.reduce((s, r) => s + parseFloat(r.amount || 0), 0);
+
+  useEffect(() => {
+    if (step === 3) {
+      rows.forEach((_, idx) => handleSuggest(idx));
+    }
+  }, [step]);
+
+  return (
+    <MainLayout title="Upload Wizard">
+      <div className="max-w-3xl mx-auto space-y-6">
+        {step === 1 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <h2 className="text-lg font-semibold">1. Select File</h2>
+            <input type="file" accept=".csv" onChange={e => handleFile(e.target.files[0])} />
+            {file && (
+              <Button onClick={() => setPreviewModal(true)} variant="secondary">Preview</Button>
+            )}
+            {errors.length > 0 && <ul className="text-red-600 text-sm list-disc list-inside">{errors.map((e,i)=><li key={i}>{e}</li>)}</ul>}
+            {file && <Button onClick={() => setStep(2)}>Next</Button>}
+          </div>
+        )}
+
+        {step === 2 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <h2 className="text-lg font-semibold">2. Review Data</h2>
+            <div className="overflow-x-auto">
+              <table className="table-auto text-xs w-full">
+                <thead>
+                  <tr>{headers.map(h => <th key={h} className="border px-1 py-0.5 text-left">{h}</th>)}</tr>
+                </thead>
+                <tbody>
+                  {rows.map((row, ri) => (
+                    <tr key={ri}>
+                      {headers.map(h => (
+                        <td key={h} className="border px-1 py-0.5">
+                          <input
+                            className="input text-xs w-full"
+                            value={row[h]}
+                            onChange={e => {
+                              const val = e.target.value;
+                              setRows(prev => prev.map((r,i)=> i===ri ? { ...r, [h]: val } : r));
+                            }}
+                          />
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <Button onClick={() => setStep(3)}>Next</Button>
+          </div>
+        )}
+
+        {step === 3 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow">
+            <h2 className="text-lg font-semibold">3. Tag & Categorize</h2>
+            {rows.map((row, ri) => (
+              <div key={ri} className="border p-2 rounded mb-2">
+                <div className="text-sm mb-1 font-medium">Row {ri + 1}</div>
+                <TagEditor
+                  tags={row.tags || []}
+                  onAddTag={t => setRows(prev => prev.map((r,i)=> i===ri ? { ...r, tags: [...(r.tags||[]), t] } : r))}
+                  onRemoveTag={t => setRows(prev => prev.map((r,i)=> i===ri ? { ...r, tags: (r.tags||[]).filter(x=>x!==t) } : r))}
+                />
+                <SuggestionChips suggestions={tagSuggestions[ri] || []} onClick={tag => setRows(prev => prev.map((r,i)=> i===ri ? { ...r, tags: [...(r.tags||[]), tag] } : r))} />
+              </div>
+            ))}
+            <Button onClick={() => setStep(4)}>Next</Button>
+          </div>
+        )}
+
+        {step === 4 && (
+          <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow text-center">
+            <h2 className="text-lg font-semibold">4. Finalize Upload</h2>
+            <p className="text-sm">{rows.length} invoices, total ${totalAmount.toFixed(2)}</p>
+            {uploading && <ProgressBar value={uploadProgress} />}
+            <Button onClick={handleUpload} disabled={uploading}>{uploading ? 'Uploading...' : 'Upload'}</Button>
+          </div>
+        )}
+
+        <PreviewModal
+          open={previewModal}
+          data={file ? { name: file.name, preview: [headers, ...rows.slice(0,5).map(r => headers.map(h => r[h]))] } : null }
+          onClose={() => setPreviewModal(false)}
+        />
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -18,6 +18,7 @@ import Board from './Board';
 import NotFound from './NotFound';
 import LandingPage from './LandingPage';
 import OnboardingWizard from './OnboardingWizard';
+import UploadWizard from './UploadWizard';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
@@ -102,6 +103,7 @@ function AnimatedRoutes() {
         <Route path="/board" element={<PageWrapper><Board /></PageWrapper>} />
         <Route path="/builder" element={<PageWrapper><DashboardBuilder /></PageWrapper>} />
         <Route path="/export-builder" element={<PageWrapper><ExportTemplateBuilder /></PageWrapper>} />
+        <Route path="/upload-wizard" element={<PageWrapper><UploadWizard /></PageWrapper>} />
         <Route path="/onboarding" element={<PageWrapper><OnboardingWizard /></PageWrapper>} />
         <Route path="/" element={<PageWrapper><LandingPage /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- implement `UploadWizard` component for guided uploads
- register `/upload-wizard` route
- document wizard feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a048e4a70832e85dd628a105058fe