### PR TITLE
Add budget guardrails and forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ npm install --legacy-peer-deps
 - Auto-routing invoices by vendor or tag
 - Smart auto-assignment routes invoices to the usual owner using vendor history
 - Budget threshold warnings
+- Budget guardrails with live upload warnings and budget forecasts
 - Anomaly detection dashboard
 - Automatic anomaly alerts with severity tiers
 - Fraud pattern detection for suspicious vendor activity
@@ -293,6 +294,7 @@ as "Marketing", "Legal", or "Recurring" when no rule matches.
 
 - `POST /api/invoices/budgets` – create/update a monthly or quarterly budget by vendor or tag
 - `GET /api/invoices/budgets/warnings` – check if spending has exceeded 90% of a budget
+- `GET /api/invoices/budgets/forecast` – predict next month's spend by department
 - `GET /api/invoices/anomalies` – list vendors with unusual spending spikes
 - `GET /api/workflows` – list saved workflows
 - `POST /api/workflows` – create or update a workflow

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -98,7 +98,7 @@ const { suggestVendor, suggestVoucher } = require('../controllers/aiController')
 const { naturalLanguageQuery, naturalLanguageSearch } = require("../controllers/aiController");
 const { flagSuspiciousInvoice } = require('../controllers/invoiceController');
 const { getActivityLogs, getInvoiceTimeline, exportComplianceReport, exportInvoiceHistory, exportVendorHistory } = require('../controllers/activityController');
-const { setBudget, getBudgets, checkBudgetWarnings, getBudgetVsActual } = require('../controllers/budgetController');
+const { setBudget, getBudgets, checkBudgetWarnings, getBudgetVsActual, getBudgetForecast } = require('../controllers/budgetController');
 const { getAnomalies } = require('../controllers/anomalyController');
 const { detectPatterns, fraudHeatmap } = require('../controllers/fraudController');
 const { vendorReply } = require('../controllers/vendorReplyController');
@@ -201,6 +201,7 @@ router.post('/budgets', authMiddleware, authorizeRoles('admin'), setBudget);
 router.get('/budgets', authMiddleware, authorizeRoles('admin'), getBudgets);
 router.get('/budgets/warnings', authMiddleware, checkBudgetWarnings);
 router.get('/budgets/department-report', authMiddleware, getBudgetVsActual);
+router.get('/budgets/forecast', authMiddleware, getBudgetForecast);
 router.get('/anomalies', authMiddleware, getAnomalies);
 router.get('/fraud/patterns', authMiddleware, authorizeRoles('admin'), detectPatterns);
 router.get('/fraud/heatmap', authMiddleware, authorizeRoles('admin'), fraudHeatmap);

--- a/frontend/src/Dashboard.js
+++ b/frontend/src/Dashboard.js
@@ -19,6 +19,8 @@ function Dashboard() {
   const [categories, setCategories] = useState([]);
   const [anomalies, setAnomalies] = useState([]);
   const [budget, setBudget] = useState([]);
+  const [remainingBudget, setRemainingBudget] = useState([]);
+  const [budgetForecast, setBudgetForecast] = useState([]);
   const [selectedVendor, setSelectedVendor] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -50,8 +52,14 @@ function Dashboard() {
       fetch(`${API_BASE}/api/invoices/budgets/department-report`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
-          if (ok) setBudget(d.data || []);
+          if (ok) {
+            setBudget(d.data || []);
+            setRemainingBudget((d.data || []).map(b => ({ department: b.department, remaining: b.remaining })));
+          }
         }),
+      fetch(`${API_BASE}/api/invoices/budgets/forecast`, { headers })
+        .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+        .then(({ ok, d }) => { if (ok) setBudgetForecast(d.forecast || []); }),
       fetch(`${API_BASE}/api/invoices/upload-heatmap`, { headers })
         .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
         .then(({ ok, d }) => {
@@ -303,6 +311,44 @@ function Dashboard() {
                     <YAxis />
                     <Tooltip />
                     <Bar dataKey="spent" fill="#3b82f6" name="Spent" />
+                    <Bar dataKey="budget" fill="#ef4444" name="Budget" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </motion.div>
+            )}
+          </div>
+          <div className="h-64">
+            <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Remaining Budget</h2>
+            {loading ? (
+              <Skeleton rows={1} className="h-full" height="h-full" />
+            ) : (
+              <motion.div initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={remainingBudget} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="department" />
+                    <YAxis />
+                    <Tooltip />
+                    <Bar dataKey="remaining" fill="#4ade80" name="Remaining" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </motion.div>
+            )}
+          </div>
+          <div className="h-64">
+            <h2 className="text-lg font-semibold mb-2 text-gray-800 dark:text-gray-100">Budget Forecast</h2>
+            {loading ? (
+              <Skeleton rows={1} className="h-full" height="h-full" />
+            ) : (
+              <motion.div initial={{ x: 20, opacity: 0 }} animate={{ x: 0, opacity: 1 }}>
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={budgetForecast} margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="department" />
+                    <YAxis />
+                    <Tooltip />
+                    <Legend />
+                    <Bar dataKey="forecast" fill="#3b82f6" name="Forecast" />
                     <Bar dataKey="budget" fill="#ef4444" name="Budget" />
                   </BarChart>
                 </ResponsiveContainer>


### PR DESCRIPTION
## Summary
- extend budget vs actual endpoint to return remaining amounts
- add budget forecast endpoint
- warn on upload if department budget would be exceeded
- show remaining budget and forecast charts in dashboard
- document new feature and endpoint

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm test` in backend *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_685cd712fc5c832ebc97621ac39be1c4