### PR TITLE
Add animated CSV demo

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -33,6 +33,7 @@ import FeatureCard from './components/FeatureCard';
 import ProblemSolutionSection from './components/ProblemSolutionSection';
 import ScheduleDemoModal from './components/ScheduleDemoModal';
 import SocialProofSection from './components/SocialProofSection';
+import CsvUploadFlowDemo from './components/CsvUploadFlowDemo';
 
 export default function LandingPage() {
   const [demoOpen, setDemoOpen] = useState(false);
@@ -56,6 +57,10 @@ export default function LandingPage() {
       </nav>
       <HeroSection onRequestDemo={() => setDemoOpen(true)} />
       <ProblemSolutionSection />
+      <section className="py-12">
+        <h2 className="text-3xl font-bold text-center mb-6">Interactive Demo</h2>
+        <CsvUploadFlowDemo />
+      </section>
       <section id="features" className="py-12 bg-gray-50 dark:bg-gray-800">
         <div className="container mx-auto grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-8 px-6">
           <FeatureCard

--- a/frontend/src/components/CsvUploadFlowDemo.js
+++ b/frontend/src/components/CsvUploadFlowDemo.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import SuccessAnimation from './SuccessAnimation';
+
+export default function CsvUploadFlowDemo() {
+  const steps = [
+    {
+      title: 'Drag & Drop CSV',
+      img: 'https://dummyimage.com/800x450/6366f1/ffffff.png&text=Drag+%26+Drop+CSV'
+    },
+    {
+      title: 'Preview & Fix Issues',
+      img: 'https://dummyimage.com/800x450/4f46e5/ffffff.png&text=Preview+Rows'
+    },
+    {
+      title: 'Dashboard Populated',
+      img: 'https://dummyimage.com/800x450/312e81/ffffff.png&text=Dashboard'
+    }
+  ];
+
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % steps.length);
+    }, 2500);
+    return () => clearInterval(id);
+  }, []);
+
+  const { title, img } = steps[index];
+
+  return (
+    <div className="relative w-full max-w-xl mx-auto">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={index}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          transition={{ duration: 0.5 }}
+          className="space-y-2"
+        >
+          <img src={img} alt={title} className="w-full rounded-lg shadow-lg" />
+          <p className="text-center font-medium">{title}</p>
+        </motion.div>
+      </AnimatePresence>
+      {index === steps.length - 1 && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <SuccessAnimation className="w-20 h-20" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/VideoPlayer.js
+++ b/frontend/src/components/VideoPlayer.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function VideoPlayer({ src, className }) {
+  return (
+    <video
+      src={src}
+      className={className}
+      autoPlay
+      loop
+      muted
+      playsInline
+      controls
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- show interactive CSV upload flow on landing page
- create demo component cycling through drag/drop, preview and dashboard
- add generic video player helper

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c87cd309c832ea50252bb32de92fb