### PR TITLE
Enhance dashboard metrics

### DIFF
--- a/frontend/src/components/StatCard.jsx
+++ b/frontend/src/components/StatCard.jsx
@@ -1,13 +1,67 @@
 import React from 'react';
+import { TrendingUpIcon, TrendingDownIcon } from '@heroicons/react/24/outline';
 import { Card } from './ui/Card';
+import { Button } from './ui/Button';
+import { cn } from '../lib/utils';
 
-export default function StatCard({ title, value }) {
+export default function StatCard({
+  icon,
+  title,
+  value,
+  subtext,
+  trend,
+  cta,
+  onCta,
+  badge,
+  children,
+}) {
+  const TrendIcon =
+    typeof trend === 'number'
+      ? trend > 0
+        ? TrendingUpIcon
+        : trend < 0
+        ? TrendingDownIcon
+        : null
+      : null;
+  const trendColor =
+    typeof trend === 'number'
+      ? trend > 0
+        ? 'text-green-600'
+        : trend < 0
+        ? 'text-red-600'
+        : 'text-gray-500'
+      : 'text-gray-500';
+
   return (
-    <Card className="text-center p-4">
-      <div className="text-xs text-gray-500 dark:text-gray-400">{title}</div>
-      <div className="text-lg font-semibold text-gray-800 dark:text-gray-100">
+    <Card className="p-4 flex flex-col gap-1 relative">
+      <div className="flex items-start gap-1">
+        {icon && <span className="text-indigo-600">{icon}</span>}
+        <span className="text-xs text-gray-500 dark:text-gray-400 flex-1">
+          {title}
+        </span>
+        {badge && (
+          <span className="w-2 h-2 rounded-full bg-red-500" />
+        )}
+      </div>
+      <div className="text-xl font-semibold text-gray-800 dark:text-gray-100">
         {value}
       </div>
+      {subtext && (
+        <div className={cn('text-xs flex items-center gap-1', trendColor)}>
+          {TrendIcon && <TrendIcon className="w-3 h-3" />}
+          <span>{subtext}</span>
+        </div>
+      )}
+      {children}
+      {cta && (
+        <Button
+          onClick={onCta}
+          size="sm"
+          className="mt-2 self-start"
+        >
+          {cta}
+        </Button>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- improve `StatCard` component with CTA, icons and trend display
- revamp dashboard metric row to use enhanced `StatCard`
- fetch monthly insights for top AI suggestions

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f57499388832eb92d823ed0263a74