### PR TITLE
Add personalized dashboard recommendations

### DIFF
--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -16,6 +16,7 @@ const {
   getSpendHeatmap,
   detectOutliers,
   getRealTimeDashboard,
+  getDashboardRecommendations,
   detectDuplicateInvoices,
   getApprovalTimeByVendor,
   getLatePaymentTrend,
@@ -54,6 +55,7 @@ router.get('/kpi/over-budget', authMiddleware, getInvoicesOverBudget);
 router.get('/metadata', authMiddleware, getDashboardMetadata);
 router.get('/outliers', authMiddleware, detectOutliers);
 router.get('/dashboard/realtime', authMiddleware, getRealTimeDashboard);
+router.get('/dashboard/recommendations', authMiddleware, getDashboardRecommendations);
 router.get('/anomalies/duplicates', authMiddleware, detectDuplicateInvoices);
 router.get('/risk/heatmap', authMiddleware, getRiskHeatmap);
 router.get('/risk/clusters', authMiddleware, getInvoiceClusters);


### PR DESCRIPTION
## Summary
- implement `/api/analytics/dashboard/recommendations` endpoint
- expose new route in analytics router
- surface personalized recommendations in Adaptive Dashboard

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686332ba9df8832ebc47ce7cae606151