### PR TITLE
Add i18next-based language selector

### DIFF
--- a/frontend/src/components/BulkSummary.js
+++ b/frontend/src/components/BulkSummary.js
@@ -1,11 +1,13 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 export default function BulkSummary({ open, summary, onClose }) {
+  const { t } = useTranslation();
   if (!open || !summary) return null;
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-all duration-300 ease-in-out">
       <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-96 max-w-full transition-all duration-300 ease-in-out">
-        <h2 className="text-lg font-semibold mb-2">Upload Summary</h2>
+        <h2 className="text-lg font-semibold mb-2">{t('uploadSummary')}</h2>
         <ul className="text-sm mb-4 space-y-1">
           <li><strong>Valid:</strong> {summary.valid}</li>
           <li><strong>Flagged:</strong> {summary.flagged}</li>
@@ -18,7 +20,7 @@ export default function BulkSummary({ open, summary, onClose }) {
           )}
         </ul>
         <div className="flex justify-end">
-          <button onClick={onClose} className="px-3 py-1 rounded bg-indigo-600 text-white text-sm transition-all duration-300 ease-in-out">Close</button>
+          <button onClick={onClose} className="px-3 py-1 rounded bg-indigo-600 text-white text-sm transition-all duration-300 ease-in-out">{t('close')}</button>
         </div>
       </div>
     </div>

--- a/frontend/src/components/DemoUploadModal.js
+++ b/frontend/src/components/DemoUploadModal.js
@@ -3,10 +3,12 @@ import { motion } from 'framer-motion';
 import Lottie from 'lottie-react';
 import ProgressBar from './ProgressBar';
 import checkmark from '../checkmark.json';
+import { useTranslation } from 'react-i18next';
 
 export default function DemoUploadModal({ open, onClose }) {
   const [progress, setProgress] = useState(0);
   const [done, setDone] = useState(false);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!open) return;
