### PR TITLE
Add smart search bar

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -96,6 +96,7 @@ const { smartDraftEmail } = require('../controllers/emailController');
 const { summarizeVendorData } = require('../controllers/aiController');
 const { suggestVendor, suggestVoucher } = require('../controllers/aiController');
 const { naturalLanguageQuery, naturalLanguageSearch } = require("../controllers/aiController");
+const { smartSearchParse } = require('../controllers/aiController');
 const { flagSuspiciousInvoice } = require('../controllers/invoiceController');
 const { getActivityLogs, getInvoiceTimeline, exportComplianceReport, exportInvoiceHistory, exportVendorHistory } = require('../controllers/activityController');
 const { setBudget, getBudgets, checkBudgetWarnings, getBudgetVsActual, getBudgetForecast } = require('../controllers/budgetController');
@@ -125,6 +126,7 @@ router.delete('/:id', authMiddleware, authorizeRoles('admin'), deleteInvoiceById
 router.get('/search', searchInvoicesByVendor);
 router.post('/nl-query', authMiddleware, naturalLanguageQuery);
 router.post('/nl-search', authMiddleware, naturalLanguageSearch);
+router.post('/smart-search', authMiddleware, smartSearchParse);
 router.post('/nl-chart', authMiddleware, nlChartQuery);
 router.post('/quality-score', authMiddleware, invoiceQualityScore);
 router.post('/payment-risk', authMiddleware, paymentRiskScore);

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -36,6 +36,9 @@ export default function Navbar({
   onUpload,
   search,
   onSearchChange,
+  smartQuery,
+  onSmartQueryChange,
+  onSmartSearch,
   onStartTour,
   isOffline = false,
   pendingCount = 0,
@@ -87,6 +90,16 @@ export default function Navbar({
           placeholder={t('searchPlaceholder')}
           aria-label={t('searchPlaceholder')}
           className="input text-gray-800 dark:text-gray-100 h-7 text-sm"
+        />
+        <input
+          id="smartSearchInput"
+          type="text"
+          value={smartQuery}
+          onChange={(e) => onSmartQueryChange?.(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && onSmartSearch?.()}
+          placeholder="Invoices from Amazon last quarter > $1,000"
+          aria-label="Smart search"
+          className="input text-gray-800 dark:text-gray-100 h-7 text-sm w-52"
         />
         <div className="flex items-center space-x-3 relative">
           {isOffline && (


### PR DESCRIPTION
## Summary
- add natural language smart search parsing endpoint
- expose smart-search route
- display a second search bar for natural language queries
- connect navbar with new smart search handler

## Testing
- `npm run lint` in `backend`
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce6933cdc832e8a5d2f5147b351d7