### PR TITLE
Add interactive demo sandbox

### DIFF
--- a/frontend/public/demo.csv
+++ b/frontend/public/demo.csv
@@ -1,0 +1,5 @@
+invoice_number,date,amount,vendor
+INV-001,2025-05-01,150.00,Acme Corp
+INV-002,INVALID_DATE,200.50,Globex Inc
+INV-003,2025-05-03,abc123,Foo Ltd
+INV-004,2025-05-04,100.00,

--- a/frontend/src/DemoSandbox.js
+++ b/frontend/src/DemoSandbox.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from 'react';
+import ProgressBar from './components/ProgressBar';
+import { API_BASE } from './api';
+
+export default function DemoSandbox() {
+  const [csvText, setCsvText] = useState('');
+  const [step, setStep] = useState(1);
+  const [errors, setErrors] = useState([]);
+  const [summary, setSummary] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/demo.csv')
+      .then(res => res.text())
+      .then(setCsvText)
+      .catch(() => setCsvText(''));
+  }, []);
+
+  const parseAndSummarize = async () => {
+    setStep(2);
+    const lines = csvText.trim().split(/\r?\n/);
+    const heads = lines[0].split(',').map(h => h.trim());
+    const rows = lines.slice(1).map(l => {
+      const vals = l.split(',');
+      const obj = {};
+      heads.forEach((h, idx) => { obj[h] = vals[idx] || ''; });
+      return obj;
+    });
+    const errs = [];
+    rows.forEach((r, i) => {
+      if (!r.invoice_number) errs.push(`Row ${i + 1}: Missing invoice_number`);
+      if (!r.date) errs.push(`Row ${i + 1}: Missing date`);
+      else if (isNaN(Date.parse(r.date))) errs.push(`Row ${i + 1}: Date is not valid`);
+      if (!r.amount) errs.push(`Row ${i + 1}: Missing amount`);
+      else if (isNaN(parseFloat(r.amount))) errs.push(`Row ${i + 1}: Amount is not a number`);
+      if (!r.vendor) errs.push(`Row ${i + 1}: Missing vendor`);
+    });
+    setErrors(errs);
+    setLoading(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/invoices/summarize-errors`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ errors: errs })
+      });
+      const data = await res.json();
+      if (res.ok && data.summary) setSummary(data.summary);
+    } catch (e) {
+      setSummary('Failed to generate summary.');
+    } finally {
+      setLoading(false);
+      setStep(3);
+    }
+  };
+
+  return (
+    <div className="min-h-screen p-6 flex flex-col items-center bg-gradient-to-br from-purple-50 via-indigo-100 to-indigo-200 dark:from-purple-900 dark:via-indigo-900 dark:to-gray-900 text-gray-900 dark:text-gray-100">
+      <div className="max-w-2xl w-full space-y-6">
+        <h1 className="text-3xl font-bold text-center">Interactive Demo Sandbox</h1>
+        {step === 1 && (
+          <>
+            <p className="text-sm text-center">Preview of sample invoice CSV:</p>
+            <pre className="bg-white dark:bg-gray-800 p-4 rounded overflow-x-auto text-sm whitespace-pre-wrap">{csvText}</pre>
+            <div className="text-center">
+              <button className="btn btn-primary" onClick={parseAndSummarize}>See it in Action</button>
+            </div>
+          </>
+        )}
+        {step === 2 && (
+          <div className="space-y-4 text-center">
+            <p className="text-sm">Processing sample CSV...</p>
+            <ProgressBar value={loading ? 60 : 100} />
+          </div>
+        )}
+        {step === 3 && (
+          <div className="space-y-4">
+            <h2 className="text-lg font-semibold">AI Summary</h2>
+            <pre className="bg-white dark:bg-gray-800 p-4 rounded whitespace-pre-wrap text-sm">{summary}</pre>
+            <h3 className="font-semibold mt-4">Detected Issues</h3>
+            <ul className="list-disc list-inside text-sm space-y-1">
+              {errors.map((e, i) => (<li key={i}>{e}</li>))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -30,14 +30,12 @@ import LanguageSelector from './components/LanguageSelector';
 import DarkModeToggle from './components/DarkModeToggle';
 import Carousel from './components/Carousel';
 import { Card } from './components/ui/Card';
-import DemoUploadModal from './components/DemoUploadModal';
 import ProgressDashboard from './components/ProgressDashboard';
 import AiSearchDemo from './components/AiSearchDemo';
 import DummyDataButton from './components/DummyDataButton';
 
 export default function LandingPage() {
   const [authOpen, setAuthOpen] = useState(false);
-  const [demoOpen, setDemoOpen] = useState(false);
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-purple-50 via-indigo-100 to-indigo-200 dark:from-purple-900 dark:via-indigo-900 dark:to-gray-900 text-gray-900 dark:text-gray-100">
       <nav className="bg-indigo-700 text-white p-4 shadow">
@@ -106,12 +104,12 @@ export default function LandingPage() {
             </p>
             <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0">
               <Link to="/invoices" className="btn btn-primary text-lg px-8 py-3">Upload Invoice</Link>
-              <button
-                onClick={() => setDemoOpen(true)}
+              <Link
+                to="/sandbox"
                 className="btn btn-secondary text-lg px-8 py-3 flex items-center justify-center"
               >
-                Try Demo
-              </button>
+                See it in Action
+              </Link>
             </div>
             <div className="flex justify-center md:justify-start items-center gap-4 pt-4 opacity-80">
               <img src="https://dummyimage.com/120x60/000/fff.png&text=Client+1" alt="Client 1" className="h-8 object-contain" />
@@ -464,7 +462,6 @@ export default function LandingPage() {
           © {new Date().getFullYear()} Invoice Uploader AI
         </p>
       </footer>
-      <DemoUploadModal open={demoOpen} onClose={() => setDemoOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -21,6 +21,7 @@ import NotFound from './NotFound';
 import LandingPage from './LandingPage';
 import OnboardingWizard from './OnboardingWizard';
 import UploadWizard from './UploadWizard';
+import DemoSandbox from './DemoSandbox';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
@@ -109,6 +110,7 @@ function AnimatedRoutes() {
         <Route path="/export-builder" element={<PageWrapper><ExportTemplateBuilder /></PageWrapper>} />
         <Route path="/upload-wizard" element={<PageWrapper><UploadWizard /></PageWrapper>} />
         <Route path="/onboarding" element={<PageWrapper><OnboardingWizard /></PageWrapper>} />
+        <Route path="/sandbox" element={<PageWrapper><DemoSandbox /></PageWrapper>} />
         <Route path="/" element={<PageWrapper><LandingPage /></PageWrapper>} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>


### PR DESCRIPTION
## Summary
- add a `/sandbox` page showing a sample CSV walkthrough
- link landing page "See it in Action" button to the sandbox
- register sandbox route in React router
- include demo CSV data for the sandbox

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685b2f908e30832e933b23e75c4ea240