### PR TITLE
Add spend heatmap analytics

### DIFF
--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -12,6 +12,7 @@ const {
   getApprovalStats,
   getApprovalTimeChart,
   getVendorSpend,
+  getSpendHeatmap,
   detectOutliers,
   getRealTimeDashboard,
   detectDuplicateInvoices,
@@ -36,6 +37,7 @@ router.post('/rules', authMiddleware, addRule);
 router.get('/approvals/stats', authMiddleware, getApprovalStats);
 router.get('/approvals/times', authMiddleware, getApprovalTimeChart);
 router.get('/spend/vendor', authMiddleware, getVendorSpend);
+router.get('/spend/heatmap', authMiddleware, getSpendHeatmap);
 router.get('/kpi/approval-time-vendor', authMiddleware, getApprovalTimeByVendor);
 router.get('/kpi/late-payments-trend', authMiddleware, getLatePaymentTrend);
 router.get('/kpi/over-budget', authMiddleware, getInvoicesOverBudget);


### PR DESCRIPTION
## Summary
- provide endpoint to fetch spend heatmap
- expose `/spend/heatmap` route
- display spend heatmap on reports page with drill‑down

## Testing
- `npm run lint` in `backend`
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ccd5c7818832eab44e26d75fc48aa