### PR TITLE
Implement outside-click closing for menus

### DIFF
--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import TenantSwitcher from './TenantSwitcher';
 import NotificationBell from './NotificationBell';
@@ -6,6 +6,7 @@ import LanguageSelector from './LanguageSelector';
 import ThemePicker from './ThemePicker';
 import DarkModeToggle from './DarkModeToggle';
 import useDarkMode from '../hooks/useDarkMode';
+import useOutsideClick from '../hooks/useOutsideClick';
 import { useTranslation } from 'react-i18next';
 import {
   Bars3Icon,
@@ -39,6 +40,10 @@ export default function Navbar({
   const [userOpen, setUserOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const [darkMode, setDarkMode] = useDarkMode();
+  const menuRef = useRef(null);
+  const userRef = useRef(null);
+  useOutsideClick(menuRef, () => setMenuOpen(false));
+  useOutsideClick(userRef, () => setUserOpen(false));
   const { t } = useTranslation();
   const location = useLocation();
 
@@ -90,76 +95,82 @@ export default function Navbar({
           )}
           {token && (
             <>
-              <button
-                className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
-                onClick={() => setMenuOpen((o) => !o)}
-                title="Menu"
-                aria-label="Menu"
-              >
-                <Bars3Icon className="h-6 w-6" />
-              </button>
-              {menuOpen && (
-                <div className="absolute right-12 top-8 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 rounded shadow-lg w-40">
-                  <Link
-                    to="/dashboard"
-                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <HomeIcon className="h-5 w-5 mr-2" /> Dashboard
-                  </Link>
-                  <Link
-                    to="/analytics"
-                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <DocumentChartBarIcon className="h-5 w-5 mr-2" /> Analytics
-                  </Link>
-                  <Link
-                    to="/vendors"
-                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <UsersIcon className="h-5 w-5 mr-2" /> Vendors
-                  </Link>
-                  <Link
-                    to="/archive"
-                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <ArchiveBoxIcon className="h-5 w-5 mr-2" /> Archive
-                  </Link>
-                  <Link
-                    to="/board"
-                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <Squares2X2Icon className="h-5 w-5 mr-2" /> Board
-                  </Link>
-                  <Link
-                    to="/fraud"
-                    className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    <FlagIcon className="h-5 w-5 mr-2" /> Fraud
-                  </Link>
-                  {role === 'admin' && (
+              <div className="relative" ref={menuRef}>
+                <button
+                  className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
+                  onClick={() => setMenuOpen((o) => !o)}
+                  title="Menu"
+                  aria-label="Menu"
+                >
+                  <Bars3Icon className="h-6 w-6" />
+                </button>
+                {menuOpen && (
+                  <div className="absolute right-12 top-8 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 rounded shadow-lg w-40">
                     <Link
-                      to="/settings"
+                      to="/dashboard"
                       className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
                       onClick={() => setMenuOpen(false)}
                     >
-                      <UsersIcon className="h-5 w-5 mr-2" /> Settings
+                      <HomeIcon className="h-5 w-5 mr-2" /> Dashboard
                     </Link>
-                  )}
-                </div>
-              )}
-              <div className="relative" onMouseEnter={() => setHelpOpen(true)} onMouseLeave={() => setHelpOpen(false)}>
+                    <Link
+                      to="/analytics"
+                      className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      <DocumentChartBarIcon className="h-5 w-5 mr-2" /> Analytics
+                    </Link>
+                    <Link
+                      to="/vendors"
+                      className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      <UsersIcon className="h-5 w-5 mr-2" /> Vendors
+                    </Link>
+                    <Link
+                      to="/archive"
+                      className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      <ArchiveBoxIcon className="h-5 w-5 mr-2" /> Archive
+                    </Link>
+                    <Link
+                      to="/board"
+                      className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      <Squares2X2Icon className="h-5 w-5 mr-2" /> Board
+                    </Link>
+                    <Link
+                      to="/fraud"
+                      className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      <FlagIcon className="h-5 w-5 mr-2" /> Fraud
+                    </Link>
+                    {role === 'admin' && (
+                      <Link
+                        to="/settings"
+                        className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
+                        onClick={() => setMenuOpen(false)}
+                      >
+                        <UsersIcon className="h-5 w-5 mr-2" /> Settings
+                      </Link>
+                    )}
+                  </div>
+                )}
+              </div>
+              <div
+                className="relative"
+                onMouseEnter={() => setHelpOpen(true)}
+                onMouseLeave={() => setHelpOpen(false)}
+              >
                 <QuestionMarkCircleIcon className="h-6 w-6 cursor-help" />
                 {helpOpen && <HelpTooltip topic="dashboard" token={token} />}
               </div>
               <DarkModeToggle />
               <ThemePicker darkMode={darkMode} setDarkMode={setDarkMode} tenant={tenant} />
-              <div className="relative">
+              <div className="relative" ref={userRef}>
                 <button
                   onClick={() => setUserOpen((o) => !o)}
                   className="flex items-center space-x-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -1,7 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
+import useOutsideClick from '../hooks/useOutsideClick';
 
 export default function NotificationBell({ notifications = [], onOpen }) {
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  useOutsideClick(wrapperRef, () => setOpen(false));
   const unreadCount = notifications.filter((n) => !n.read).length;
 
   const handleToggle = () => {
@@ -10,7 +13,7 @@ export default function NotificationBell({ notifications = [], onOpen }) {
   };
 
   return (
-    <div className="relative">
+    <div className="relative" ref={wrapperRef}>
       <button
         className="text-xl focus:outline-none"
         onClick={handleToggle}

--- a/frontend/src/components/ThemePicker.js
+++ b/frontend/src/components/ThemePicker.js
@@ -1,8 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import useOutsideClick from '../hooks/useOutsideClick';
 import { PaintBrushIcon } from '@heroicons/react/24/outline';
 
 export default function ThemePicker({ darkMode, setDarkMode, tenant = 'default' }) {
   const [open, setOpen] = useState(false);
+  const wrapperRef = useRef(null);
+  useOutsideClick(wrapperRef, () => setOpen(false));
   const [mode, setMode] = useState(() => localStorage.getItem(`themeMode_${tenant}`) || (darkMode ? 'dark' : 'light'));
   const [accent, setAccent] = useState(() => localStorage.getItem(`accentColor_${tenant}`) || '#4f46e5');
   const [font, setFont] = useState(() => localStorage.getItem(`fontFamily_${tenant}`) || 'Inter');
@@ -43,7 +46,7 @@ export default function ThemePicker({ darkMode, setDarkMode, tenant = 'default' 
   }, [tenant]);
 
   return (
-    <div className="relative">
+    <div className="relative" ref={wrapperRef}>
       <button
         onClick={() => setOpen(o => !o)}
         className="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"

--- a/frontend/src/hooks/useOutsideClick.js
+++ b/frontend/src/hooks/useOutsideClick.js
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export default function useOutsideClick(ref, handler) {
+  useEffect(() => {
+    const listener = (event) => {
+      if (!ref.current || ref.current.contains(event.target)) {
+        return;
+      }
+      handler(event);
+    };
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+}


### PR DESCRIPTION
## Summary
- add `useOutsideClick` hook
- close NotificationBell, ThemePicker, navbar menus on outside click

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685a3d1515d0832eb2a16c8f4a9f5de7