### PR TITLE
Enhance spend analytics hub

### DIFF
--- a/backend/controllers/analyticsController.js
+++ b/backend/controllers/analyticsController.js
@@ -58,7 +58,9 @@ exports.getReport = async (req, res) => {
   const { where, params } = buildFilterQuery({ vendor, department, startDate, endDate, minAmount, maxAmount, tag });
   try {
     const result = await pool.query(
-      `SELECT id, invoice_number, date, vendor, amount FROM invoices ${where} ORDER BY date DESC`,
+      `SELECT id, invoice_number, date, vendor, amount, approval_status, flagged, flag_reason
+       FROM invoices ${where}
+       ORDER BY date DESC`,
       params
     );
     res.json({ invoices: result.rows });


### PR DESCRIPTION
## Summary
- enrich analytics report endpoint to include invoice status and flags
- show invoices in AI Spend Analytics Hub with status and flag details
- open invoice detail modal on row click for preview and history

## Testing
- `npm test --silent -- -w 1` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863261c6a38832e9296e1c4cd88204d