### PR TITLE
Fix jsondiffpatch import error

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -34,6 +34,7 @@
         "pg": "^8.11.1",
         "socket.io": "^4.8.1",
         "stripe": "^12.18.0",
+        "swagger-ui-express": "^4.6.3",
         "telnet": "^0.0.1",
         "tesseract.js": "^4.0.2"
       },
@@ -87,6 +88,13 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
       "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sentry-internal/tracing": {
       "version": "7.120.3",
@@ -3207,6 +3215,30 @@
       },
       "engines": {
         "node": ">=12.*"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.25.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.25.2.tgz",
+      "integrity": "sha512-V4JyoygUe5nCbn7bAD0fVKSC0yNcL3ROIQtGC7M0NATKuyosCSmMU6T0yDZIIuGpSxjsjZh/D2Ejb8lnF2jjxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
+      "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.11.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar-stream": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -38,6 +38,6 @@
     "stripe": "^12.18.0",
     "telnet": "^0.0.1",
     "tesseract.js": "^4.0.2",
-    "swagger-ui-express": "^4.7.1"
+    "swagger-ui-express": "^4.6.3"
   }
 }

--- a/backend/utils/versionLogger.js
+++ b/backend/utils/versionLogger.js
@@ -1,9 +1,19 @@
 const pool = require('../config/db');
-const { diff } = require('jsondiffpatch');
+// jsondiffpatch is an ES module. Use dynamic import in CommonJS.
+
+let diff;
+
+async function getDiff() {
+  if (!diff) {
+    ({ diff } = await import('jsondiffpatch'));
+  }
+  return diff;
+}
 
 async function recordInvoiceVersion(invoiceId, oldInvoice, newInvoice, userId, username) {
   try {
-    const changes = diff(oldInvoice, newInvoice) || {};
+    const diffFn = await getDiff();
+    const changes = diffFn(oldInvoice, newInvoice) || {};
     await pool.query(
       'INSERT INTO invoice_versions (invoice_id, editor_id, editor_name, diff, snapshot) VALUES ($1,$2,$3,$4,$5)',
       [invoiceId, userId || null, username || null, changes, newInvoice]


### PR DESCRIPTION
## Summary
- handle jsondiffpatch as an ES module with dynamic import
- pin `swagger-ui-express` to a valid version

## Testing
- `npm run lint`
- `node -e "require('./utils/versionLogger'); console.log('loaded')"`

------
https://chatgpt.com/codex/tasks/task_e_685a56f1ed3c832e881734adb23605ba