### PR TITLE
Add social proof slider and expand feature grid

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -16,6 +16,8 @@ import {
   ShieldCheckIcon,
   GlobeAltIcon,
   LockClosedIcon,
+  ExclamationCircleIcon,
+  ArrowDownTrayIcon,
 } from '@heroicons/react/24/outline';
 import Carousel from './components/Carousel';
 import { Card } from './components/ui/Card';
@@ -30,6 +32,7 @@ import HeroSection from './components/HeroSection';
 import FeatureCard from './components/FeatureCard';
 import ProblemSolutionSection from './components/ProblemSolutionSection';
 import ScheduleDemoModal from './components/ScheduleDemoModal';
+import SocialProofSection from './components/SocialProofSection';
 
 export default function LandingPage() {
   const [demoOpen, setDemoOpen] = useState(false);
@@ -54,24 +57,35 @@ export default function LandingPage() {
       <HeroSection onRequestDemo={() => setDemoOpen(true)} />
       <ProblemSolutionSection />
       <section id="features" className="py-12 bg-gray-50 dark:bg-gray-800">
-        <div className="container mx-auto grid md:grid-cols-3 gap-8 px-6">
+        <div className="container mx-auto grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-8 px-6">
+          <FeatureCard
+            icon={DocumentArrowUpIcon}
+            title="Invoice Upload"
+            description="Import CSVs or PDFs in seconds."
+          />
           <FeatureCard
             icon={CheckCircleIcon}
-            title="Automatic Validation"
-            description="Catch errors and duplicates before they hit your books."
+            title="AI Validation"
+            description="Catch errors before they hit your books."
+          />
+          <FeatureCard
+            icon={ExclamationCircleIcon}
+            title="Error Insights"
+            description="Understand issues with smart summaries."
           />
           <FeatureCard
             icon={ChartBarIcon}
-            title="Real-Time Analytics"
-            description="AI insights reveal spending trends and anomalies."
+            title="Analytics"
+            description="See trends and anomalies instantly."
           />
           <FeatureCard
-            icon={DocumentArrowUpIcon}
-            title="One-Click Uploads"
-            description="Import CSVs or PDFs and organize them instantly."
+            icon={ArrowDownTrayIcon}
+            title="Export to Finance"
+            description="Send clean data to your ERP."
           />
         </div>
       </section>
+      <SocialProofSection />
       <section id="customers" className="py-12 bg-gray-50 dark:bg-gray-800">
         <h2 className="text-3xl font-bold text-center mb-8">Why Teams Choose Us Over Other Tools</h2>
         <div className="container mx-auto overflow-x-auto px-6">

--- a/frontend/src/components/SocialProofSection.js
+++ b/frontend/src/components/SocialProofSection.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PartnerLogos from './PartnerLogos';
+import TestimonialSlider from './TestimonialSlider';
+
+export default function SocialProofSection() {
+  const testimonials = [
+    { quote: 'Saved our team 40+ hours weekly', author: 'Alex, Ops Lead' },
+    { quote: 'A must-have for finance automation', author: 'Jamie, CFO' },
+    { quote: 'Intuitive and incredibly fast', author: 'Taylor, Controller' },
+  ];
+  return (
+    <section className="py-12">
+      <div className="container mx-auto space-y-8 px-6">
+        <PartnerLogos />
+        <TestimonialSlider testimonials={testimonials} />
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/TestimonialSlider.js
+++ b/frontend/src/components/TestimonialSlider.js
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function TestimonialSlider({ testimonials = [], interval = 5000 }) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (testimonials.length <= 1) return;
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % testimonials.length);
+    }, interval);
+    return () => clearInterval(id);
+  }, [testimonials.length, interval]);
+
+  const prev = () => setIndex((index - 1 + testimonials.length) % testimonials.length);
+  const next = () => setIndex((index + 1) % testimonials.length);
+
+  if (testimonials.length === 0) return null;
+
+  const { quote, author } = testimonials[index];
+
+  return (
+    <div className="relative max-w-xl mx-auto">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -20 }}
+          transition={{ duration: 0.4 }}
+          className="text-center space-y-2"
+        >
+          <p className="text-lg font-medium">"{quote}"</p>
+          {author && <p className="text-sm text-gray-500">- {author}</p>}
+        </motion.div>
+      </AnimatePresence>
+      {testimonials.length > 1 && (
+        <>
+          <button
+            onClick={prev}
+            className="absolute left-0 top-1/2 -translate-y-1/2 p-1 bg-white/80 dark:bg-gray-700/80 rounded-full hover:bg-white dark:hover:bg-gray-700"
+            aria-label="Previous"
+          >
+            <ChevronLeftIcon className="w-5 h-5" />
+          </button>
+          <button
+            onClick={next}
+            className="absolute right-0 top-1/2 -translate-y-1/2 p-1 bg-white/80 dark:bg-gray-700/80 rounded-full hover:bg-white dark:hover:bg-gray-700"
+            aria-label="Next"
+          >
+            <ChevronRightIcon className="w-5 h-5" />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- build testimonial slider component using Framer Motion
- show partner logos and testimonial slider in new SocialProofSection
- update Landing page feature grid with 5 cards
- wire up new SocialProofSection in Landing page

## Testing
- `npm install --legacy-peer-deps`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685c85e54ed4832ebaa025370709f8fd