### PR TITLE
Fix trending icons import

### DIFF
--- a/frontend/src/components/StatCard.jsx
+++ b/frontend/src/components/StatCard.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { TrendingUpIcon, TrendingDownIcon } from '@heroicons/react/24/outline';
+import {
+  ArrowTrendingUpIcon,
+  ArrowTrendingDownIcon,
+} from '@heroicons/react/24/outline';
 import { Card } from './ui/Card';
 import { Button } from './ui/Button';
 import { cn } from '../lib/utils';
@@ -18,9 +21,9 @@ export default function StatCard({
   const TrendIcon =
     typeof trend === 'number'
       ? trend > 0
-        ? TrendingUpIcon
+        ? ArrowTrendingUpIcon
         : trend < 0
-        ? TrendingDownIcon
+        ? ArrowTrendingDownIcon
         : null
       : null;
   const trendColor =


### PR DESCRIPTION
## Summary
- replace deprecated TrendingUpIcon/TrendingDownIcon
- use ArrowTrendingUpIcon/ArrowTrendingDownIcon instead

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_685f5d316720832eb3c4ee519f5b5d54