### PR TITLE
Implement scheduled report emails

### DIFF
--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -20,7 +20,10 @@ const {
   getLatePaymentTrend,
   getInvoicesOverBudget,
   getRiskHeatmap,
-  getInvoiceClusters
+  getInvoiceClusters,
+  listReportSchedules,
+  createReportSchedule,
+  deleteReportSchedule
 } = require('../controllers/analyticsController');
 const { listRules, addRule } = require('../controllers/rulesController');
 const { authMiddleware } = require('../controllers/userController');
@@ -28,6 +31,9 @@ const { authMiddleware } = require('../controllers/userController');
 router.get('/report', authMiddleware, getReport);
 router.get('/report/pdf', authMiddleware, exportReportPDF);
 router.get('/report/excel', authMiddleware, exportReportExcel);
+router.get('/report/schedules', authMiddleware, listReportSchedules);
+router.post('/report/schedules', authMiddleware, createReportSchedule);
+router.delete('/report/schedules/:id', authMiddleware, deleteReportSchedule);
 router.get('/trends', authMiddleware, getTrends);
 router.get('/aging', authMiddleware, getAgingReport);
 router.get('/cash-flow/predict', authMiddleware, predictCashFlowRisk);

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -243,6 +243,19 @@ async function initDb() {
       vendor TEXT PRIMARY KEY,
       country TEXT
     )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS report_schedules (
+      id SERIAL PRIMARY KEY,
+      email TEXT NOT NULL,
+      vendor TEXT,
+      department TEXT,
+      start_date DATE,
+      end_date DATE,
+      cron TEXT NOT NULL DEFAULT '0 8 * * *',
+      active BOOLEAN DEFAULT TRUE,
+      last_run TIMESTAMP,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
   } catch (err) {
     console.error('Database init error:', err);
   }

--- a/backend/utils/reportScheduler.js
+++ b/backend/utils/reportScheduler.js
@@ -4,20 +4,26 @@ const ExcelJS = require('exceljs');
 const pool = require('../config/db');
 const { sendMail } = require('./email');
 const { sendSlackNotification } = require('./notify');
+const { buildFilterQuery } = require('../controllers/analyticsController');
 
-async function buildReport() {
+let jobs = [];
+
+async function buildReport(filters = {}) {
+  const { where, params } = buildFilterQuery(filters);
   const { rows } = await pool.query(
-    "SELECT invoice_number, date, vendor, amount FROM invoices WHERE date >= NOW() - INTERVAL '1 day' ORDER BY date DESC"
+    `SELECT invoice_number, date, vendor, department, amount FROM invoices ${where} ORDER BY date DESC`,
+    params
   );
   const doc = new PDFDocument();
   const pdfBuffers = [];
   doc.on('data', b => pdfBuffers.push(b));
-  doc.fontSize(18).text('Daily Invoice Report', { align: 'center' });
+  doc.fontSize(18).text('Invoice Report', { align: 'center' });
   doc.moveDown();
   rows.forEach(r => {
     doc.fontSize(12).text(`Invoice #${r.invoice_number}`);
     doc.text(`Date: ${r.date}`);
     doc.text(`Vendor: ${r.vendor}`);
+    if (r.department) doc.text(`Department: ${r.department}`);
     doc.text(`Amount: $${parseFloat(r.amount).toFixed(2)}`);
     doc.moveDown();
   });
@@ -30,6 +36,7 @@ async function buildReport() {
     { header: 'Invoice', key: 'invoice_number' },
     { header: 'Date', key: 'date' },
     { header: 'Vendor', key: 'vendor' },
+    { header: 'Department', key: 'department' },
     { header: 'Amount', key: 'amount' },
   ];
   rows.forEach(r => sheet.addRow(r));
@@ -39,7 +46,8 @@ async function buildReport() {
 
 async function sendDailyReport() {
   try {
-    const { pdf, excel } = await buildReport();
+    const start = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const { pdf, excel } = await buildReport({ startDate: start.toISOString() });
     const { rows: flagged } = await pool.query(
       "SELECT COUNT(*) AS cnt FROM invoices WHERE flagged = TRUE AND created_at >= NOW() - INTERVAL '1 day'"
     );
@@ -64,6 +72,48 @@ async function sendDailyReport() {
 
 function scheduleReports() {
   cron.schedule('0 8 * * *', sendDailyReport);
+  loadReportSchedules();
 }
 
-module.exports = { scheduleReports };
+async function sendScheduledReport(s) {
+  try {
+    const { pdf, excel } = await buildReport({
+      vendor: s.vendor,
+      department: s.department,
+      startDate: s.start_date ? s.start_date.toISOString?.() || s.start_date : null,
+      endDate: s.end_date ? s.end_date.toISOString?.() || s.end_date : null,
+    });
+    await sendMail({
+      to: s.email,
+      subject: 'Scheduled Invoice Report',
+      text: 'Your requested report is attached.',
+      attachments: [
+        { filename: 'report.pdf', content: pdf },
+        { filename: 'report.xlsx', content: excel },
+      ],
+    });
+    await pool.query('UPDATE report_schedules SET last_run = NOW() WHERE id = $1', [s.id]);
+  } catch (err) {
+    console.error('Scheduled report error:', err);
+  }
+}
+
+async function loadReportSchedules() {
+  try {
+    const { rows } = await pool.query('SELECT * FROM report_schedules WHERE active = TRUE');
+    jobs.forEach(j => j.stop());
+    jobs = [];
+    for (const s of rows) {
+      try {
+        const job = cron.schedule(s.cron || '0 8 * * *', () => sendScheduledReport(s).catch(() => {}));
+        jobs.push(job);
+      } catch (err) {
+        console.error('Report schedule cron error:', err.message);
+      }
+    }
+  } catch (err) {
+    console.error('Load report schedules error:', err);
+  }
+}
+
+module.exports = { scheduleReports, loadReportSchedules };


### PR DESCRIPTION
## Summary
- support filtering by department in analytics report queries
- allow configuring scheduled report emails
- add DB table for report schedules
- export helper to schedule custom reports

## Testing
- `npm test --watchAll=false` *(fails: react-scripts not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685cd2fda614832ea2361d6505f7836f