### PR TITLE
Add feature comparison to landing page

### DIFF
--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -156,6 +156,77 @@ export default function LandingPage() {
           </motion.div>
         </div>
       </section>
+      <section className="py-12 bg-gray-50 dark:bg-gray-800">
+        <h2 className="text-3xl font-bold text-center mb-8">Why Teams Choose Us Over Other Tools</h2>
+        <div className="container mx-auto overflow-x-auto px-6">
+          <table className="min-w-full text-sm text-center">
+            <thead>
+              <tr>
+                <th className="border-b px-4 py-2 text-left">Feature</th>
+                <th className="border-b px-4 py-2">Invoice Uploader AI</th>
+                <th className="border-b px-4 py-2">Competitor A</th>
+                <th className="border-b px-4 py-2">Competitor B</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              <tr>
+                <td className="px-4 py-2 text-left">Upload CSV/PDF/Image</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">✅</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Natural Language Insights</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">❌</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">AI-generated Emails</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">✅</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Fraud Detection</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">❌</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Recurring Billing Automation</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">❌</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Audit Logs &amp; Scoring</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Workflow Builder</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">❌</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Slack/Teams Integration</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">✅</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-2 text-left">Whitelabel &amp; Multitenancy</td>
+                <td className="px-4 py-2">✅</td>
+                <td className="px-4 py-2">❌</td>
+                <td className="px-4 py-2">❌</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
       <section className="py-12">
         <h2 className="text-3xl font-bold text-center mb-8">
           Deep-Dive on Your Differentiators

--- a/frontend/src/components/PartnerLogos.js
+++ b/frontend/src/components/PartnerLogos.js
@@ -1,17 +1,24 @@
 import React from 'react';
 
 export default function PartnerLogos() {
-  const logos = [
-    'https://dummyimage.com/120x60/000/fff.png&text=Client+1',
-    'https://dummyimage.com/120x60/000/fff.png&text=Client+2',
-    'https://dummyimage.com/120x60/000/fff.png&text=Client+3',
-    'https://dummyimage.com/120x60/000/fff.png&text=Client+4',
-  ];
+  const companies = ['Contoso', 'NuBank', 'Globex', 'Initech'];
   return (
-    <div className="flex justify-center md:justify-start items-center gap-4 pt-4 opacity-80">
-      {logos.map((src, idx) => (
-        <img key={idx} src={src} alt={`Partner ${idx + 1}`} className="h-8 object-contain" />
-      ))}
+    <div className="pt-4 text-center md:text-left">
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-2 font-medium">
+        Used by FinOps teams at
+      </p>
+      <div className="flex justify-center md:justify-start items-center gap-4 opacity-80">
+        {companies.map((name, idx) => (
+          <img
+            key={idx}
+            src={`https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=${encodeURIComponent(
+              name
+            )}`}
+            alt={name}
+            className="h-8 object-contain rounded"
+          />
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update partner logos to show FinOps companies
- add a feature comparison table to the landing page

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b6c284858832eaa28919124358e00