### PR TITLE
Enhance cash flow analytics

### DIFF
--- a/frontend/src/AISpendAnalyticsHub.js
+++ b/frontend/src/AISpendAnalyticsHub.js
@@ -427,7 +427,8 @@ function AISpendAnalyticsHub() {
           {loadingHeatmap && <p className="text-sm">Loading heatmap...</p>}
         </div>
         <div className="mt-8">
-          <h2 className="text-lg font-semibold mb-1 text-gray-800 dark:text-gray-100">Cash Flow Simulation</h2>
+          <h2 className="text-lg font-semibold mb-1 text-gray-800 dark:text-gray-100">Cash Flow Stress Test</h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">Use slider to project how delays impact available cash.</p>
           <CashflowSimulation token={token} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rename "Cash Flow Simulation" section to **Cash Flow Stress Test**
- show description and export option
- compute projected dip, burn rate and days-to-zero metrics

## Testing
- `CI=true npm test --silent` *(fails: useLocation may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_686321657924832eae6e6631be587e21