### PR TITLE
Add KPI analytics and risk visualizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ npm install --legacy-peer-deps
 - Analytics and reports page with filtering and PDF export
 - Trend reports for monthly spend and aging invoices
 - Customizable dashboards with date filters and export options
+- Custom KPI dashboards per department or vendor with charts like approval time by vendor, late payments trend and invoices over budget
 - Public shareable dashboards accessible via secure link
 - ML predictions highlight cash-flow problem areas
 - Private notes on invoices
@@ -88,6 +89,7 @@ npm install --legacy-peer-deps
 - Natural language invoice search
 - Hoverable vendor bios with website and industry info
 - AI fraud detection heatmaps (color-coded anomaly maps)
+- Risk heatmap with clustering graphs highlighting similar invoices or vendors
 - Fraud detection reports listing flagged invoices with reasons
 - Automatic vendor bios + risk scores from public data
 - Real-time invoice chat thread with collaborators

--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -14,7 +14,12 @@ const {
   getVendorSpend,
   detectOutliers,
   getRealTimeDashboard,
-  detectDuplicateInvoices
+  detectDuplicateInvoices,
+  getApprovalTimeByVendor,
+  getLatePaymentTrend,
+  getInvoicesOverBudget,
+  getRiskHeatmap,
+  getInvoiceClusters
 } = require('../controllers/analyticsController');
 const { listRules, addRule } = require('../controllers/rulesController');
 const { authMiddleware } = require('../controllers/userController');
@@ -31,9 +36,14 @@ router.post('/rules', authMiddleware, addRule);
 router.get('/approvals/stats', authMiddleware, getApprovalStats);
 router.get('/approvals/times', authMiddleware, getApprovalTimeChart);
 router.get('/spend/vendor', authMiddleware, getVendorSpend);
+router.get('/kpi/approval-time-vendor', authMiddleware, getApprovalTimeByVendor);
+router.get('/kpi/late-payments-trend', authMiddleware, getLatePaymentTrend);
+router.get('/kpi/over-budget', authMiddleware, getInvoicesOverBudget);
 router.get('/metadata', authMiddleware, getDashboardMetadata);
 router.get('/outliers', authMiddleware, detectOutliers);
 router.get('/dashboard/realtime', authMiddleware, getRealTimeDashboard);
 router.get('/anomalies/duplicates', authMiddleware, detectDuplicateInvoices);
+router.get('/risk/heatmap', authMiddleware, getRiskHeatmap);
+router.get('/risk/clusters', authMiddleware, getInvoiceClusters);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- extend analytics controller with KPI endpoints
- expose new analytics routes
- document custom KPI dashboards and risk visualizations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b7a7256f0832ea4a7af4b16fc9426