### PR TITLE
Add self-healing imports and flag explain badge

### DIFF
--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -25,6 +25,7 @@ const { encrypt } = require('../utils/encryption');
 const levenshtein = require('fast-levenshtein');
 const { categorizeInvoice } = require('../utils/categorize');
 const { applyCorrections, loadCorrections } = require('../utils/parserTrainer');
+const { selfHealInvoices } = require('../utils/selfHeal');
 const { updateWeights } = require('../utils/parserTrainer');
 
 // Basic vendor -> tag mapping for quick suggestions
@@ -101,6 +102,7 @@ exports.parseInvoiceSample = async (req, res) => {
     }
 
     invoices = invoices.map(applyCorrections);
+    invoices = await selfHealInvoices(invoices);
 
     fs.unlinkSync(req.file.path);
     const invoice = invoices[0];
@@ -711,6 +713,7 @@ exports.importInvoicesCSV = async (req, res) => {
     } else {
       rows = await parseCSV(req.file.path);
     }
+    rows = await selfHealInvoices(rows);
     const encryptUploads = process.env.UPLOAD_ENCRYPTION_KEY && (req.body.encrypt === 'true' || req.headers['x-encrypt'] === 'true');
     const inserted = [];
     const totalRows = rows.length;

--- a/backend/utils/selfHeal.js
+++ b/backend/utils/selfHeal.js
@@ -1,0 +1,34 @@
+const openai = require('../config/openai');
+
+async function selfHealInvoices(invoices) {
+  if (!process.env.OPENROUTER_API_KEY) return invoices;
+  const healed = [];
+  for (const inv of invoices) {
+    if (inv.invoice_number && inv.date && inv.amount && inv.vendor) {
+      healed.push(inv);
+      continue;
+    }
+    try {
+      const prompt = `Fix this invoice JSON by filling missing invoice_number, date, amount or vendor if possible. Return JSON.\n\n${JSON.stringify(inv)}`;
+      const resp = await openai.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: 'You repair corrupted invoice data.' },
+          { role: 'user', content: prompt },
+        ],
+      });
+      const txt = resp.choices?.[0]?.message?.content?.trim();
+      try {
+        healed.push(JSON.parse(txt));
+      } catch {
+        healed.push(inv);
+      }
+    } catch (err) {
+      console.error('Self heal error:', err.response?.data || err.message);
+      healed.push(inv);
+    }
+  }
+  return healed;
+}
+
+module.exports = { selfHealInvoices };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -38,6 +38,7 @@ import ProgressBar from './components/ProgressBar';
 import FeatureWidget from './components/FeatureWidget';
 import VoiceResultModal from './components/VoiceResultModal';
 import ExplanationModal from './components/ExplanationModal';
+import FlaggedBadge from './components/FlaggedBadge';
 import { Button } from './components/ui/Button';
 import { Card } from './components/ui/Card';
 import { motion } from 'framer-motion';
@@ -2847,6 +2848,7 @@ useEffect(() => {
                           {duplicateFlags[inv.id] && (
                             <span title="Possible duplicate" className="text-yellow-500 text-[10px] font-semibold">⚠️</span>
                           )}
+                          {inv.flagged && <FlaggedBadge id={inv.id} />}
                         </div>
                       </div>
                     </td>
@@ -3175,7 +3177,7 @@ useEffect(() => {
                     }`}
                   >
                       <img src="/logo192.png" alt="preview" className="w-full h-32 object-contain rounded" />
-                      <div className="text-sm font-semibold">#{inv.invoice_number} {duplicateFlags[inv.id] && <span className="text-yellow-500">⚠️</span>}</div>
+                      <div className="text-sm font-semibold">#{inv.invoice_number} {duplicateFlags[inv.id] && <span className="text-yellow-500">⚠️</span>} {inv.flagged && <FlaggedBadge id={inv.id} />}</div>
                       <div className="text-sm">💰 {inv.amount}</div>
                       <div className="text-sm">📅 {new Date(inv.date).toLocaleDateString()}</div>
                       <div className="text-sm">🏢 {inv.vendor}

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import Skeleton from './components/Skeleton';
 import EmptyState from './components/EmptyState';
 import VendorProfilePanel from './components/VendorProfilePanel';
@@ -274,11 +274,21 @@ function Dashboard() {
           </div>
           <div>
             <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Unusual Invoice Spikes</h2>
-            <ul className="list-disc pl-5 text-gray-700 dark:text-gray-300">
-              {anomalies.map(a => (
-                <li key={a.vendor}>{a.vendor}: avg ${a.avg.toFixed(2)} last ${a.last.toFixed(2)}</li>
-              ))}
-            </ul>
+            {anomalies.length ? (
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart data={anomalies} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="vendor" />
+                  <YAxis />
+                  <Tooltip />
+                  <Legend />
+                  <Bar dataKey="avg" fill="#3b82f6" name="Avg" />
+                  <Bar dataKey="last" fill="#ef4444" name="Last" />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-sm text-gray-600">No anomalies detected</p>
+            )}
           </div>
           <div className="h-64">
             <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Budget vs Actual</h2>

--- a/frontend/src/components/FlaggedBadge.js
+++ b/frontend/src/components/FlaggedBadge.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import Tippy from '@tippyjs/react';
+import 'tippy.js/dist/tippy.css';
+import { API_BASE } from '../api';
+
+export default function FlaggedBadge({ id }) {
+  const token = localStorage.getItem('token') || '';
+  const [info, setInfo] = useState(null);
+
+  const loadInfo = async () => {
+    if (!token || info) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/invoices/${id}/flag-explanation`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      if (res.ok) setInfo(data);
+    } catch (err) {
+      console.error('Flag explanation load error:', err);
+    }
+  };
+
+  const content = info
+    ? `${info.explanation}${info.confidence !== undefined ? ` (Confidence: ${info.confidence})` : ''}`
+    : 'Loading...';
+
+  return (
+    <Tippy content={content} onShow={loadInfo} maxWidth={300}>
+      <span className="ml-1 text-red-600 border border-red-500 rounded px-1 text-[10px] cursor-help">Why?</span>
+    </Tippy>
+  );
+}


### PR DESCRIPTION
## Summary
- enable AI-based invoice healing during uploads and CSV imports
- expose flagged invoice reasoning via a hoverable badge
- visualize anomaly spikes with a bar chart on the dashboard

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b77ef0480832e9a578827ea2ccced