### PR TITLE
Add interactive pricing components

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -36,6 +36,10 @@ import SocialProofSection from './components/SocialProofSection';
 import CsvUploadFlowDemo from './components/CsvUploadFlowDemo';
 import BlogSection from './components/BlogSection';
 import ChatWidget from './components/ChatWidget';
+import PricingSection from './components/PricingSection';
+import FeatureComparisonTable from './components/FeatureComparisonTable';
+import AddOnsTable from './components/AddOnsTable';
+import FaqAccordion from './components/FaqAccordion';
 
 export default function LandingPage() {
   const [demoOpen, setDemoOpen] = useState(false);
@@ -345,94 +349,10 @@ export default function LandingPage() {
           </Card>
         </div>
       </section>
-      <section className="py-12 bg-gray-50 dark:bg-gray-800">
-        <h2 className="text-3xl font-bold text-center mb-8">Pricing</h2>
-        <div className="container mx-auto grid md:grid-cols-4 gap-8 px-6">
-          <Card className="text-center space-y-4">
-            <h3 className="text-xl font-semibold">Starter</h3>
-            <p className="text-4xl font-bold">$49</p>
-            <ul className="text-sm space-y-1">
-              <li>500 invoices/month</li>
-              <li>1 AI summary/query</li>
-              <li>1 user</li>
-            </ul>
-            <Button asChild>
-              <Link to="/onboarding">Start Free Trial</Link>
-            </Button>
-          </Card>
-          <Card className="text-center space-y-4">
-            <h3 className="text-xl font-semibold">Growth</h3>
-            <p className="text-4xl font-bold">$149</p>
-            <ul className="text-sm space-y-1">
-              <li>2,500 invoices/month</li>
-              <li>All AI features</li>
-              <li>3 users</li>
-            </ul>
-            <Button asChild>
-              <Link to="/onboarding">Start Free Trial</Link>
-            </Button>
-          </Card>
-          <Card className="text-center space-y-4">
-            <h3 className="text-xl font-semibold">Pro</h3>
-            <p className="text-4xl font-bold">$399</p>
-            <ul className="text-sm space-y-1">
-              <li>10,000 invoices/month</li>
-              <li>All features unlocked</li>
-              <li>10 users</li>
-            </ul>
-            <Button asChild>
-              <Link to="/onboarding">Start Free Trial</Link>
-            </Button>
-          </Card>
-          <Card className="text-center space-y-4">
-            <h3 className="text-xl font-semibold">Enterprise</h3>
-            <p className="text-4xl font-bold">Custom</p>
-            <ul className="text-sm space-y-1">
-              <li>Unlimited invoices</li>
-              <li>Dedicated manager</li>
-              <li>Custom SLA</li>
-            </ul>
-            <Button asChild>
-              <Link to="/invoices">Contact Sales</Link>
-            </Button>
-          </Card>
-        </div>
-      </section>
-      <section className="py-12">
-        <h2 className="text-3xl font-bold text-center mb-6">Optional Add-Ons</h2>
-        <div className="container mx-auto overflow-x-auto px-6">
-          <table className="min-w-full text-left text-sm">
-            <thead>
-              <tr>
-                <th className="border-b px-4 py-2">Add-On Feature</th>
-                <th className="border-b px-4 py-2">Monthly Price</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y">
-              <tr>
-                <td className="px-4 py-2">Extra 1,000 invoices</td>
-                <td className="px-4 py-2">$10</td>
-              </tr>
-              <tr>
-                <td className="px-4 py-2">Additional user</td>
-                <td className="px-4 py-2">$5/user</td>
-              </tr>
-              <tr>
-                <td className="px-4 py-2">Email/Slack alert bundle</td>
-                <td className="px-4 py-2">$20</td>
-              </tr>
-              <tr>
-                <td className="px-4 py-2">Dedicated tenant setup</td>
-                <td className="px-4 py-2">$50</td>
-              </tr>
-              <tr>
-                <td className="px-4 py-2">Smart vendor scoring</td>
-                <td className="px-4 py-2">$100</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
+      <PricingSection />
+      <FeatureComparisonTable />
+      <AddOnsTable />
+      <FaqAccordion />
       <footer className="bg-gray-100 dark:bg-gray-900 p-8 text-gray-600 dark:text-gray-400">
         <div className="container mx-auto grid md:grid-cols-4 gap-8 text-sm">
           <div>

--- a/frontend/src/components/AddOnsTable.jsx
+++ b/frontend/src/components/AddOnsTable.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Card } from './ui/Card';
+
+const addOns = [
+  { feature: '+1,000 invoices', price: '$10', best: 'High-volume months' },
+  { feature: 'Extra team member', price: '$5/user', best: 'Adding finance or AI support' },
+  { feature: 'Slack/Email alerts', price: '$20', best: 'Real-time ops workflows' },
+  { feature: 'Dedicated tenant setup', price: '$50', best: 'Enterprises & white-label clients' },
+  { feature: 'Smart vendor scoring', price: '$100', best: 'Vendor prioritization & risk reduction' },
+];
+
+export default function AddOnsTable() {
+  return (
+    <section className="py-12">
+      <h2 className="text-3xl font-bold text-center mb-6">Optional Add-Ons</h2>
+      <div className="container mx-auto overflow-x-auto px-6">
+        <Card className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm">
+            <thead>
+              <tr>
+                <th className="border-b px-4 py-2">Add-On Feature</th>
+                <th className="border-b px-4 py-2">Monthly Price</th>
+                <th className="border-b px-4 py-2">Best For</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {addOns.map(a => (
+                <tr key={a.feature}>
+                  <td className="px-4 py-2">{a.feature}</td>
+                  <td className="px-4 py-2">{a.price}</td>
+                  <td className="px-4 py-2">{a.best}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/FaqAccordion.jsx
+++ b/frontend/src/components/FaqAccordion.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Card } from './ui/Card';
+import { ChevronDownIcon } from '@heroicons/react/24/outline';
+
+const faqs = [
+  {
+    q: 'What happens after the free trial?',
+    a: 'You can pick a paid plan or keep using the limited free tier.',
+  },
+  {
+    q: 'Can I cancel anytime?',
+    a: 'Yes. Your subscription will stop at the end of the current period.',
+  },
+  {
+    q: 'Do you offer annual billing discounts?',
+    a: 'Absolutely—switch to annual to save 20%.',
+  },
+];
+
+export default function FaqAccordion() {
+  const [open, setOpen] = useState(null);
+  return (
+    <section className="py-12 bg-gray-50 dark:bg-gray-800">
+      <h2 className="text-3xl font-bold text-center mb-6">FAQ</h2>
+      <div className="container mx-auto max-w-2xl px-6 space-y-2">
+        {faqs.map((f, idx) => (
+          <Card key={idx} className="p-4 cursor-pointer" onClick={() => setOpen(open === idx ? null : idx)}>
+            <div className="flex justify-between items-center">
+              <span className="font-medium">{f.q}</span>
+              <ChevronDownIcon className={`w-5 h-5 transform transition ${open === idx ? 'rotate-180' : ''}`} />
+            </div>
+            {open === idx && <p className="mt-2 text-sm text-gray-600 dark:text-gray-300">{f.a}</p>}
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/FeatureComparisonTable.jsx
+++ b/frontend/src/components/FeatureComparisonTable.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Card } from './ui/Card';
+
+const rows = [
+  { label: 'Invoice Limit', starter: '500', growth: '2,500', pro: '10,000', enterprise: 'Unlimited' },
+  { label: 'AI Summary Reports', starter: '1', growth: 'Unlimited', pro: 'Unlimited', enterprise: 'Unlimited' },
+  { label: 'Number of Users', starter: '1', growth: '3', pro: '10', enterprise: 'Custom' },
+  { label: 'Smart Vendor Scoring', starter: '❌', growth: '✅', pro: '✅', enterprise: '✅' },
+  { label: 'Slack/Email Alerts', starter: '❌', growth: '✅', pro: '✅', enterprise: '✅' },
+  { label: 'Dedicated Manager', starter: '❌', growth: '❌', pro: '❌', enterprise: '✅' },
+  { label: 'API Access', starter: '❌', growth: '✅', pro: '✅', enterprise: '✅' },
+];
+
+export default function FeatureComparisonTable() {
+  return (
+    <div className="container mx-auto overflow-x-auto px-6 mt-8">
+      <Card className="overflow-x-auto">
+        <table className="min-w-full text-sm text-center">
+          <thead>
+            <tr>
+              <th className="border-b px-4 py-2 text-left">Feature</th>
+              <th className="border-b px-4 py-2">Starter</th>
+              <th className="border-b px-4 py-2">Growth</th>
+              <th className="border-b px-4 py-2">Pro</th>
+              <th className="border-b px-4 py-2">Enterprise</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {rows.map(row => (
+              <tr key={row.label}>
+                <td className="px-4 py-2 text-left">{row.label}</td>
+                <td className="px-4 py-2">{row.starter}</td>
+                <td className="px-4 py-2">{row.growth}</td>
+                <td className="px-4 py-2">{row.pro}</td>
+                <td className="px-4 py-2">{row.enterprise}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/PricingSection.jsx
+++ b/frontend/src/components/PricingSection.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useEffect } from 'react';
+import { Card } from './ui/Card';
+import { Button } from './ui/Button';
+import {
+  CheckCircleIcon,
+  UserGroupIcon,
+  ChartBarIcon,
+  SparklesIcon,
+} from '@heroicons/react/24/outline';
+
+const plans = [
+  {
+    id: 'starter',
+    title: 'Starter',
+    subtitle: 'For solo users getting started',
+    price: 49,
+    invoices: 500,
+    summaries: 1,
+    users: 1,
+    cta: 'Start free — no credit card',
+  },
+  {
+    id: 'growth',
+    title: 'Growth',
+    subtitle: 'For growing finance teams',
+    price: 149,
+    invoices: 2500,
+    summaries: 'Unlimited',
+    users: 3,
+    cta: 'Start free for 14 days',
+    popular: true,
+  },
+  {
+    id: 'pro',
+    title: 'Pro',
+    subtitle: 'For scaling ops',
+    price: 399,
+    invoices: 10000,
+    summaries: 'Unlimited',
+    users: 10,
+    cta: 'Schedule Demo',
+  },
+  {
+    id: 'enterprise',
+    title: 'Enterprise',
+    subtitle: 'Built for complex orgs',
+    price: 'Custom',
+    invoices: 'Unlimited',
+    summaries: 'Unlimited',
+    users: 'Custom',
+    cta: 'Contact Sales →',
+  },
+];
+
+export default function PricingSection() {
+  const [annual, setAnnual] = useState(false);
+  const price = p => (p === 'Custom' ? p : annual ? p * 12 * 0.8 : p);
+  useEffect(() => {
+    const handle = () => {
+      const bar = document.getElementById('sticky-cta');
+      if (!bar) return;
+      bar.style.display = window.scrollY > 400 ? 'flex' : 'none';
+    };
+    window.addEventListener('scroll', handle);
+    return () => window.removeEventListener('scroll', handle);
+  }, []);
+  return (
+    <section id="pricing" className="py-12 bg-gray-50 dark:bg-gray-800">
+      <h2 className="text-3xl font-bold text-center mb-6">Pricing</h2>
+      <div className="flex justify-center mb-6 space-x-2 text-sm">
+        <span className={annual ? 'opacity-50' : 'font-semibold'}>Monthly</span>
+        <label className="relative inline-flex items-center cursor-pointer">
+          <input
+            type="checkbox"
+            value=""
+            className="sr-only peer"
+            checked={annual}
+            onChange={() => setAnnual(v => !v)}
+          />
+          <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none rounded-full peer peer-checked:bg-indigo-600"></div>
+        </label>
+        <span className={annual ? 'font-semibold' : 'opacity-50'}>
+          Annual <span className="text-indigo-600">(save 20%)</span>
+        </span>
+      </div>
+      <div className="container mx-auto grid md:grid-cols-4 gap-8 px-6">
+        {plans.map(plan => (
+          <Card
+            key={plan.id}
+            className={
+              'text-center space-y-4 p-6 transform transition hover:scale-105 hover:shadow-xl ' +
+              (plan.popular ? 'ring-2 ring-indigo-600' : '')
+            }
+          >
+            {plan.popular && (
+              <span className="text-xs uppercase tracking-wide text-indigo-600">Most Popular</span>
+            )}
+            <h3 className="text-xl font-semibold">{plan.title}</h3>
+            <p className="text-sm text-gray-500">{plan.subtitle}</p>
+            <p className="text-4xl font-bold">
+              {typeof plan.price === 'number' ? `$${price(plan.price)}` : plan.price}
+            </p>
+            {typeof plan.price === 'number' && annual && (
+              <p className="text-xs text-gray-500">billed annually</p>
+            )}
+            <ul className="text-sm space-y-1 text-left">
+              <li className="flex items-center space-x-1">
+                <CheckCircleIcon className="w-4 h-4" />
+                <span>{plan.invoices} invoices/mo</span>
+              </li>
+              <li className="flex items-center space-x-1">
+                <SparklesIcon className="w-4 h-4" />
+                <span>{plan.summaries} AI summary</span>
+              </li>
+              <li className="flex items-center space-x-1">
+                <UserGroupIcon className="w-4 h-4" />
+                <span>{plan.users} users</span>
+              </li>
+              <li className="flex items-center space-x-1">
+                <ChartBarIcon className="w-4 h-4" />
+                <span>Analytics</span>
+              </li>
+            </ul>
+            <Button>{plan.cta}</Button>
+          </Card>
+        ))}
+      </div>
+      <div id="sticky-cta" className="fixed bottom-0 inset-x-0 hidden justify-center bg-indigo-600 text-white p-4 z-40">
+        <span className="mr-4 font-semibold">Ready to get started?</span>
+        <Button variant="secondary" className="bg-white text-indigo-600">Start Free Trial</Button>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add `PricingSection` with plan highlights, toggleable annual pricing and sticky CTA
- create comparison table and add-on bundle components
- introduce simple FAQ accordion under pricing
- hook the new components into the landing page

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685c9358d190832ebb22df453206f4a7