### PR TITLE
Update branding to ClarifyOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Invoice Uploader + AI Error Summarizer
+# ClarifyOps Invoice Uploader + AI Error Summarizer
 
 This is a full-stack invoice uploader tool with AI-powered CSV error summarization, built using:
 

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "Invoice Uploader AI API",
+    "title": "ClarifyOps API",
     "version": "1.0.0"
   },
   "paths": {

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Invoice Uploader Gmail",
+  "name": "ClarifyOps Gmail",
   "version": "0.1",
   "description": "Upload invoices directly from Gmail",
   "permissions": ["activeTab", "scripting"],

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -9,12 +9,12 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap"
       rel="stylesheet"
     />
-    <title>Invoice Uploader AI</title>
+    <title>ClarifyOps</title>
     <meta
       name="description"
       content="Automate invoice uploads and use AI to instantly catch errors and gain insights."
     />
-    <meta property="og:title" content="Invoice Uploader AI" />
+    <meta property="og:title" content="ClarifyOps" />
     <meta
       property="og:description"
       content="Streamline accounts payable with AI-driven invoice validation and analytics."

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2244,7 +2244,7 @@ useEffect(() => {
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100 flex items-center space-x-1">
             <DocumentArrowDownIcon className="w-6 h-6" />
-            <span>Invoice Uploader AI</span>
+            <span>ClarifyOps</span>
           </h1>
           <LiveFeed token={token} tenant={tenant} />
         </div>

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -47,7 +47,7 @@ export default function LandingPage() {
         <div className="container mx-auto flex justify-between items-center p-4">
           <div className="flex items-center space-x-2">
             <DocumentArrowUpIcon className="w-6 h-6 text-indigo-600" />
-            <span className="font-bold text-lg">Invoice Uploader AI</span>
+            <span className="font-bold text-lg">ClarifyOps</span>
           </div>
           <div className="hidden md:flex items-center space-x-6 text-sm">
             <a href="#product" className="hover:text-indigo-600">Product</a>
@@ -102,7 +102,7 @@ export default function LandingPage() {
             <thead>
               <tr>
                 <th className="border-b px-4 py-2 text-left">Feature</th>
-                <th className="border-b px-4 py-2">Invoice Uploader AI</th>
+                <th className="border-b px-4 py-2">ClarifyOps</th>
                 <th className="border-b px-4 py-2">Competitor A</th>
                 <th className="border-b px-4 py-2">Competitor B</th>
               </tr>
@@ -374,7 +374,7 @@ export default function LandingPage() {
                 <a href="#about" className="hover:underline">About</a>
               </li>
               <li>
-                <a href="mailto:contact@example.com" className="hover:underline">Contact</a>
+                <a href="mailto:contact@clarifyops.com" className="hover:underline">Contact</a>
               </li>
               <li>
                 <Link to="/blog" className="hover:underline">Blog</Link>
@@ -416,7 +416,7 @@ export default function LandingPage() {
           </div>
         </div>
         <p className="text-center mt-8 text-xs">
-          © {new Date().getFullYear()} Invoice Uploader AI
+          © {new Date().getFullYear()} ClarifyOps
         </p>
       </footer>
       <ChatWidget />

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -39,7 +39,7 @@ export default function Login({ onLogin, addToast }) {
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-4 z-20 flex justify-between items-center">
         <h1 className="text-xl font-bold flex items-center space-x-1">
           <img src={`/api/${localStorage.getItem('tenant') || 'default'}/logo`} alt="logo" className="h-5 w-5" />
-          <span>Invoice Uploader AI</span>
+          <span>ClarifyOps</span>
         </h1>
         <div className="flex items-center gap-2">
           <HighContrastToggle />

--- a/frontend/src/components/ChatWidget.jsx
+++ b/frontend/src/components/ChatWidget.jsx
@@ -6,7 +6,7 @@ export default function ChatWidget() {
   const [voice, setVoice] = useState(false);
   const [input, setInput] = useState('');
   const [messages, setMessages] = useState([
-    { sender: 'bot', text: 'Hi! Ask me anything about Invoice Uploader AI.' }
+    { sender: 'bot', text: 'Hi! Ask me anything about ClarifyOps.' }
   ]);
 
   const send = () => {

--- a/frontend/src/components/TourModal.js
+++ b/frontend/src/components/TourModal.js
@@ -5,7 +5,7 @@ export default function TourModal({ open, onClose }) {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 transition-all duration-300 ease-in-out">
       <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg max-w-sm w-full transition-all duration-300 ease-in-out">
-        <h2 className="text-lg font-semibold mb-2">Welcome to Invoice Uploader</h2>
+        <h2 className="text-lg font-semibold mb-2">Welcome to ClarifyOps</h2>
         <p className="text-sm mb-4">
           Use the Upload button to add invoices, search to filter them and tap an invoice number for full details.
         </p>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "title": "Invoice Uploader AI",
+  "title": "ClarifyOps",
   "upload": "Upload",
   "searchPlaceholder": "Search...",
   "demoUpload": "Demo Upload",

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,5 +1,5 @@
 {
-  "title": "Cargador de Facturas AI",
+  "title": "ClarifyOps",
   "upload": "Subir",
   "searchPlaceholder": "Buscar...",
   "demoUpload": "Carga de Demostración",

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,5 +1,5 @@
 {
-  "title": "Téléverseur de Factures AI",
+  "title": "ClarifyOps",
   "upload": "Téléverser",
   "searchPlaceholder": "Recherche...",
   "demoUpload": "Téléversement Démo",


### PR DESCRIPTION
## Summary
- rename UI and docs from Invoice Uploader AI to ClarifyOps
- update contact email to contact@clarifyops.com
- update browser extension name and API docs
- keep translations in sync with new company name

## Testing
- `CI=true npm test --silent > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_685f2e55acb0832eaf2f3c2a560923a3