### PR TITLE
Fix builder timeline crash

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1640,7 +1640,9 @@ useEffect(() => {
       });
       const data = await res.json();
       setTimelineInvoice(id);
-      setTimeline(data);
+      if (Array.isArray(data)) setTimeline(data);
+      else if (Array.isArray(data.timeline)) setTimeline(data.timeline);
+      else setTimeline([]);
       setShowTimeline(true);
     } catch (err) {
       console.error('Timeline fetch failed:', err);
@@ -2018,9 +2020,10 @@ useEffect(() => {
           <div className="bg-white dark:bg-gray-800 p-4 rounded w-96">
             <h2 className="text-lg font-semibold mb-2">Timeline for #{timelineInvoice}</h2>
             <ul className="text-sm max-h-60 overflow-y-auto">
-              {timeline.map((t, i) => (
-                <li key={i}>{new Date(t.created_at).toLocaleString()} - {t.action}</li>
-              ))}
+              {Array.isArray(timeline) &&
+                timeline.map((t, i) => (
+                  <li key={i}>{new Date(t.created_at).toLocaleString()} - {t.action}</li>
+                ))}
             </ul>
             <button onClick={() => setShowTimeline(false)} className="mt-2 bg-indigo-600 text-white px-3 py-1 rounded" title="Close">Close</button>
           </div>

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -39,7 +39,11 @@ export default function DashboardBuilder() {
           const id = list[0].id;
           fetch(`${API_BASE}/api/invoices/${id}/timeline`, { headers })
             .then((res) => res.json())
-            .then((data) => setTimeline(data))
+            .then((data) => {
+              if (Array.isArray(data)) setTimeline(data);
+              else if (Array.isArray(data.timeline)) setTimeline(data.timeline);
+              else setTimeline([]);
+            })
             .catch(() => {});
         }
       })
@@ -124,9 +128,12 @@ export default function DashboardBuilder() {
                           <>
                             <h2 className="text-lg font-semibold mb-2">Approval Timeline</h2>
                             <ul className="text-sm max-h-48 overflow-y-auto">
-                              {timeline.map((t, i) => (
-                                <li key={i}>{new Date(t.created_at).toLocaleString()} - {t.action}</li>
-                              ))}
+                              {Array.isArray(timeline) &&
+                                timeline.map((t, i) => (
+                                  <li key={i}>
+                                    {new Date(t.created_at).toLocaleString()} - {t.action}
+                                  </li>
+                                ))}
                             </ul>
                           </>
                         )}

--- a/frontend/src/components/InvoiceDetailModal.js
+++ b/frontend/src/components/InvoiceDetailModal.js
@@ -25,7 +25,11 @@ export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate, t
           headers: { Authorization: `Bearer ${token}` },
         })
           .then((res) => res.json())
-          .then((data) => setTimeline(data))
+          .then((data) => {
+            if (Array.isArray(data)) setTimeline(data);
+            else if (Array.isArray(data.timeline)) setTimeline(data.timeline);
+            else setTimeline([]);
+          })
           .catch((err) => console.error('Timeline fetch failed:', err));
       }
     }
@@ -188,9 +192,10 @@ export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate, t
             {invoice.approval_history?.map((h, i) => (
               <li key={i}>{new Date(h.date).toLocaleString()} - {h.step} {h.status}</li>
             ))}
-            {timeline.map((t, i) => (
-              <li key={`tl-${i}`}>{new Date(t.created_at).toLocaleString()} - {t.action}</li>
-            ))}
+            {Array.isArray(timeline) &&
+              timeline.map((t, i) => (
+                <li key={`tl-${i}`}>{new Date(t.created_at).toLocaleString()} - {t.action}</li>
+              ))}
           </ul>
         </div>
         <div className="mt-3">


### PR DESCRIPTION
## Summary
- ensure timeline data arrays are validated before using them in App, DashboardBuilder and InvoiceDetailModal
- handle cases where the `/timeline` API returns an object instead of an array

## Testing
- `npm test --silent --unsafe-perm` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3dd6ce7c832e911fcf82359bcca2