### PR TITLE
Add email-based invoice ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ EMAIL_USER=
 # If using Gmail with 2FA, set EMAIL_PASS to an App Password
 EMAIL_PASS=
 EMAIL_TO=
+# Gmail API service account key for email ingestion
+GOOGLE_SERVICE_ACCOUNT_KEY=
+# Inbox to poll for forwarded invoices
+EMAIL_INBOX=upload@yourdomain.com
 # Stripe secret key for billing
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm install --legacy-peer-deps
 - Automation marketplace integrations (Zapier/Make) for Slack and Google Sheets, plus connectors for your accounting platform, via `/api/integrations`
 - RPA automation engine triggers post-approval exports to your ERP system
 - Scheduled email fetch imports PDF invoices automatically
+- Forward invoices to `upload@yourdomain.com` and attachments are parsed via Gmail API
 - Low-code automation builder (`/api/automations`) for if‑then API workflows
 - Blockchain-backed invoice validation with PDF hashing for tamper-proof records
 
@@ -137,6 +138,7 @@ cp .env.example .env   # Make sure to add your DATABASE_URL and OPENAI_API_KEY
 # Optional: adjust DUE_REMINDER_DAYS and APPROVAL_REMINDER_DAYS in .env to tweak reminder timing
 # Set DATA_ENCRYPTION_KEY to enable at-rest encryption of sensitive fields
 # Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER if you want SMS alerts
+# Set GOOGLE_SERVICE_ACCOUNT_KEY and EMAIL_INBOX to enable email-to-upload support
 npm start
 ```
 

--- a/backend/utils/emailSync.js
+++ b/backend/utils/emailSync.js
@@ -1,20 +1,81 @@
 const cron = require('node-cron');
+const fs = require('fs');
+const path = require('path');
 const { google } = require('googleapis');
+const { sendMail } = require('./email');
+const { uploadInvoice } = require('../controllers/invoiceController');
+
+const inbox = process.env.EMAIL_INBOX || 'invoices@company.com';
+
+async function processMessage(gmail, message) {
+  const msg = await gmail.users.messages.get({ userId: inbox, id: message.id });
+  const headers = {};
+  (msg.data.payload.headers || []).forEach(h => { headers[h.name.toLowerCase()] = h.value; });
+  const from = headers['from'] || '';
+  const match = from.match(/<(.+?)>/);
+  const sender = match ? match[1] : from;
+  const parts = msg.data.payload.parts || [];
+  for (const part of parts) {
+    if (!part.filename || !part.body || !part.body.attachmentId) continue;
+    const ext = path.extname(part.filename).toLowerCase();
+    if (!['.pdf', '.csv', '.png', '.jpg', '.jpeg'].includes(ext)) continue;
+    const att = await gmail.users.messages.attachments.get({
+      userId: inbox,
+      messageId: message.id,
+      id: part.body.attachmentId,
+    });
+    const data = Buffer.from(att.data.data, 'base64');
+    const tmp = path.join('/tmp', `${message.id}-${part.filename}`);
+    fs.writeFileSync(tmp, data);
+    const req = {
+      file: { path: tmp, originalname: part.filename, size: data.length },
+      body: {},
+      params: { tenantId: 'default' },
+      headers: {},
+      user: { userId: 0, username: sender },
+    };
+    const res = { status: () => ({ json: () => {} }), json: () => {} };
+    try {
+      await uploadInvoice(req, res);
+    } catch (err) {
+      console.error('Email attachment processing failed:', err.message);
+    }
+    fs.unlinkSync(tmp);
+  }
+  await gmail.users.messages.modify({
+    userId: inbox,
+    id: message.id,
+    requestBody: { removeLabelIds: ['UNREAD'] },
+  });
+  if (sender) {
+    try {
+      await sendMail({
+        to: sender,
+        subject: 'Invoice received',
+        text: 'Your forwarded invoice was processed successfully.',
+      });
+    } catch (err) {
+      console.error('Confirmation email error:', err.message);
+    }
+  }
+}
 
 async function fetchEmailAttachments() {
   try {
     const auth = new google.auth.GoogleAuth({
       keyFile: process.env.GOOGLE_SERVICE_ACCOUNT_KEY,
-      scopes: ['https://www.googleapis.com/auth/gmail.readonly']
+      scopes: ['https://www.googleapis.com/auth/gmail.modify'],
     });
     const gmail = google.gmail({ version: 'v1', auth });
     const res = await gmail.users.messages.list({
-      userId: 'invoices@company.com',
-      q: 'has:attachment is:unread'
+      userId: inbox,
+      q: `to:${inbox} has:attachment is:unread`,
     });
     const messages = res.data.messages || [];
     if (messages.length) console.log(`📥 Found ${messages.length} invoice emails`);
-    // Placeholder: actual attachment processing not implemented
+    for (const m of messages) {
+      await processMessage(gmail, m);
+    }
   } catch (err) {
     console.error('Email sync error:', err.message);
   }


### PR DESCRIPTION
## Summary
- implement Gmail inbox parser to auto-upload invoice attachments
- expose `GOOGLE_SERVICE_ACCOUNT_KEY` and `EMAIL_INBOX` in `.env.example`
- document new email ingestion feature and environment variables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b7c8192f8832e9b72f4cb1327ed4a