### PR TITLE
Add high contrast accessibility

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,9 +3,18 @@ import App from './App';
 
 // Mock graph component which uses ESM build incompatible with jest
 jest.mock('react-force-graph-2d', () => () => null);
+jest.mock('yjs', () => ({}));
+jest.mock('y-websocket', () => ({ WebsocketProvider: function() {} }));
+jest.mock('textarea-caret', () => () => ({ top: 0, left: 0 }));
 
 test('renders login heading by default', () => {
   render(<App />);
   const heading = screen.getByRole('heading', { name: /login/i });
   expect(heading).toBeInTheDocument();
+});
+
+test('high contrast toggle is present', () => {
+  render(<App />);
+  const toggle = screen.getByLabelText(/high contrast/i);
+  expect(toggle).toBeInTheDocument();
 });

--- a/frontend/src/LandingPage.js
+++ b/frontend/src/LandingPage.js
@@ -21,6 +21,7 @@ import {
 } from '@heroicons/react/24/outline';
 import LanguageSelector from './components/LanguageSelector';
 import DarkModeToggle from './components/DarkModeToggle';
+import HighContrastToggle from './components/HighContrastToggle';
 import Carousel from './components/Carousel';
 import { Card } from './components/ui/Card';
 import { Button } from './components/ui/Button';
