### PR TITLE
Add formal/casual tone options for vendor email drafts

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,12 @@ POST /api/invoices/42/vendor-reply
 }
 ```
 
+Optional fields:
+
+```json
+{ "tone": "formal" } // or "casual" for a more relaxed style
+```
+
 Example response:
 
 ```json

--- a/backend/controllers/vendorReplyController.js
+++ b/backend/controllers/vendorReplyController.js
@@ -41,7 +41,14 @@ exports.vendorReply = async (req, res) => {
     }
 
     const tone = (req.body.tone || settings.emailTone || 'professional').toLowerCase();
-    const toneText = tone === 'friendly' ? 'friendly' : tone === 'assertive' ? 'assertive' : 'professional';
+    const toneMap = {
+      friendly: 'friendly',
+      assertive: 'assertive',
+      formal: 'formal',
+      casual: 'casual',
+      professional: 'professional',
+    };
+    const toneText = toneMap[tone] || 'professional';
     const prompt = `Write a short, ${toneText} email to vendor ${inv.vendor} letting them know their invoice number ${inv.invoice_number} dated ${inv.date.toISOString().split('T')[0]} for $${inv.amount} was ${status}. Reason: ${why}. Offer guidance on how to correct and resubmit.`;
 
     const completion = await openai.chat.completions.create({


### PR DESCRIPTION
## Summary
- expand `vendorReply` controller tone options to support formal and casual styles
- document new `tone` field in the **Vendor Reply Drafts** README section

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685cc4076d00832ebfa958443f53c9d9