### PR TITLE
Improve vendor management with AI features

### DIFF
--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -16,6 +16,8 @@ const {
   deleteVendor,
   getVendorRiskProfile,
   vendorMatchFeedback,
+  getDuplicateVendors,
+  getVendorAnomalies,
 } = require('../controllers/vendorController');
 const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
@@ -28,6 +30,8 @@ router.get('/match', authMiddleware, matchVendors);
 router.post('/ai-match', authMiddleware, aiVendorMatch);
 router.post('/suggestions/:id/feedback', authMiddleware, vendorMatchFeedback);
 router.get('/behavior-flags', authMiddleware, authorizeRoles('admin'), getBehaviorFlags);
+router.get('/duplicates', authMiddleware, authorizeRoles('admin'), getDuplicateVendors);
+router.get('/:vendor/anomalies', authMiddleware, getVendorAnomalies);
 router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
 router.get('/:vendor/info', authMiddleware, getVendorInfo);
 router.get('/:vendor/predict', authMiddleware, predictVendorBehavior);

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -35,6 +35,7 @@ function VendorManagement() {
   const [profileVendor, setProfileVendor] = useState(null);
   const [detailInvoice, setDetailInvoice] = useState(null);
   const [detailVendor, setDetailVendor] = useState(null);
+  const [duplicates, setDuplicates] = useState([]);
 
   const headers = useMemo(
     () => ({ 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }),
@@ -55,7 +56,16 @@ function VendorManagement() {
     setLoading(false);
   }, [headers, showTop]);
 
+  const fetchDuplicates = useCallback(async () => {
+    const res = await fetch(`${API_BASE}/api/vendors/duplicates`, { headers });
+    if (res.ok) {
+      const data = await res.json();
+      setDuplicates(data.duplicates || []);
+    }
+  }, [headers]);
+
   useEffect(() => { if (token) fetchVendors(); }, [fetchVendors, token, showTop]);
+  useEffect(() => { if (token) fetchDuplicates(); }, [fetchDuplicates, token]);
 
   const saveNotes = async (vendor) => {
     const notes = notesInput[vendor] ?? '';
@@ -187,6 +197,16 @@ function VendorManagement() {
           </div>
         </div>
       )}
+      {duplicates.length > 0 && (
+        <div className="bg-yellow-100 dark:bg-yellow-900 p-2 rounded mb-2 text-sm">
+          <p className="font-semibold mb-1">Possible Duplicates:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            {duplicates.map((d, i) => (
+              <li key={i}>{d.vendor1} &amp; {d.vendor2}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <div className="flex flex-wrap gap-4 items-end mt-4 mb-2">
         <div>
           <label className="text-sm">Min Spend</label>
@@ -223,6 +243,7 @@ function VendorManagement() {
             <th className="p-2">Status</th>
             <th className="p-2">Contact Email</th>
             <th className="p-2">Category</th>
+            <th className="p-2">Tags</th>
             <th className="p-2">Notes</th>
             <th className="p-2">Actions</th>
           </tr>
@@ -230,7 +251,7 @@ function VendorManagement() {
         <tbody>
           {loading ? (
             <tr>
-              <td colSpan="6" className="p-4"><Skeleton rows={5} height="h-4" /></td>
+              <td colSpan="9" className="p-4"><Skeleton rows={5} height="h-4" /></td>
             </tr>
           ) : (
             filteredVendors.map(v => (
@@ -264,6 +285,11 @@ function VendorManagement() {
                 </td>
                 <td className="p-2">{v.contact_email || '-'}</td>
                 <td className="p-2">{v.category || '-'}</td>
+                <td className="p-2 space-x-1">
+                  {v.tags && v.tags.map((t, i) => (
+                    <span key={i} className="bg-gray-200 dark:bg-gray-600 px-1 rounded text-xs">{t}</span>
+                  ))}
+                </td>
                 <td className="p-2">
                   {editingVendor === v.vendor ? (
                     <div className="space-y-1">

--- a/frontend/src/components/VendorDetailModal.js
+++ b/frontend/src/components/VendorDetailModal.js
@@ -4,6 +4,7 @@ import { API_BASE } from '../api';
 export default function VendorDetailModal({ vendor, open, onClose, token }) {
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [anomalies, setAnomalies] = useState([]);
 
   useEffect(() => {
     if (!open || !vendor) return;
@@ -12,9 +13,11 @@ export default function VendorDetailModal({ vendor, open, onClose, token }) {
     Promise.all([
       fetch(`${API_BASE}/api/vendors/${encodeURIComponent(vendor)}/profile`, { headers }).then(r => r.json()),
       fetch(`${API_BASE}/api/vendors/${encodeURIComponent(vendor)}/info`, { headers }).then(r => r.json()),
+      fetch(`${API_BASE}/api/vendors/${encodeURIComponent(vendor)}/anomalies`, { headers }).then(r => r.json()),
     ])
-      .then(([profile, info]) => {
+      .then(([profile, info, anomaly]) => {
         setData({ ...profile, info });
+        setAnomalies(anomaly?.anomalies || []);
       })
       .catch(err => console.error('Vendor detail error:', err))
       .finally(() => setLoading(false));
@@ -46,6 +49,19 @@ export default function VendorDetailModal({ vendor, open, onClose, token }) {
             <div className="text-sm mb-1"><span className="font-medium">Health:</span> {health}</div>
             <div className="text-sm mb-1"><span className="font-medium">Notes:</span> {data?.notes || 'None'}</div>
             <div className="text-sm mb-2"><span className="font-medium">Info:</span> {data?.info?.description || '-'}</div>
+            {anomalies.length > 0 && (
+              <div className="mb-2">
+                <h3 className="font-semibold text-sm mb-1">Anomaly History</h3>
+                <ul className="text-sm max-h-32 overflow-y-auto space-y-1">
+                  {anomalies.map((a, i) => (
+                    <li key={i} className="border-b pb-1">
+                      {new Date(a.month).toLocaleDateString(undefined, { month: 'short', year: 'numeric' })} - ${' '}
+                      {a.total.toFixed(2)} (avg {a.avg.toFixed(2)})
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <div>
               <h3 className="font-semibold text-sm mb-1">Invoice Timeline</h3>
               <ul className="text-sm max-h-40 overflow-y-auto space-y-1">


### PR DESCRIPTION
## Summary
- auto-tag vendors as Late Payer or Inactive on the API
- expose vendor duplicate and anomaly endpoints
- show duplicate suggestions and vendor tags in the management page
- include anomaly history in the vendor detail modal

## Testing
- `npm test -- -u` in `frontend` *(fails: react-scripts not found)*
- `npm test` in `backend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68601281d1a8832e816e82d845e240f2