@@ -44,6 +45,7 @@ export default function LandingPage() {
           </div>
           <div className="flex items-center space-x-2 relative">
             <LanguageSelector />
+            <HighContrastToggle />
             <DarkModeToggle />
             <Button
               variant="secondary"

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -2,6 +2,8 @@
 import React, { useState } from 'react';
 import { Card } from './components/ui/Card';
 import { API_BASE } from './api';
+import DarkModeToggle from './components/DarkModeToggle';
+import HighContrastToggle from './components/HighContrastToggle';
 
 export default function Login({ onLogin, addToast }) {
   const [username, setUsername] = useState('');
@@ -34,21 +36,27 @@ export default function Login({ onLogin, addToast }) {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-4 z-20">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-4 z-20 flex justify-between items-center">
         <h1 className="text-xl font-bold flex items-center space-x-1">
           <img src={`/api/${localStorage.getItem('tenant') || 'default'}/logo`} alt="logo" className="h-5 w-5" />
           <span>Invoice Uploader AI</span>
         </h1>
+        <div className="flex items-center gap-2">
+          <HighContrastToggle />
+          <DarkModeToggle />
+        </div>
       </nav>
       <div className="flex-1 flex items-center justify-center pt-20">
         <Card className="w-80 space-y-4">
           <h1 className="text-xl font-bold text-center">Login</h1>
 
           {error && (
-            <div className="bg-red-100 text-red-700 p-2 mb-4 text-sm rounded">{error}</div>
+            <div className="bg-red-100 text-red-700 p-2 mb-4 text-sm rounded" role="alert">{error}</div>
           )}
 
+          <label htmlFor="username" className="sr-only">Username</label>
           <input
+            id="username"
             type="text"
             placeholder="Username"
             value={username}
@@ -56,7 +64,9 @@ export default function Login({ onLogin, addToast }) {
             className="input w-full mb-3"
           />
 
+          <label htmlFor="password" className="sr-only">Password</label>
           <input
+            id="password"
             type="password"
             placeholder="Password"
             value={password}

--- a/frontend/src/components/HighContrastToggle.js
+++ b/frontend/src/components/HighContrastToggle.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { EyeDropperIcon } from '@heroicons/react/24/outline';
+import useHighContrast from '../hooks/useHighContrast';
+
+export default function HighContrastToggle() {
+  const [highContrast, setHighContrast] = useHighContrast();
+  return (
+    <button
+      onClick={() => setHighContrast(!highContrast)}
+      className="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+      aria-label="Toggle high contrast mode"
+      title={highContrast ? 'Disable high contrast' : 'Enable high contrast'}
+    >
+      <EyeDropperIcon className="h-6 w-6" />
+    </button>
+  );
+}

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -5,6 +5,7 @@ import NotificationBell from './NotificationBell';
 import LanguageSelector from './LanguageSelector';
 import ThemePicker from './ThemePicker';
 import DarkModeToggle from './DarkModeToggle';
+import HighContrastToggle from './HighContrastToggle';
 import useDarkMode from '../hooks/useDarkMode';
 import useOutsideClick from '../hooks/useOutsideClick';
 import { useTranslation } from 'react-i18next';
@@ -71,6 +72,7 @@ export default function Navbar({
           value={search}
           onChange={(e) => onSearchChange?.(e.target.value)}
           placeholder={t('searchPlaceholder')}
+          aria-label={t('searchPlaceholder')}
           className="input text-gray-800 dark:text-gray-100 h-7 text-sm"
         />
         <div className="flex items-center space-x-3 relative">
@@ -166,11 +168,12 @@ export default function Navbar({
                 onMouseEnter={() => setHelpOpen(true)}
                 onMouseLeave={() => setHelpOpen(false)}
               >
-                <QuestionMarkCircleIcon className="h-6 w-6 cursor-help" />
-                {helpOpen && <HelpTooltip topic="dashboard" token={token} />}
-              </div>
-              <DarkModeToggle />
-              <ThemePicker darkMode={darkMode} setDarkMode={setDarkMode} tenant={tenant} />
+              <QuestionMarkCircleIcon className="h-6 w-6 cursor-help" />
+              {helpOpen && <HelpTooltip topic="dashboard" token={token} />}
+            </div>
+            <HighContrastToggle />
+            <DarkModeToggle />
+            <ThemePicker darkMode={darkMode} setDarkMode={setDarkMode} tenant={tenant} />
               <div className="relative" ref={userRef}>
                 <button
                   onClick={() => setUserOpen((o) => !o)}

--- a/frontend/src/components/Toast.js
+++ b/frontend/src/components/Toast.js
@@ -7,7 +7,7 @@ export default function Toast({ message, type, actionText, onAction }) {
   const color = type === 'error' ? 'bg-red-600' : 'bg-green-600';
   const Icon = type === 'error' ? XCircleIcon : CheckCircleIcon;
   return (
-    <div className={`${base} ${color} animate-slide-in-right`}>
+    <div className={`${base} ${color} animate-slide-in-right`} role="alert" aria-live="assertive">
       <Icon className="h-5 w-5" />
       <span className="flex-1">{message}</span>
       {actionText && (

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import HelpTooltip from './HelpTooltip';
 import LanguageSelector from './LanguageSelector';
 import DarkModeToggle from './DarkModeToggle';
+import HighContrastToggle from './HighContrastToggle';
 
 export default function TopNavbar({ title, helpTopic }) {
   const token = localStorage.getItem('token') || '';
@@ -20,6 +21,7 @@ export default function TopNavbar({ title, helpTopic }) {
       </h1>
       <div className="flex items-center gap-2">
         <LanguageSelector />
+        <HighContrastToggle />
         <DarkModeToggle />
         <Link to="/invoices" className="underline">Back to App</Link>
       </div>

--- a/frontend/src/hooks/useHighContrast.js
+++ b/frontend/src/hooks/useHighContrast.js
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export default function useHighContrast() {
+  const [highContrast, setHighContrast] = useState(() => localStorage.getItem('contrast') === 'high');
+
+  useEffect(() => {
+    if (highContrast) {
+      document.documentElement.classList.add('high-contrast');
+      localStorage.setItem('contrast', 'high');
+    } else {
+      document.documentElement.classList.remove('high-contrast');
+      localStorage.setItem('contrast', 'normal');
+    }
+  }, [highContrast]);
+
+  return [highContrast, setHighContrast];
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -76,3 +76,18 @@ code {
     @apply bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4;
   }
 }
+
+/* High contrast mode */
+.high-contrast body {
+  @apply bg-black text-yellow-300;
+}
+.high-contrast .btn-primary {
+  background-color: #ffff00;
+  @apply text-black;
+}
+.high-contrast .input {
+  @apply border-yellow-400 bg-black text-yellow-300;
+}
+.high-contrast .card {
+  @apply bg-black text-yellow-300 border border-yellow-400;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -63,6 +63,10 @@ const savedTheme = localStorage.getItem(`themeMode_${currentTenant}`);
 if (savedTheme === 'dark') {
   document.documentElement.classList.add('dark');
 }
+const savedContrast = localStorage.getItem('contrast');
+if (savedContrast === 'high') {
+  document.documentElement.classList.add('high-contrast');
+}
 const savedAccent = localStorage.getItem(`accentColor_${currentTenant}`);
 if (savedAccent) document.documentElement.style.setProperty('--accent-color', savedAccent);
 const savedFont = localStorage.getItem(`fontFamily_${currentTenant}`);


### PR DESCRIPTION
## Summary
- add high contrast mode hook and toggle
- load saved high contrast setting on page load
- style high contrast colors
- label login inputs for screen readers and add alert roles
- expose high contrast toggle in navbars and landing page
- add ARIA label to search input
- include unit test for the new toggle

## Testing
- `npm install --legacy-peer-deps`
- `CI=true npm test --silent --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685b904fa548832e92d501e27c2cbd70