### PR TITLE
Enhance landing page with shadcn ui and mobile nav

### DIFF
--- a/frontend/src/Inbox.js
+++ b/frontend/src/Inbox.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
+import { motion } from 'framer-motion';
 import { API_BASE } from './api';
 
 export default function Inbox() {
@@ -42,6 +43,14 @@ export default function Inbox() {
     fetchInvoices();
   };
 
+  const archive = async (id) => {
+    await fetch(`${API_BASE}/api/${tenant}/invoices/${id}/archive`, {
+      method: 'PATCH',
+      headers,
+    }).catch(() => {});
+    fetchInvoices();
+  };
+
   return (
     <MainLayout title="Inbox" helpTopic="inbox">
       <div className="overflow-x-auto rounded-lg">
@@ -61,7 +70,16 @@ export default function Inbox() {
             </tr>
           ) : (
             invoices.map(inv => (
-              <tr key={inv.id} className="border-t hover:bg-gray-100">
+              <motion.tr
+                key={inv.id}
+                className="border-t hover:bg-gray-100"
+                drag="x"
+                dragConstraints={{ left: -120, right: 0 }}
+                onDragEnd={(e, info) => {
+                  if (info.offset.x < -100) archive(inv.id);
+                }}
+                whileDrag={{ scale: 1.02 }}
+              >
                 <td className="px-2 py-1">{inv.invoice_number}</td>
                 <td className="px-2 py-1">{inv.vendor}</td>
                 <td className="px-2 py-1">${inv.amount}</td>
@@ -69,7 +87,7 @@ export default function Inbox() {
                   <button onClick={() => approve(inv.id)} className="bg-green-600 text-white px-2 py-1 rounded text-xs">Approve</button>
                   <button onClick={() => reject(inv.id)} className="bg-red-600 text-white px-2 py-1 rounded text-xs">Reject</button>
                 </td>
-              </tr>
+              </motion.tr>
             ))
           )}
         </tbody>

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -26,6 +26,7 @@ import LanguageSelector from './components/LanguageSelector';
 import DarkModeToggle from './components/DarkModeToggle';
 import Carousel from './components/Carousel';
 import { Card } from './components/ui/Card';
+import { Button } from './components/ui/Button';
 import ProgressDashboard from './components/ProgressDashboard';
 import AiSearchDemo from './components/AiSearchDemo';
 import DummyDataButton from './components/DummyDataButton';
@@ -46,13 +47,14 @@ export default function LandingPage() {
           <div className="flex items-center space-x-2 relative">
             <LanguageSelector />
             <DarkModeToggle />
-            <button
+            <Button
+              variant="secondary"
+              className="bg-white text-indigo-700 hover:bg-gray-100 flex items-center"
               onClick={() => setAuthOpen(o => !o)}
-              className="btn btn-primary bg-white text-indigo-700 hover:bg-gray-100 flex items-center"
             >
               <span className="mr-1">Account</span>
               <ArrowRightOnRectangleIcon className="w-5 h-5" />
-            </button>
+            </Button>
             {authOpen && (
               <motion.div
                 initial={{ opacity: 0, y: -10 }}
@@ -102,13 +104,12 @@ export default function LandingPage() {
               Upload invoices, validate details and uncover insights—all in one intuitive platform.
             </p>
             <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-2 sm:space-y-0">
-              <Link to="/invoices" className="btn btn-primary text-lg px-8 py-3">Upload Invoice</Link>
-              <Link
-                to="/sandbox"
-                className="btn btn-secondary text-lg px-8 py-3 flex items-center justify-center"
-              >
-                See it in Action
-              </Link>
+              <Button asChild className="text-lg px-8 py-3">
+                <Link to="/invoices">Upload Invoice</Link>
+              </Button>
+              <Button asChild variant="secondary" className="text-lg px-8 py-3 flex items-center justify-center">
+                <Link to="/sandbox">See it in Action</Link>
+              </Button>
             </div>
             <PartnerLogos />
           </motion.div>
@@ -129,6 +130,7 @@ export default function LandingPage() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
+            whileHover={{ scale: 1.05 }}
           >
             <Card className="text-center space-y-2">
               <CheckCircleIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
@@ -141,6 +143,7 @@ export default function LandingPage() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
+            whileHover={{ scale: 1.05 }}
           >
             <Card className="text-center space-y-2">
               <ChartBarIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
@@ -153,6 +156,7 @@ export default function LandingPage() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.7 }}
+            whileHover={{ scale: 1.05 }}
           >
             <Card className="text-center space-y-2">
               <DocumentArrowUpIcon className="w-10 h-10 text-indigo-600 dark:text-indigo-400 mx-auto" />
@@ -264,7 +268,9 @@ export default function LandingPage() {
         <h2 className="text-3xl font-bold text-center mb-8">Developers</h2>
         <p className="text-center mb-4">Explore our API and build custom integrations.</p>
         <div className="text-center">
-          <Link to="/api-docs" className="btn btn-primary text-lg px-8 py-3">View API Docs</Link>
+          <Button asChild className="text-lg px-8 py-3">
+            <Link to="/api-docs">View API Docs</Link>
+          </Button>
         </div>
       </section>
       <section className="py-12 bg-gray-50 dark:bg-gray-800">
@@ -291,19 +297,25 @@ export default function LandingPage() {
             <h3 className="text-xl font-semibold">Free</h3>
             <p className="text-4xl font-bold">$0</p>
             <p className="text-sm">All core features for small teams.</p>
-            <Link to="/invoices" className="btn btn-primary">Get Started</Link>
+            <Button asChild>
+              <Link to="/invoices">Get Started</Link>
+            </Button>
           </Card>
           <Card className="text-center space-y-4">
             <h3 className="text-xl font-semibold">Pro</h3>
             <p className="text-4xl font-bold">$49</p>
             <p className="text-sm">Advanced analytics and priority support.</p>
-            <Link to="/invoices" className="btn btn-primary">Start Free Trial</Link>
+            <Button asChild>
+              <Link to="/invoices">Start Free Trial</Link>
+            </Button>
           </Card>
           <Card className="text-center space-y-4">
             <h3 className="text-xl font-semibold">Enterprise</h3>
             <p className="text-4xl font-bold">Contact us</p>
             <p className="text-sm">Custom integrations and onboarding.</p>
-            <Link to="/invoices" className="btn btn-primary">Contact Sales</Link>
+            <Button asChild>
+              <Link to="/invoices">Contact Sales</Link>
+            </Button>
           </Card>
         </div>
       </section>
@@ -398,10 +410,10 @@ export default function LandingPage() {
                 placeholder="you@example.com"
                 className="input flex-1 text-xs"
               />
-              <button className="btn btn-primary px-3 flex items-center" type="submit">
+              <Button type="submit" className="px-3 flex items-center">
                 <EnvelopeIcon className="w-4 h-4 mr-1" />
                 Sign Up
-              </button>
+              </Button>
             </form>
           </div>
         </div>

--- a/frontend/src/components/BottomNav.js
+++ b/frontend/src/components/BottomNav.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import {
+  HomeIcon,
+  DocumentIcon,
+  InboxIcon,
+  ArchiveBoxIcon,
+} from '@heroicons/react/24/outline';
+
+export default function BottomNav() {
+  const location = useLocation();
+  const items = [
+    { to: '/dashboard', icon: HomeIcon, label: 'Home' },
+    { to: '/invoices', icon: DocumentIcon, label: 'Invoices' },
+    { to: '/inbox', icon: InboxIcon, label: 'Inbox' },
+    { to: '/archive', icon: ArchiveBoxIcon, label: 'Archive' },
+  ];
+  return (
+    <nav className="sm:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t z-20">
+      <ul className="flex justify-around">
+        {items.map(({ to, icon: Icon, label }) => (
+          <li key={to} className="flex-1">
+            <motion.div whileHover={{ scale: 1.1 }} className="py-2">
+              <Link
+                to={to}
+                className={`flex flex-col items-center text-xs ${
+                  location.pathname === to ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-300'
+                }`}
+              >
+                <Icon className="w-5 h-5 mb-0.5" />
+                {label}
+              </Link>
+            </motion.div>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import SidebarNav from './SidebarNav';
 import TopNavbar from './TopNavbar';
+import BottomNav from './BottomNav';
 
 export default function MainLayout({ title, helpTopic, children }) {
   const [notifications] = React.useState(() => {
@@ -10,12 +11,13 @@ export default function MainLayout({ title, helpTopic, children }) {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
       <SidebarNav notifications={notifications} />
-      <div className="flex-1 pt-16">
+      <div className="flex-1 pt-16 pb-16 sm:pb-0">
         <TopNavbar title={title} helpTopic={helpTopic} />
         <div className="container mx-auto px-6 py-8">
           {children}
         </div>
       </div>
+      <BottomNav />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- use `shadcn/ui` Button on landing page calls to action
- add framer-motion hover animations to feature cards
- introduce `BottomNav` component for sticky mobile navigation
- support swipe-to-archive gesture in inbox list

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b3327839c832ebdf7df388cf549ac