### PR TITLE
Refine inbox view

### DIFF
--- a/frontend/src/Inbox.js
+++ b/frontend/src/Inbox.js
@@ -4,6 +4,15 @@ import Skeleton from './components/Skeleton';
 import { motion } from 'framer-motion';
 import ChatSidebar from './components/ChatSidebar';
 import { API_BASE } from './api';
+import {
+  DocumentTextIcon,
+  BuildingOfficeIcon,
+  CurrencyDollarIcon,
+  Cog6ToothIcon,
+  CheckCircleIcon,
+  XCircleIcon,
+  ChatBubbleLeftRightIcon,
+} from '@heroicons/react/24/outline';
 
 export default function Inbox() {
   const token = localStorage.getItem('token') || '';
@@ -92,11 +101,23 @@ export default function Inbox() {
       <div className="overflow-x-auto rounded-lg">
       <table className="min-w-full text-sm border rounded-lg overflow-hidden">
         <thead>
-          <tr className="bg-gray-200 dark:bg-gray-700">
-            <th className="px-2 py-1">#</th>
-            <th className="px-2 py-1">Vendor</th>
-            <th className="px-2 py-1">Amount</th>
-            <th className="px-2 py-1">Actions</th>
+          <tr className="bg-gray-200 dark:bg-gray-700 text-center">
+            <th className="px-2 py-2" title="Invoice #">
+              <DocumentTextIcon className="w-4 h-4 mx-auto" />
+              <span className="sr-only">Invoice #</span>
+            </th>
+            <th className="px-2 py-2" title="Vendor">
+              <BuildingOfficeIcon className="w-4 h-4 mx-auto" />
+              <span className="sr-only">Vendor</span>
+            </th>
+            <th className="px-2 py-2" title="Amount">
+              <CurrencyDollarIcon className="w-4 h-4 mx-auto" />
+              <span className="sr-only">Amount</span>
+            </th>
+            <th className="px-2 py-2" title="Actions">
+              <Cog6ToothIcon className="w-4 h-4 mx-auto" />
+              <span className="sr-only">Actions</span>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -105,27 +126,54 @@ export default function Inbox() {
               <td colSpan="4" className="p-4"><Skeleton rows={5} height="h-4" /></td>
             </tr>
           ) : (
-            invoices.map(inv => (
-              <motion.tr
-                key={inv.id}
-                className="border-t hover:bg-gray-100"
-                drag="x"
-                dragConstraints={{ left: -120, right: 0 }}
-                onDragEnd={(e, info) => {
-                  if (info.offset.x < -100) archive(inv.id);
-                }}
-                whileDrag={{ scale: 1.02 }}
-              >
-                <td className="px-2 py-1">{inv.invoice_number}</td>
-                <td className="px-2 py-1">{inv.vendor}</td>
-                <td className="px-2 py-1">${inv.amount}</td>
-                <td className="px-2 py-1 space-x-1">
-                  <button onClick={() => approve(inv.id)} className="bg-green-600 text-white px-2 py-1 rounded text-xs">Approve</button>
-                  <button onClick={() => reject(inv.id)} className="bg-red-600 text-white px-2 py-1 rounded text-xs">Reject</button>
-                  <button onClick={() => openCopilot(inv)} className="bg-indigo-600 text-white px-2 py-1 rounded text-xs">Chat</button>
-                </td>
-              </motion.tr>
-            ))
+            invoices.map(inv => {
+              const status = inv.flagged ? 'Flagged' : inv.approval_status || 'Pending';
+              const borderColor =
+                status === 'Approved'
+                  ? 'border-green-500'
+                  : status === 'Flagged' || status === 'Rejected'
+                  ? 'border-red-500'
+                  : 'border-yellow-500';
+              return (
+                <motion.tr
+                  key={inv.id}
+                  className={`border-t hover:bg-gray-50 hover:shadow-sm transition-shadow ${borderColor} border-l-4`}
+                  drag="x"
+                  dragConstraints={{ left: -120, right: 0 }}
+                  onDragEnd={(e, info) => {
+                    if (info.offset.x < -100) archive(inv.id);
+                  }}
+                  whileDrag={{ scale: 1.02 }}
+                >
+                  <td className="px-3 py-2">{inv.invoice_number}</td>
+                  <td className="px-3 py-2">{inv.vendor}</td>
+                  <td className="px-3 py-2">${inv.amount}</td>
+                  <td className="px-3 py-2 space-x-1 flex justify-center">
+                    <button
+                      onClick={() => approve(inv.id)}
+                      className="btn bg-green-600 hover:bg-green-700 text-white p-1"
+                      title="Approve"
+                    >
+                      <CheckCircleIcon className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => reject(inv.id)}
+                      className="btn bg-red-600 hover:bg-red-700 text-white p-1"
+                      title="Reject"
+                    >
+                      <XCircleIcon className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => openCopilot(inv)}
+                      className="btn bg-indigo-600 hover:bg-indigo-700 text-white p-1"
+                      title="Chat"
+                    >
+                      <ChatBubbleLeftRightIcon className="w-4 h-4" />
+                    </button>
+                  </td>
+                </motion.tr>
+              );
+            })
           )}
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- modernize inbox table with icon headers and compact buttons
- add colored status indicator and hover effects

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_685f70826818832eac1c3ce525c42606