@@ -30,7 +32,7 @@ export default function DemoUploadModal({ open, onClose }) {
         animate={{ scale: 1, opacity: 1 }}
         className="bg-white dark:bg-gray-800 p-6 rounded shadow-lg w-80 space-y-4"
       >
-        <h2 className="text-lg font-bold text-center">Demo Upload</h2>
+        <h2 className="text-lg font-bold text-center">{t('demoUpload')}</h2>
         <div className="relative">
           <img
             src="https://dummyimage.com/400x250/cccccc/000&text=Sample+Invoice"
@@ -42,16 +44,16 @@ export default function DemoUploadModal({ open, onClose }) {
         {done ? (
           <div className="flex flex-col items-center space-y-2">
             <Lottie animationData={checkmark} style={{ width: 80, height: 80 }} loop={false} />
-            <p className="text-sm">Invoice Parsed!</p>
+            <p className="text-sm">{t('invoiceParsed')}</p>
           </div>
         ) : (
           <>
-            <p className="text-sm text-center">Parsing invoice...</p>
+            <p className="text-sm text-center">{t('parsingInvoice')}</p>
             <ProgressBar value={progress} />
           </>
         )}
-        <button onClick={onClose} className="btn btn-primary w-full" title="Close demo">
-          Close
+        <button onClick={onClose} className="btn btn-primary w-full" title={t('close') + ' demo'}>
+          {t('close')}
         </button>
       </motion.div>
     </div>

--- a/frontend/src/components/DummyDataButton.js
+++ b/frontend/src/components/DummyDataButton.js
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { API_BASE } from '../api';
+import { useTranslation } from 'react-i18next';
 
 export default function DummyDataButton() {
   const token = localStorage.getItem('token') || '';
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
+  const { t } = useTranslation();
 
   const handleSeed = async () => {
     setLoading(true);
@@ -19,7 +21,7 @@ export default function DummyDataButton() {
 
   return (
     <button className="btn btn-secondary" onClick={handleSeed} disabled={loading}>
-      {loading ? 'Seeding...' : done ? 'Seeded!' : 'Seed Dummy Data'}
+      {loading ? t('seeding') : done ? t('seeded') : t('seedDummyData')}
     </button>
   );
 }

--- a/frontend/src/components/InvoiceSnapshotView.js
+++ b/frontend/src/components/InvoiceSnapshotView.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import GraphView from './GraphView';
+import { useTranslation } from 'react-i18next';
 
 export default function InvoiceSnapshotView({ open, invoice, onClose, token, tenant, onAddComment }) {
   const [comment, setComment] = useState('');
+  const { t } = useTranslation();
   if (!open || !invoice) return null;
   return (
     <div className="fixed inset-0 z-40">
@@ -16,7 +18,7 @@ export default function InvoiceSnapshotView({ open, invoice, onClose, token, ten
               className="text-sm px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
               aria-label="Close snapshot"
             >
-              Close
+              {t('close')}
             </button>
           </div>
           <div className="text-sm space-y-1">

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -70,7 +70,7 @@ export default function Navbar({
           type="text"
           value={search}
           onChange={(e) => onSearchChange?.(e.target.value)}
-          placeholder="Search..."
+          placeholder={t('searchPlaceholder')}
           className="input text-gray-800 dark:text-gray-100 h-7 text-sm"
         />
         <div className="flex items-center space-x-3 relative">
@@ -80,7 +80,7 @@ export default function Navbar({
           {token && (
             <button onClick={onUpload} className="btn btn-primary text-xs flex items-center space-x-1">
               <ArrowUpTrayIcon className="w-4 h-4" />
-              <span>Upload</span>
+              <span>{t('upload')}</span>
             </button>
           )}
           {token && onToggleFilters && (

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,10 +1,14 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import en from './locales/en/translation.json';
+import es from './locales/es/translation.json';
+import fr from './locales/fr/translation.json';
+
 const resources = {
-  en: { translation: { "title": "Invoice Uploader AI" } },
-  es: { translation: { "title": "Cargador de Facturas AI" } },
-  fr: { translation: { "title": "Téléverseur de Factures AI" } },
+  en: { translation: en },
+  es: { translation: es },
+  fr: { translation: fr },
 };
 
 i18n.use(initReactI18next).init({

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,0 +1,13 @@
+{
+  "title": "Invoice Uploader AI",
+  "upload": "Upload",
+  "searchPlaceholder": "Search...",
+  "demoUpload": "Demo Upload",
+  "parsingInvoice": "Parsing invoice...",
+  "invoiceParsed": "Invoice Parsed!",
+  "close": "Close",
+  "seedDummyData": "Seed Dummy Data",
+  "seeding": "Seeding...",
+  "seeded": "Seeded!"
+  ,"uploadSummary": "Upload Summary"
+}

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,0 +1,13 @@
+{
+  "title": "Cargador de Facturas AI",
+  "upload": "Subir",
+  "searchPlaceholder": "Buscar...",
+  "demoUpload": "Carga de Demostración",
+  "parsingInvoice": "Procesando factura...",
+  "invoiceParsed": "¡Factura Procesada!",
+  "close": "Cerrar",
+  "seedDummyData": "Generar Datos de Prueba",
+  "seeding": "Generando...",
+  "seeded": "¡Generado!"
+  ,"uploadSummary": "Resumen de Subida"
+}

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,0 +1,13 @@
+{
+  "title": "Téléverseur de Factures AI",
+  "upload": "Téléverser",
+  "searchPlaceholder": "Recherche...",
+  "demoUpload": "Téléversement Démo",
+  "parsingInvoice": "Analyse de la facture...",
+  "invoiceParsed": "Facture Analysée !",
+  "close": "Fermer",
+  "seedDummyData": "Générer des Données d'Essai",
+  "seeding": "Génération...",
+  "seeded": "Généré !"
+  ,"uploadSummary": "Récapitulatif de Téléversement"
+}


### PR DESCRIPTION
## Summary
- add JSON translation resources for English, Spanish and French
- configure i18next to use translation files
- translate several UI strings and wire language dropdown

## Testing
- `npm test -- -u` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685b8dd88470832eb2d96212d923a675