### PR TITLE
Add inbox queue and notification enhancements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@ SENTRY_DSN=
 # Webhook URLs for notifications
 SLACK_WEBHOOK_URL=
 TEAMS_WEBHOOK_URL=
+# Twilio SMS settings
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=
 # External risk scoring service
 RISK_SCORE_URL=
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ cd backend
 npm install
 cp .env.example .env   # Make sure to add your DATABASE_URL and OPENAI_API_KEY
 # Optional: adjust DUE_REMINDER_DAYS and APPROVAL_REMINDER_DAYS in .env to tweak reminder timing
+# Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER if you want SMS alerts
 npm start
 ```
 
@@ -272,6 +273,7 @@ as "Marketing", "Legal", or "Recurring" when no rule matches.
 The `/workflow-builder` page lets admins design approval chains and rules with an
 interactive expression builder. Test expressions are sent to `POST /api/workflows/evaluate`
 to see how rules would route a sample invoice.
+The `/inbox` page shows newly uploaded invoices waiting for approval.
 - `GET /api/invoices/fraud/flagged` – list flagged invoices with reasons
 - `GET /api/invoices/:id/timeline` – view a timeline of state changes for an invoice
 - `GET /api/:tenantId/export-templates` – list saved CSV templates

--- a/backend/controllers/workflowRulesController.js
+++ b/backend/controllers/workflowRulesController.js
@@ -18,6 +18,8 @@ exports.addWorkflowRule = async (req, res) => {
     assign_approver,
     approval_chain,
     alert_message,
+    alert_email,
+    alert_phone,
     priority,
     active,
   } = req.body || {};
@@ -29,8 +31,9 @@ exports.addWorkflowRule = async (req, res) => {
     const result = await pool.query(
       `INSERT INTO workflow_rules (
         vendor, amount_greater_than, route_to_department,
-        assign_approver, approval_chain, alert_message, priority, active
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8,TRUE)) RETURNING *`,
+        assign_approver, approval_chain, alert_message, alert_email, alert_phone,
+        priority, active
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,COALESCE($10,TRUE)) RETURNING *`,
       [
         vendor || null,
         amount_greater_than || null,
@@ -38,6 +41,8 @@ exports.addWorkflowRule = async (req, res) => {
         assign_approver || null,
         approval_chain ? JSON.stringify(approval_chain) : null,
         alert_message || null,
+        alert_email || null,
+        alert_phone || null,
         priority || 0,
         active,
       ]
@@ -58,6 +63,8 @@ exports.updateWorkflowRule = async (req, res) => {
     assign_approver,
     approval_chain,
     alert_message,
+    alert_email,
+    alert_phone,
     priority,
     active,
   } = req.body || {};
@@ -70,9 +77,11 @@ exports.updateWorkflowRule = async (req, res) => {
         assign_approver = COALESCE($4, assign_approver),
         approval_chain = COALESCE($5, approval_chain),
         alert_message = COALESCE($6, alert_message),
-        priority = COALESCE($7, priority),
-        active = COALESCE($8, active)
-       WHERE id = $9 RETURNING *`,
+        alert_email = COALESCE($7, alert_email),
+        alert_phone = COALESCE($8, alert_phone),
+        priority = COALESCE($9, priority),
+        active = COALESCE($10, active)
+       WHERE id = $11 RETURNING *`,
       [
         vendor,
         amount_greater_than,
@@ -80,6 +89,8 @@ exports.updateWorkflowRule = async (req, res) => {
         assign_approver,
         approval_chain ? JSON.stringify(approval_chain) : null,
         alert_message,
+        alert_email,
+        alert_phone,
         priority,
         active,
         id,

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -170,10 +170,14 @@ async function initDb() {
       assign_approver TEXT,
       approval_chain JSONB,
       alert_message TEXT,
+      alert_email TEXT,
+      alert_phone TEXT,
       priority INTEGER DEFAULT 0,
       active BOOLEAN DEFAULT TRUE,
       created_at TIMESTAMP DEFAULT NOW()
     )`);
+    await pool.query("ALTER TABLE workflow_rules ADD COLUMN IF NOT EXISTS alert_email TEXT");
+    await pool.query("ALTER TABLE workflow_rules ADD COLUMN IF NOT EXISTS alert_phone TEXT");
 
     await pool.query(`CREATE TABLE IF NOT EXISTS workflow_evaluations (
       id SERIAL PRIMARY KEY,

--- a/backend/utils/notify.js
+++ b/backend/utils/notify.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { sendMail } = require('./email');
 
 exports.sendSlackNotification = async (message) => {
   if (!process.env.SLACK_WEBHOOK_URL) return;
@@ -15,5 +16,27 @@ exports.sendTeamsNotification = async (message) => {
     await axios.post(process.env.TEAMS_WEBHOOK_URL, { text: message });
   } catch (err) {
     console.error('Teams notification error:', err.message);
+  }
+};
+
+exports.sendEmailNotification = async (to, subject, message) => {
+  const recipient = to || process.env.EMAIL_TO;
+  if (!recipient) return;
+  try {
+    await sendMail({ to: recipient, subject: subject || 'Invoice Alert', text: message });
+  } catch (err) {
+    console.error('Email notification error:', err.message);
+  }
+};
+
+exports.sendSmsNotification = async (to, message) => {
+  const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER } = process.env;
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_FROM_NUMBER || !to) return;
+  const url = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`;
+  const payload = new URLSearchParams({ From: TWILIO_FROM_NUMBER, To: to, Body: message });
+  try {
+    await axios.post(url, payload, { auth: { username: TWILIO_ACCOUNT_SID, password: TWILIO_AUTH_TOKEN } });
+  } catch (err) {
+    console.error('SMS notification error:', err.message);
   }
 };

--- a/backend/utils/workflowRulesEngine.js
+++ b/backend/utils/workflowRulesEngine.js
@@ -1,5 +1,10 @@
 const pool = require('../config/db');
-const { sendSlackNotification, sendTeamsNotification } = require('./notify');
+const {
+  sendSlackNotification,
+  sendTeamsNotification,
+  sendEmailNotification,
+  sendSmsNotification,
+} = require('./notify');
 
 async function evaluateWorkflowRules(invoice) {
   try {
@@ -20,6 +25,8 @@ async function evaluateWorkflowRules(invoice) {
           const msg = rule.alert_message.replace('{invoice}', invoice.invoice_number || '');
           await sendSlackNotification?.(msg);
           await sendTeamsNotification?.(msg);
+          await sendEmailNotification?.(rule.alert_email, 'Workflow Alert', msg);
+          await sendSmsNotification?.(rule.alert_phone, msg);
         }
       }
     }

--- a/frontend/src/Inbox.js
+++ b/frontend/src/Inbox.js
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import MainLayout from './components/MainLayout';
+import Skeleton from './components/Skeleton';
+import { API_BASE } from './api';
+
+export default function Inbox() {
+  const token = localStorage.getItem('token') || '';
+  const tenant = localStorage.getItem('tenant') || 'default';
+  const [invoices, setInvoices] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const headers = { Authorization: `Bearer ${token}` };
+
+  const fetchInvoices = async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/${tenant}/invoices?status=Pending`, { headers });
+      const data = await res.json();
+      if (res.ok) setInvoices(data);
+    } catch (err) {
+      console.error('Inbox fetch error:', err);
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { fetchInvoices(); }, [token, tenant]);
+
+  const approve = async (id) => {
+    await fetch(`${API_BASE}/api/${tenant}/invoices/${id}/approve`, {
+      method: 'PATCH',
+      headers
+    }).catch(() => {});
+    fetchInvoices();
+  };
+
+  const reject = async (id) => {
+    await fetch(`${API_BASE}/api/${tenant}/invoices/${id}/reject`, {
+      method: 'PATCH',
+      headers
+    }).catch(() => {});
+    fetchInvoices();
+  };
+
+  return (
+    <MainLayout title="Inbox" helpTopic="inbox">
+      <div className="overflow-x-auto rounded-lg">
+      <table className="min-w-full text-sm border rounded-lg overflow-hidden">
+        <thead>
+          <tr className="bg-gray-200 dark:bg-gray-700">
+            <th className="px-2 py-1">#</th>
+            <th className="px-2 py-1">Vendor</th>
+            <th className="px-2 py-1">Amount</th>
+            <th className="px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {loading ? (
+            <tr>
+              <td colSpan="4" className="p-4"><Skeleton rows={5} height="h-4" /></td>
+            </tr>
+          ) : (
+            invoices.map(inv => (
+              <tr key={inv.id} className="border-t hover:bg-gray-100">
+                <td className="px-2 py-1">{inv.invoice_number}</td>
+                <td className="px-2 py-1">{inv.vendor}</td>
+                <td className="px-2 py-1">${inv.amount}</td>
+                <td className="px-2 py-1 space-x-1">
+                  <button onClick={() => approve(inv.id)} className="bg-green-600 text-white px-2 py-1 rounded text-xs">Approve</button>
+                  <button onClick={() => reject(inv.id)} className="bg-red-600 text-white px-2 py-1 rounded text-xs">Reject</button>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -11,6 +11,7 @@ import {
   Squares2X2Icon,
   ArchiveBoxIcon,
   FlagIcon,
+  InboxIcon,
 } from '@heroicons/react/24/outline';
 
 export default function SidebarNav({ notifications = [] }) {
@@ -50,6 +51,13 @@ export default function SidebarNav({ notifications = [] }) {
             >
               <DocumentIcon className="w-5 h-5" />
               <span>Invoices</span>
+            </Link>
+            <Link
+              to="/inbox"
+              className={`nav-link ${location.pathname === '/inbox' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700' : ''}`}
+            >
+              <InboxIcon className="w-5 h-5" />
+              <span>Inbox</span>
             </Link>
             <Link
               to="/vendors"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,6 +15,7 @@ import VendorManagement from './VendorManagement';
 import WorkflowPage from './WorkflowPage';
 import WorkflowBuilderPage from './WorkflowBuilderPage';
 import Board from './Board';
+import Inbox from './Inbox';
 import NotFound from './NotFound';
 import LandingPage from './LandingPage';
 import OnboardingWizard from './OnboardingWizard';
@@ -92,6 +93,7 @@ function AnimatedRoutes() {
         <Route path="/adaptive" element={<PageWrapper><AdaptiveDashboard /></PageWrapper>} />
         <Route path="/dashboard/shared/:token" element={<PageWrapper><SharedDashboard /></PageWrapper>} />
         <Route path="/invoices" element={<PageWrapper><App /></PageWrapper>} />
+        <Route path="/inbox" element={<PageWrapper><Inbox /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><Reports /></PageWrapper>} />
         <Route path="/audit" element={<PageWrapper><AuditDashboard /></PageWrapper>} />
         <Route path="/fraud" element={<PageWrapper><FraudReport /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- add Twilio variables to `.env.example`
- document SMS setup and new inbox page in README
- implement sendEmailNotification and sendSmsNotification helpers
- extend workflow rules for email/SMS alerts
- create `/inbox` page and route
- expose inbox link in sidebar navigation

## Testing
- `npm run lint` *(fails: No lint configured)*

------
https://chatgpt.com/codex/tasks/task_e_685a0b886c30832e9bd6f8ad06b2125b