### PR TITLE
Implement DataTable with pagination and export

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/icons-material": "^7.1.2",
         "@mui/material": "^7.1.2",
         "@radix-ui/react-progress": "^1.0.3",
+        "@tanstack/react-table": "^8.21.3",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -4375,6 +4376,39 @@
       "integrity": "sha512-P3nr6WkvKV/ONsTzj6Gb57sWPMX29EPNPopo7+FcpkQaNsrNpZ1pv8QmrYI2RqEKD7mlGqLnGovlcYnBK0IqUA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/react-table": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.21.3.tgz",
+      "integrity": "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/table-core": "8.21.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@mui/icons-material": "^7.1.2",
     "@mui/material": "^7.1.2",
     "@radix-ui/react-progress": "^1.0.3",
+    "@tanstack/react-table": "^8.21.3",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -1,6 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import DataTable from './components/DataTable';
 import { API_BASE } from './api';
 
 function Archive() {
@@ -53,6 +54,38 @@ function Archive() {
     }
   };
 
+  const columns = useMemo(
+    () => [
+      { accessorKey: 'invoice_number', header: '#' },
+      {
+        accessorKey: 'date',
+        header: 'Date',
+        cell: (info) => new Date(info.getValue()).toLocaleDateString(),
+      },
+      { accessorKey: 'vendor', header: 'Vendor' },
+      {
+        accessorKey: 'amount',
+        header: 'Amount',
+        cell: (info) => `$${info.getValue()}`,
+      },
+      {
+        id: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => (
+          <button
+            onClick={() => handleRestore(row.original.id)}
+            className="btn btn-primary text-xs px-2 py-1"
+            title="Restore"
+          >
+            Restore
+          </button>
+        ),
+        size: 100,
+      },
+    ],
+    [handleRestore]
+  );
+
   return (
     <MainLayout title="Invoice Archive" helpTopic="archive">
       <div className="space-y-4">
@@ -66,38 +99,19 @@ function Archive() {
           </label>
         </div>
         <div className="overflow-x-auto rounded-lg">
-        <table className="min-w-full border text-sm rounded-lg overflow-hidden">
-          <thead>
-            <tr className="bg-gray-200 dark:bg-gray-700">
-              <th className="px-2 py-1">#</th>
-              <th className="px-2 py-1">Date</th>
-              <th className="px-2 py-1">Vendor</th>
-              <th className="px-2 py-1">Amount</th>
-              <th className="px-2 py-1">Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading ? (
-              <tr>
-                <td colSpan="5" className="p-4"><Skeleton rows={5} height="h-4" /></td>
-              </tr>
-            ) : (
-              filtered.map((inv) => (
-                <tr key={inv.id} className="border-t hover:bg-gray-100">
-                  <td className="px-2 py-1">{inv.invoice_number}</td>
-                  <td className="px-2 py-1">{new Date(inv.date).toLocaleDateString()}</td>
-                  <td className="px-2 py-1">{inv.vendor}</td>
-                  <td className="px-2 py-1">${inv.amount}</td>
-                  <td className="px-2 py-1">
-                    <button onClick={() => handleRestore(inv.id)} className="btn btn-primary text-xs px-2 py-1" title="Restore">
-                      Restore
-                    </button>
+          {loading ? (
+            <table className="min-w-full border text-sm rounded-lg overflow-hidden">
+              <tbody>
+                <tr>
+                  <td colSpan="5" className="p-4">
+                    <Skeleton rows={5} height="h-4" />
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+              </tbody>
+            </table>
+          ) : (
+            <DataTable columns={columns} data={filtered} />
+          )}
         </div>
       </div>
     </MainLayout>

--- a/frontend/src/components/DataTable.jsx
+++ b/frontend/src/components/DataTable.jsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import {
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { unparse } from 'papaparse';
+import { Button } from './ui/Button';
+
+export default function DataTable({ columns, data }) {
+  const [sorting, setSorting] = useState([]);
+  const [columnSizing, setColumnSizing] = useState({});
+  const [exportOpen, setExportOpen] = useState(false);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnSizing,
+    },
+    enableColumnResizing: true,
+    columnResizeMode: 'onChange',
+    onColumnSizingChange: setColumnSizing,
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const exportRows = (format) => {
+    const rows = table.getRowModel().rows.map((r) => r.original);
+    let blob;
+    if (format === 'csv') {
+      blob = new Blob([unparse(rows)], { type: 'text/csv' });
+    } else {
+      blob = new Blob([JSON.stringify(rows, null, 2)], {
+        type: 'application/json',
+      });
+    }
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `data.${format}`;
+    link.click();
+    URL.revokeObjectURL(url);
+    setExportOpen(false);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm border rounded-lg overflow-hidden">
+          <thead>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <tr key={headerGroup.id} className="bg-gray-200 dark:bg-gray-700">
+                {headerGroup.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    className="relative px-2 py-1 select-none"
+                    style={{ width: header.getSize() }}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext()
+                    )}
+                    {{ asc: ' \u2191', desc: ' \u2193' }[
+                      header.column.getIsSorted()
+                    ] || null}
+                    {header.column.getCanResize() && (
+                      <div
+                        onMouseDown={header.getResizeHandler()}
+                        onTouchStart={header.getResizeHandler()}
+                        className={`resizer${
+                          header.column.getIsResizing() ? ' isResizing' : ''
+                        }`}
+                      />
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map((row) => (
+              <tr key={row.id} className="border-t hover:bg-gray-100">
+                {row.getVisibleCells().map((cell) => (
+                  <td key={cell.id} className="px-2 py-1">
+                    {flexRender(
+                      cell.column.columnDef.cell,
+                      cell.getContext()
+                    )}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="flex items-center justify-between text-sm">
+        <div className="flex items-center space-x-1">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<<'}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            {'<'}
+          </Button>
+          <span>
+            Page {table.getState().pagination.pageIndex + 1} of{' '}
+            {table.getPageCount()}
+          </span>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>'}
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            {'>>'}
+          </Button>
+        </div>
+        <div className="relative">
+          <Button variant="secondary" size="sm" onClick={() => setExportOpen((o) => !o)}>
+            Export
+          </Button>
+          {exportOpen && (
+            <div className="absolute right-0 mt-1 bg-white dark:bg-gray-800 border rounded shadow-lg z-10">
+              <button
+                className="block px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700 w-full"
+                onClick={() => exportRows('csv')}
+              >
+                CSV
+              </button>
+              <button
+                className="block px-3 py-1 text-left hover:bg-gray-100 dark:hover:bg-gray-700 w-full"
+                onClick={() => exportRows('json')}
+              >
+                JSON
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -91,3 +91,17 @@ code {
 .high-contrast .card {
   @apply bg-black text-yellow-300 border border-yellow-400;
 }
+
+.resizer {
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 4px;
+  height: 100%;
+  cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+}
+.resizer.isResizing {
+  background-color: rgb(156 163 175); /* gray-400 */
+}


### PR DESCRIPTION
## Summary
- add `@tanstack/react-table` dependency
- create reusable `DataTable` component with pagination, sorting, resize and export
- integrate `DataTable` into Archive page
- add column-resize styles

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685f4853841c832eaa8f2d9a1677ea8a