### PR TITLE
Implement AI Threshold Rules and analytics hub updates

### DIFF
--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -286,11 +286,12 @@ exports.uploadInvoice = async (req, res) => {
       const vatAmount = parseFloat(((originalAmount * vatPercent) / 100).toFixed(2));
       const expiresAt = inv.expires_at || req.body.expires_at ||
         (req.body.expiration_days ? new Date(new Date(date).getTime() + parseInt(req.body.expiration_days) * 24 * 60 * 60 * 1000) : null);
-      const withRules = applyRules({
+      const withRules = await applyRules({
         invoice_number,
         date: new Date(date),
         amount: convertedAmount,
         vendor,
+        due_date: inv.due_date || inv.dueDate || null,
       });
       const ruleUpdates = await evaluateWorkflowRules({
         invoice_number,
@@ -1810,7 +1811,7 @@ exports.autoCategorizeInvoice = async (req, res) => {
       return res.status(404).json({ message: 'Invoice not found' });
     }
     let invoice = result.rows[0];
-    invoice = applyRules(invoice);
+    invoice = await applyRules(invoice);
     let tags = invoice.tags || [];
     if (invoice.tags) {
       tags = Array.from(new Set([...tags, ...(invoice.tags || [])]));

--- a/backend/controllers/rulesController.js
+++ b/backend/controllers/rulesController.js
@@ -1,4 +1,4 @@
-const { getRules, addRule } = require('../utils/rulesEngine');
+const { getRules, addRule, updateRule, deleteRule } = require('../utils/rulesEngine');
 
 exports.listRules = (_req, res) => {
   res.json({ rules: getRules() });
@@ -13,4 +13,19 @@ exports.addRule = (req, res) => {
   }
   addRule(rule);
   res.json({ message: 'Rule added', rules: getRules() });
+};
+
+exports.updateRule = (req, res) => {
+  const idx = parseInt(req.params.idx);
+  const rule = req.body;
+  if (isNaN(idx) || !rule) return res.status(400).json({ message: 'Invalid request' });
+  updateRule(idx, rule);
+  res.json({ message: 'Rule updated', rules: getRules() });
+};
+
+exports.deleteRule = (req, res) => {
+  const idx = parseInt(req.params.idx);
+  if (isNaN(idx)) return res.status(400).json({ message: 'Invalid request' });
+  deleteRule(idx);
+  res.json({ message: 'Rule deleted', rules: getRules() });
 };

--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -25,7 +25,7 @@ const {
   createReportSchedule,
   deleteReportSchedule
 } = require('../controllers/analyticsController');
-const { listRules, addRule } = require('../controllers/rulesController');
+const { listRules, addRule, updateRule, deleteRule } = require('../controllers/rulesController');
 const { authMiddleware } = require('../controllers/userController');
 
 router.get('/report', authMiddleware, getReport);
@@ -40,6 +40,8 @@ router.get('/cash-flow/predict', authMiddleware, predictCashFlowRisk);
 router.get('/cash-flow/forecast', authMiddleware, forecastCashFlow);
 router.get('/rules', authMiddleware, listRules);
 router.post('/rules', authMiddleware, addRule);
+router.put('/rules/:idx', authMiddleware, updateRule);
+router.delete('/rules/:idx', authMiddleware, deleteRule);
 router.get('/approvals/stats', authMiddleware, getApprovalStats);
 router.get('/approvals/times', authMiddleware, getApprovalTimeChart);
 router.get('/spend/vendor', authMiddleware, getVendorSpend);

--- a/backend/utils/rulesEngine.js
+++ b/backend/utils/rulesEngine.js
@@ -1,3 +1,5 @@
+const pool = require('../config/db');
+
 let rules = [
   { vendor: 'X', amountGreaterThan: 500, flagReason: 'Vendor X amount > $500' },
   { amountGreaterThan: 5000, flagReason: 'Amount exceeds $5000' },
@@ -5,15 +7,33 @@ let rules = [
   { vendor: 'Google', category: 'Marketing' },
 ];
 
-function applyRules(invoice) {
+// Track how many times each rule triggered
+let ruleStats = rules.map(() => 0);
+
+async function applyRules(invoice) {
   let flagged = false;
   let reason = null;
   let tags = Array.isArray(invoice.tags) ? [...invoice.tags] : [];
-  for (const r of rules) {
+  for (let i = 0; i < rules.length; i++) {
+    const r = rules[i];
     const matchVendor = !r.vendor || (invoice.vendor && invoice.vendor.toLowerCase().includes(r.vendor.toLowerCase()));
     const matchAmount = r.amountGreaterThan ? parseFloat(invoice.amount) > r.amountGreaterThan : true;
     const matchDesc = !r.descriptionContains || ((invoice.description || '').toLowerCase().includes(r.descriptionContains.toLowerCase()));
-    if (matchVendor && matchAmount && matchDesc) {
+    let matchNewVendor = true;
+    if (r.newVendor && invoice.vendor) {
+      const { rows } = await pool.query('SELECT 1 FROM invoices WHERE vendor = $1 LIMIT 1', [invoice.vendor]);
+      matchNewVendor = rows.length === 0;
+    }
+    let matchPastDue = true;
+    if (r.pastDue) {
+      matchPastDue = invoice.due_date && new Date(invoice.due_date) < new Date();
+    }
+    let matchDup = true;
+    if (r.duplicateId && invoice.invoice_number) {
+      const { rows } = await pool.query('SELECT 1 FROM invoices WHERE invoice_number = $1 LIMIT 1', [invoice.invoice_number]);
+      matchDup = rows.length > 0;
+    }
+    if (matchVendor && matchAmount && matchDesc && matchNewVendor && matchPastDue && matchDup) {
       if (r.flagReason) {
         flagged = true;
         reason = r.flagReason || 'Rule triggered';
@@ -21,6 +41,7 @@ function applyRules(invoice) {
       if (r.category) {
         tags.push(r.category);
       }
+      ruleStats[i] = (ruleStats[i] || 0) + 1;
     }
   }
   tags = Array.from(new Set(tags));
@@ -28,15 +49,30 @@ function applyRules(invoice) {
 }
 
 function getRules() {
-  return rules;
+  return rules.map((r, i) => ({ ...r, triggered: ruleStats[i] || 0 }));
 }
 
 function addRule(rule) {
   rules.push(rule);
+  ruleStats.push(0);
 }
 
 function setRules(newRules) {
   rules = newRules;
+  ruleStats = newRules.map(() => 0);
 }
 
-module.exports = { applyRules, getRules, addRule, setRules };
+function updateRule(index, rule) {
+  if (rules[index]) {
+    rules[index] = rule;
+  }
+}
+
+function deleteRule(index) {
+  if (rules[index]) {
+    rules.splice(index, 1);
+    ruleStats.splice(index, 1);
+  }
+}
+
+module.exports = { applyRules, getRules, addRule, setRules, updateRule, deleteRule };

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -157,7 +157,7 @@ export default function Navbar({
                       className="flex items-center px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-700"
                       onClick={() => setMenuOpen(false)}
                     >
-                      <DocumentChartBarIcon className="h-5 w-5 mr-2" /> Analytics
+                      <DocumentChartBarIcon className="h-5 w-5 mr-2" /> AI Spend Analytics Hub
                     </Link>
                     <Link
                       to="/vendors"

--- a/frontend/src/components/RuleModal.js
+++ b/frontend/src/components/RuleModal.js
@@ -1,0 +1,40 @@
+import React, { useState, useEffect } from 'react';
+
+export default function RuleModal({ open, onClose, onSave, initial }) {
+  const [type, setType] = useState('spend');
+  const [amount, setAmount] = useState(1000);
+
+  useEffect(() => {
+    if (initial) {
+      setType(initial.type || 'spend');
+      setAmount(initial.amount || 1000);
+    }
+  }, [initial]);
+
+  if (!open) return null;
+
+  const handleSave = () => {
+    onSave({ type, amount });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow-lg w-72 space-y-3">
+        <h3 className="font-semibold">Define Rule</h3>
+        <select value={type} onChange={e => setType(e.target.value)} className="input w-full">
+          <option value="spend">Spend exceeds</option>
+          <option value="newVendor">Vendor not seen before</option>
+          <option value="pastDue">Invoice past due</option>
+          <option value="duplicate">Duplicate invoice ID</option>
+        </select>
+        {type === 'spend' && (
+          <input type="number" value={amount} onChange={e => setAmount(e.target.value)} className="input w-full" />
+        )}
+        <div className="flex justify-end space-x-2">
+          <button className="btn" onClick={onClose}>Cancel</button>
+          <button className="btn btn-primary" onClick={handleSave}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -75,7 +75,7 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
               className={`nav-link border-l-4 ${location.pathname === '/analytics' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <BarChart2 className="w-5 h-5" />
-              <span>Analytics Hub</span>
+              <span>AI Spend Analytics Hub</span>
             </Link>
             <Link
               to="/audit"


### PR DESCRIPTION
## Summary
- rename sidebar and navbar links to **AI Spend Analytics Hub**
- add rule modal and multi-rule management to Reports page
- extend backend rules engine with new rule types and stats
- expose rule update/delete endpoints
- adjust invoice controller to await async rules

## Testing
- `npm run lint` in backend *(no lint configured)*
- `npm test --silent --prefix frontend` *(failed: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630dbf5308832eae7bc452510365f5