### PR TITLE
Add manual approval reminders + improved landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ npm install --legacy-peer-deps
 - Shared comment threads for team discussion
 - Approver reminders with escalation
 - Smart reminders for overdue invoices and pending approvals (email, Slack/Teams & in-app)
+- Manual approval reminder emails can be triggered via `POST /api/reminders/approval`
 - Batch actions with bulk approval and PDF export
 - Bulk edit/delete/archive options for faster table management
 - Multi-step upload wizard guides file selection, review, tagging and final confirmation

--- a/backend/app.js
+++ b/backend/app.js
@@ -23,9 +23,10 @@ const poRoutes = require('./routes/poRoutes');
 const integrationRoutes = require('./routes/integrationRoutes');
 const featureRoutes = require('./routes/featureRoutes');
 const notificationRoutes = require('./routes/notificationRoutes');
+const reminderRoutes = require('./routes/reminderRoutes');
 const { runRecurringInvoices } = require('./controllers/recurringController');
 const { processFailedPayments, sendPaymentReminders } = require('./controllers/paymentController');
-const { sendApprovalReminders } = require('./controllers/reminderController');
+const { sendApprovalReminders } = require('./controllers/reminderController'); // used for optional manual trigger
 const { autoArchiveOldInvoices, autoDeleteExpiredInvoices, autoCloseExpiredInvoices } = require('./controllers/invoiceController');
 const { initDb } = require('./utils/dbInit');
 const { initChat } = require('./utils/chatServer');
@@ -60,6 +61,7 @@ app.use('/api/recurring', recurringRoutes);
 app.use('/api/integrations', integrationRoutes);
 app.use('/api/features', featureRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api/reminders', reminderRoutes);
 
 app.use(Sentry.Handlers.errorHandler());
 
@@ -83,8 +85,6 @@ app.use(Sentry.Handlers.errorHandler());
   setInterval(processFailedPayments, 60 * 60 * 1000);
   sendPaymentReminders();
   setInterval(sendPaymentReminders, 24 * 60 * 60 * 1000);
-  sendApprovalReminders();
-  setInterval(sendApprovalReminders, 24 * 60 * 60 * 1000);
 
   console.log('🟢 Routes mounted');
 

--- a/backend/routes/reminderRoutes.js
+++ b/backend/routes/reminderRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const { sendApprovalReminders } = require('../controllers/reminderController');
+const { authMiddleware, authorizeRoles } = require('../controllers/userController');
+
+router.post('/approval', authMiddleware, authorizeRoles('admin','approver'), async (req, res) => {
+  try {
+    await sendApprovalReminders();
+    res.json({ message: 'Approval reminders sent' });
+  } catch (err) {
+    console.error('Approval reminders error:', err);
+    res.status(500).json({ message: 'Failed to send reminders' });
+  }
+});
+
+module.exports = router;

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -93,6 +93,13 @@ function Dashboard() {
     }
   };
 
+  const handleApprovalReminders = async () => {
+    if (!stats?.invoicesPending) return;
+    const headers = { Authorization: `Bearer ${token}` };
+    await fetch(`${API_BASE}/api/reminders/approval`, { method: 'POST', headers });
+    alert('Approval reminder emails sent');
+  };
+
   const grid = Array.from({ length: 7 }, () => Array(24).fill(0));
   let max = 0;
   heatmap.forEach(({ day, hour, count }) => {
@@ -102,9 +109,14 @@ function Dashboard() {
 
   return (
     <MainLayout title="AI Dashboard">
-      <div className="mb-4 text-right">
-        <button onClick={handleExportPDF} className="underline mr-2">Export PDF</button>
+      <div className="mb-4 text-right space-x-2">
+        <button onClick={handleExportPDF} className="underline">Export PDF</button>
         <button onClick={handleShare} className="underline">Share Link</button>
+        {stats?.invoicesPending > 0 && (
+          <button onClick={handleApprovalReminders} className="underline">
+            Send Approval Reminders
+          </button>
+        )}
       </div>
       {!token ? (
         <p className="text-center text-gray-600">Please log in from the main app.</p>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -32,11 +32,11 @@ export default function LandingPage() {
         </div>
       </nav>
       <header className="flex-1 flex flex-col items-center justify-center text-center px-6 py-12">
-        <h1 className="text-4xl md:text-5xl font-extrabold mb-4 mt-6">Automate Your Invoice Processing</h1>
-        <p className="text-lg mb-8 max-w-2xl">AI-driven tools to upload, validate, and analyze invoices instantly.</p>
+        <h1 className="text-4xl md:text-5xl font-extrabold mb-4 mt-6">Streamline Accounts Payable with AI</h1>
+        <p className="text-lg mb-8 max-w-2xl">Upload invoices, validate details and uncover insights—all in one intuitive platform.</p>
         <div className="w-full max-w-3xl mb-8">
           <video
-            src="https://www.w3schools.com/html/mov_bbb.mp4"
+            src="https://samplelib.com/lib/preview/mp4/sample-20s.mp4"
             autoPlay
             muted
             loop


### PR DESCRIPTION
## Summary
- add `/api/reminders/approval` endpoint and wire it into server
- remove automatic approval reminder emails
- expose new reminder button on Dashboard when invoices pending
- tweak landing page copy and replace placeholder video
- document manual approval reminder endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685a07a1a244832ebf380e8d24538ce5