### PR TITLE
Update reports page

### DIFF
--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -75,7 +75,7 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
               className={`nav-link border-l-4 ${location.pathname === '/analytics' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <BarChart2 className="w-5 h-5" />
-              <span>Reports</span>
+              <span>Analytics Hub</span>
             </Link>
             <Link
               to="/audit"


### PR DESCRIPTION
## Summary
- rename reports page to **AI Spend Analytics Hub**
- add anomaly, average and top vendor stats to summary
- show tooltip for anomaly percentage
- rename sidebar menu item to **Analytics Hub**

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm test --silent` in backend (no tests run)

------
https://chatgpt.com/codex/tasks/task_e_686308bd8d1c832eb2800b9d5b429da1