### PR TITLE
Implement expiring invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm install --legacy-peer-deps
 - Context-aware Inbox Copilot chat for each invoice
 - (e.g. "Which vendors had the most inconsistencies last month?")
 - Role-based access control (Admins, Approvers, Viewers)
+- Admins can generate expiring invitation links for Viewer or Editor accounts
 - Activity log of invoice actions
 - Downloadable audit history per vendor or invoice
 - Detailed logs show who made each change
@@ -402,6 +403,23 @@ cd frontend
 npm install
 npm start
 ```
+
+### Invitations
+
+Admins can generate an invite link by calling:
+
+```bash
+POST /api/invites { "role": "viewer", "expiresInHours": 48 }
+```
+
+The link returned as `/api/invites/<token>` can be shared with a teammate. They
+complete the sign‑up via:
+
+```bash
+POST /api/invites/<token>/accept { "username": "newuser", "password": "pass" }
+```
+
+Invites expire automatically and grant the specified role (viewer or editor).
 
 ### Offline Mode (PWA)
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -27,6 +27,7 @@ const reminderRoutes = require('./routes/reminderRoutes');
 const automationRoutes = require('./routes/automationRoutes');
 const tenantRoutes = require('./routes/tenantRoutes');
 const agentRoutes = require('./routes/agentRoutes');
+const inviteRoutes = require('./routes/inviteRoutes');
 const { auditLog } = require('./middleware/auditMiddleware');
 const { runRecurringInvoices } = require('./controllers/recurringController');
 const { processFailedPayments, sendPaymentReminders } = require('./controllers/paymentController');
@@ -76,6 +77,7 @@ app.use('/api/reminders', reminderRoutes);
 app.use('/api/automations', automationRoutes);
 app.use('/api/tenants', tenantRoutes);
 app.use('/api/agents', agentRoutes);
+app.use('/api/invites', inviteRoutes);
 
 app.use(Sentry.Handlers.errorHandler());
 

--- a/backend/controllers/inviteController.js
+++ b/backend/controllers/inviteController.js
@@ -1,0 +1,51 @@
+const crypto = require('crypto');
+const pool = require('../config/db');
+const { logActivity } = require('../utils/activityLogger');
+const { createUser, userExists } = require('./userController');
+
+exports.createInvite = async (req, res) => {
+  const { role = 'viewer', expiresInHours = 24 } = req.body || {};
+  if (!['viewer', 'editor'].includes(role)) {
+    return res.status(400).json({ message: 'Invalid role' });
+  }
+  const token = crypto.randomBytes(16).toString('hex');
+  const expiresAt = new Date(Date.now() + expiresInHours * 60 * 60 * 1000);
+  try {
+    await pool.query(
+      'INSERT INTO invites (token, role, expires_at, created_by) VALUES ($1,$2,$3,$4)',
+      [token, role, expiresAt, req.user?.userId]
+    );
+    logActivity(req.user?.userId, 'create_invite', null, req.user?.username);
+    res.json({ url: `/api/invites/${token}` });
+  } catch (err) {
+    console.error('Create invite error:', err);
+    res.status(500).json({ message: 'Failed to create invite' });
+  }
+};
+
+exports.acceptInvite = async (req, res) => {
+  const { token } = req.params;
+  const { username, password } = req.body || {};
+  if (!username || !password) {
+    return res.status(400).json({ message: 'Missing fields' });
+  }
+  try {
+    const { rows } = await pool.query('SELECT * FROM invites WHERE token = $1', [token]);
+    if (
+      rows.length === 0 ||
+      rows[0].used ||
+      new Date(rows[0].expires_at) < new Date()
+    ) {
+      return res.status(400).json({ message: 'Invalid or expired invite' });
+    }
+    if (userExists(username)) {
+      return res.status(400).json({ message: 'User exists' });
+    }
+    const user = createUser(username, password, rows[0].role);
+    await pool.query('UPDATE invites SET used = TRUE WHERE token = $1', [token]);
+    res.json({ id: user.id, username: user.username, role: user.role });
+  } catch (err) {
+    console.error('Accept invite error:', err);
+    res.status(500).json({ message: 'Failed to accept invite' });
+  }
+};

--- a/backend/routes/inviteRoutes.js
+++ b/backend/routes/inviteRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { createInvite, acceptInvite } = require('../controllers/inviteController');
+const { authMiddleware, authorizeRoles } = require('../controllers/userController');
+
+router.post('/', authMiddleware, authorizeRoles('admin'), createInvite);
+router.post('/:token/accept', acceptInvite);
+
+module.exports = router;

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -122,6 +122,15 @@ async function initDb() {
       created_at TIMESTAMP DEFAULT NOW()
     )`);
 
+    await pool.query(`CREATE TABLE IF NOT EXISTS invites (
+      token TEXT PRIMARY KEY,
+      role TEXT NOT NULL,
+      expires_at TIMESTAMP NOT NULL,
+      used BOOLEAN DEFAULT FALSE,
+      created_by INTEGER,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+
     await pool.query(`CREATE TABLE IF NOT EXISTS recurring_templates (
       id SERIAL PRIMARY KEY,
       vendor TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- add secure invite controller and routes
- expose helpers in user controller for invite flow
- store invites in database
- mount invite routes on backend and document API usage

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b81cb89fc832e88dc4aa0ce860579