### PR TITLE
Add security section and API docs

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -39,6 +39,8 @@ const { loadModel, trainFromCorrections } = require('./utils/ocrAgent');
 const { startEmailSync } = require('./utils/emailSync');
 const { loadSchedules } = require('./utils/automationScheduler');
 const { scheduleReports } = require('./utils/reportScheduler');
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./docs/swagger.json');
 
 const app = express();                      // create the app
 const server = http.createServer(app);
@@ -50,6 +52,7 @@ app.use(Sentry.Handlers.requestHandler());
 
 app.use(cors());
 app.use(express.json());                    // allow reading JSON data
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use(auditLog);
 app.use('/api/:tenantId/invoices', invoiceRoutes);
 app.use('/api/:tenantId/export-templates', exportTemplateRoutes);

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Invoice Uploader AI API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/{tenantId}/invoices": {
+      "get": {
+        "summary": "List invoices",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Array of invoices" }
+        }
+      }
+    },
+    "/api/{tenantId}/invoices/upload": {
+      "post": {
+        "summary": "Upload invoice",
+        "parameters": [
+          {
+            "name": "tenantId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": { "type": "string", "format": "binary" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Upload result" }
+        }
+      }
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,6 +37,7 @@
     "socket.io": "^4.8.1",
     "stripe": "^12.18.0",
     "telnet": "^0.0.1",
-    "tesseract.js": "^4.0.2"
+    "tesseract.js": "^4.0.2",
+    "swagger-ui-express": "^4.7.1"
   }
 }

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -21,6 +21,9 @@ import {
   ShieldExclamationIcon,
   LightBulbIcon,
   ArrowLongRightIcon,
+  ShieldCheckIcon,
+  GlobeAltIcon,
+  LockClosedIcon,
 } from '@heroicons/react/24/outline';
 import LanguageSelector from './components/LanguageSelector';
 import DarkModeToggle from './components/DarkModeToggle';
@@ -268,6 +271,31 @@ export default function LandingPage() {
         />
       </section>
       <section className="py-12 bg-gray-50 dark:bg-gray-800">
+        <h2 className="text-3xl font-bold text-center mb-8">Security &amp; Compliance</h2>
+        <div className="container mx-auto grid md:grid-cols-3 gap-8 px-6">
+          <Card className="text-center space-y-2">
+            <ShieldCheckIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
+            <h3 className="font-semibold">SOC2 Compliant</h3>
+          </Card>
+          <Card className="text-center space-y-2">
+            <GlobeAltIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
+            <h3 className="font-semibold">GDPR Ready</h3>
+          </Card>
+          <Card className="text-center space-y-2">
+            <LockClosedIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
+            <h3 className="font-semibold">SSL Encryption</h3>
+          </Card>
+        </div>
+        <p className="text-center mt-6 font-semibold text-indigo-600 dark:text-indigo-400">Bank-grade encryption</p>
+      </section>
+      <section className="py-12">
+        <h2 className="text-3xl font-bold text-center mb-8">Developers</h2>
+        <p className="text-center mb-4">Explore our API and build custom integrations.</p>
+        <div className="text-center">
+          <Link to="/api-docs" className="btn btn-primary text-lg px-8 py-3">View API Docs</Link>
+        </div>
+      </section>
+      <section className="py-12 bg-gray-50 dark:bg-gray-800">
         <h2 className="text-3xl font-bold text-center mb-8">Pricing</h2>
         <div className="container mx-auto grid md:grid-cols-3 gap-8 px-6">
           <Card className="text-center space-y-4">
@@ -316,6 +344,11 @@ export default function LandingPage() {
                 <Link to="/onboarding" className="hover:underline">
                   Sign Up
                 </Link>
+              </li>
+              <li>
+                <a href="/api-docs" className="hover:underline">
+                  API Docs
+                </a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- add Security & Compliance section to landing page
- add Developers section linking to `/api-docs`
- expose Swagger docs at `/api-docs`

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685a4b2dfe4c832e8ec5c6fecfde5301