### PR TITLE
Fix ESLint unused variable warnings

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,7 +50,6 @@ import {
   ArrowDownTrayIcon,
   ArrowUpTrayIcon,
   ArrowUturnUpIcon,
-  ArrowPathIcon,
   CheckCircleIcon,
   ClockIcon,
   CurrencyDollarIcon,

--- a/frontend/src/components/ActionToolbar.js
+++ b/frontend/src/components/ActionToolbar.js
@@ -35,13 +35,11 @@ export default function ActionToolbar({
 }) {
   const [exportOpen, setExportOpen] = useState(false);
   const [insightsOpen, setInsightsOpen] = useState(false);
-  const [filterOpen, setFilterOpen] = useState(false);
   const exportRef = useRef(null);
   const insightsRef = useRef(null);
   const filterRef = useRef(null);
   useOutsideClick(exportRef, () => setExportOpen(false));
   useOutsideClick(insightsRef, () => setInsightsOpen(false));
-  useOutsideClick(filterRef, () => setFilterOpen(false));
 
   return (
     <div className="sticky top-16 z-10 bg-white dark:bg-gray-800 border-b p-2 flex items-center gap-2 shadow">
@@ -110,7 +108,6 @@ export default function ActionToolbar({
           <Button
             onClick={() => {
               if (onToggleFilters) onToggleFilters();
-              else setFilterOpen((o) => !o);
             }}
             size="icon"
             variant="outline"


### PR DESCRIPTION
## Summary
- remove unused `ArrowPathIcon` import in App
- remove unused filter open logic in ActionToolbar

## Testing
- `npm test --silent` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685f40e136c0832eb2f8a8a59d51c824