### PR TITLE
Add adaptive dashboard alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ npm install --legacy-peer-deps
 - Analytics and reports page with filtering and PDF export
 - Trend reports for monthly spend and aging invoices
 - Customizable dashboards with date filters and export options
+- Adaptive dashboard with context-aware alerts and AI suggestions
 - Custom KPI dashboards per department or vendor with charts like approval time by vendor, late payments trend and invoices over budget
 - Public shareable dashboards accessible via secure link
 - ML predictions highlight cash-flow problem areas


### PR DESCRIPTION
## Summary
- add context-aware alerts and suggestion logic in AdaptiveDashboard
- show spike and inactivity alerts on the dashboard
- document adaptive dashboard alerts in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68632a92b2d4832e9ad9301801ee5026