### PR TITLE
Add AI vendor matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ npm install --legacy-peer-deps
 - Vendor scorecards rating responsiveness, payment consistency, and volume/price trends
 - Vendor management page with notes and spending totals per vendor
 - Smart vendor matching for inconsistent spellings
+- AI vendor matching with confidence scores and accept/reject feedback
 - Team member roles view with profile avatars
 - Shareable collaborator mode with comment-only or editor access
 - Export template builder for custom CSV layouts
@@ -388,6 +389,25 @@ Example response:
 
 ```json
 { "summary": "Row 1 is missing a vendor name. Row 2 has an invalid amount." }
+```
+
+### AI Vendor Matching
+
+Get AI help choosing the correct vendor when names are incomplete or misspelled.
+
+```bash
+POST /api/vendors/ai-match
+{
+  "vendor": "Acme Co",
+  "invoice_number": "12345",
+  "amount": 99.50
+}
+```
+
+Example response:
+
+```json
+{ "suggestion_id": 1, "vendor": "Acme Corporation", "confidence": 0.92 }
 ```
 
 ### Payment Request Form

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -72,6 +72,27 @@
           "200": { "description": "Summary text" }
         }
       }
+    },
+    "/api/vendors/ai-match": {
+      "post": {
+        "summary": "AI vendor matching",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "vendor": { "type": "string" },
+                  "invoice_number": { "type": "string" },
+                  "amount": { "type": "number" }
+                },
+                "required": ["vendor"]
+              }
+            }
+          }
+        },
+        "responses": { "200": { "description": "Vendor suggestion" } }
+      }
     }
   }
 }

--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -5,6 +5,7 @@ const {
   updateVendorNotes,
   getVendorInfo,
   matchVendors,
+  aiVendorMatch,
   predictVendorBehavior,
   exportVendorsCSV,
   importVendorsCSV,
@@ -12,6 +13,7 @@ const {
   getVendorAnalytics,
   updateVendorCountry,
   getVendorRiskProfile,
+  vendorMatchFeedback,
 } = require('../controllers/vendorController');
 const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
@@ -21,6 +23,8 @@ router.get('/', authMiddleware, listVendors);
 router.get('/export', authMiddleware, authorizeRoles('admin'), exportVendorsCSV);
 router.post('/import', authMiddleware, authorizeRoles('admin'), upload.single('file'), importVendorsCSV);
 router.get('/match', authMiddleware, matchVendors);
+router.post('/ai-match', authMiddleware, aiVendorMatch);
+router.post('/suggestions/:id/feedback', authMiddleware, vendorMatchFeedback);
 router.get('/behavior-flags', authMiddleware, authorizeRoles('admin'), getBehaviorFlags);
 router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
 router.get('/:vendor/info', authMiddleware, getVendorInfo);

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -104,6 +104,16 @@ async function initDb() {
       notes TEXT
     )`);
 
+    await pool.query(`CREATE TABLE IF NOT EXISTS vendor_suggestions (
+      id SERIAL PRIMARY KEY,
+      invoice_id INTEGER REFERENCES invoices(id) ON DELETE SET NULL,
+      input_vendor TEXT NOT NULL,
+      suggested_vendor TEXT NOT NULL,
+      confidence NUMERIC,
+      accepted BOOLEAN,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+
     await pool.query(`CREATE TABLE IF NOT EXISTS workflows (
       department TEXT PRIMARY KEY,
       approval_chain JSONB NOT NULL


### PR DESCRIPTION
## Summary
- add vendor suggestion table
- implement AI vendor matching with confidence and feedback loop
- expose new vendor endpoints
- document API and feature in README and Swagger

## Testing
- `npm run lint` *(backend)*
- `npm test --silent` *(backend)*
- `npm run lint` *(frontend: fails - missing script)*
- `npm test --silent` *(frontend: fails - react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc1fb63a0832e85d855536f8f09fc