### PR TITLE
Add audit log tracking

### DIFF
--- a/backend/controllers/auditController.js
+++ b/backend/controllers/auditController.js
@@ -1,0 +1,52 @@
+const pool = require('../config/db');
+
+exports.getAuditTrail = async (req, res) => {
+  try {
+    const { invoiceId } = req.query;
+    let result;
+    if (invoiceId) {
+      result = await pool.query(
+        'SELECT * FROM audit_logs WHERE invoice_id = $1 ORDER BY created_at',
+        [invoiceId]
+      );
+    } else {
+      result = await pool.query('SELECT * FROM audit_logs ORDER BY created_at DESC');
+    }
+    res.json(result.rows);
+  } catch (err) {
+    console.error('Audit fetch error:', err);
+    res.status(500).json({ message: 'Failed to fetch audit logs' });
+  }
+};
+
+exports.updateAuditEntry = async (req, res) => {
+  const { id } = req.params;
+  const { action } = req.body;
+  try {
+    const result = await pool.query(
+      'UPDATE audit_logs SET action = $1 WHERE id = $2 RETURNING *',
+      [action, id]
+    );
+    if (result.rowCount === 0) {
+      return res.status(404).json({ message: 'Audit entry not found' });
+    }
+    res.json(result.rows[0]);
+  } catch (err) {
+    console.error('Audit update error:', err);
+    res.status(500).json({ message: 'Failed to update audit entry' });
+  }
+};
+
+exports.deleteAuditEntry = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const result = await pool.query('DELETE FROM audit_logs WHERE id = $1', [id]);
+    if (result.rowCount === 0) {
+      return res.status(404).json({ message: 'Audit entry not found' });
+    }
+    res.json({ message: 'Audit entry deleted' });
+  } catch (err) {
+    console.error('Audit delete error:', err);
+    res.status(500).json({ message: 'Failed to delete audit entry' });
+  }
+};

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -99,6 +99,7 @@ const { naturalLanguageQuery, naturalLanguageSearch } = require("../controllers/
 const { smartSearchParse } = require('../controllers/aiController');
 const { flagSuspiciousInvoice } = require('../controllers/invoiceController');
 const { getActivityLogs, getInvoiceTimeline, exportComplianceReport, exportInvoiceHistory, exportVendorHistory } = require('../controllers/activityController');
+const { getAuditTrail, updateAuditEntry, deleteAuditEntry } = require('../controllers/auditController');
 const { setBudget, getBudgets, checkBudgetWarnings, getBudgetVsActual, getBudgetForecast } = require('../controllers/budgetController');
 const { getAnomalies } = require('../controllers/anomalyController');
 const { detectPatterns, fraudHeatmap, mlDetect, labelFraud } = require('../controllers/fraudController');
@@ -199,6 +200,9 @@ router.get('/logs/export', authMiddleware, authorizeRoles('admin'), exportCompli
 router.get('/logs/invoice/:id/export', authMiddleware, authorizeRoles('admin'), exportInvoiceHistory);
 router.get('/logs/vendor/:vendor/export', authMiddleware, authorizeRoles('admin'), exportVendorHistory);
 router.get('/:id/timeline', authMiddleware, getInvoiceTimeline);
+router.get('/audit', authMiddleware, authorizeRoles('admin'), getAuditTrail);
+router.patch('/audit/:id', authMiddleware, authorizeRoles('admin'), updateAuditEntry);
+router.delete('/audit/:id', authMiddleware, authorizeRoles('admin'), deleteAuditEntry);
 router.post('/budgets', authMiddleware, authorizeRoles('admin'), setBudget);
 router.get('/budgets', authMiddleware, authorizeRoles('admin'), getBudgets);
 router.get('/budgets/warnings', authMiddleware, checkBudgetWarnings);

--- a/backend/utils/activityLogger.js
+++ b/backend/utils/activityLogger.js
@@ -1,5 +1,6 @@
 const pool = require('../config/db');
 const { broadcastActivity } = require('./chatServer');
+const { logAudit } = require('./auditLogger');
 
 async function logActivity(userId, action, invoiceId = null, username = null) {
   try {
@@ -9,6 +10,9 @@ async function logActivity(userId, action, invoiceId = null, username = null) {
     );
     broadcastActivity?.(rows[0]);
     await logActivityDetailed('default', userId, username, action, { invoiceId });
+    if (['upload_invoice', 'approve_invoice', 'flag_invoice', 'unflag_invoice'].includes(action)) {
+      await logAudit(action, invoiceId, userId, username);
+    }
   } catch (err) {
     console.error('Activity log error:', err);
   }

--- a/backend/utils/auditLogger.js
+++ b/backend/utils/auditLogger.js
@@ -1,0 +1,14 @@
+const pool = require('../config/db');
+
+async function logAudit(action, invoiceId, userId, username) {
+  try {
+    await pool.query(
+      'INSERT INTO audit_logs (action, invoice_id, user_id, username) VALUES ($1,$2,$3,$4)',
+      [action, invoiceId, userId, username]
+    );
+  } catch (err) {
+    console.error('Audit log error:', err);
+  }
+}
+
+module.exports = { logAudit };

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -70,6 +70,15 @@ async function initDb() {
       created_at TIMESTAMP DEFAULT NOW()
     )`);
 
+    await pool.query(`CREATE TABLE IF NOT EXISTS audit_logs (
+      id SERIAL PRIMARY KEY,
+      invoice_id INTEGER,
+      action TEXT NOT NULL,
+      user_id INTEGER,
+      username TEXT,
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+
     await pool.query(`CREATE TABLE IF NOT EXISTS notifications (
       id SERIAL PRIMARY KEY,
       user_id INTEGER NOT NULL,


### PR DESCRIPTION
## Summary
- add audit logger utility and controller
- extend activity logging with audit writes
- create database table for audit logs
- expose admin routes to manage audit entries

## Testing
- `npm run lint` in backend


------
https://chatgpt.com/codex/tasks/task_e_685ce9383a1c832eafc7b54218a7b902