### PR TITLE
Improve logout flow and header layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-use-before-define */
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { io } from 'socket.io-client';
 import { API_BASE } from './api';
 import LiveFeed from './components/LiveFeed';
@@ -1613,9 +1613,12 @@ useEffect(() => {
   
   
 
+  const navigate = useNavigate();
+
   const handleLogout = () => {
     localStorage.removeItem('token');
     setToken(null);
+    navigate('/');
   };
 
   const handleSuggestVendor = async (invoice) => {

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -44,7 +44,7 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen flex flex-col bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <nav className="sticky top-0 bg-white/80 backdrop-blur dark:bg-gray-900/80 shadow z-30">
-        <div className="container mx-auto flex justify-between items-center p-4">
+        <div className="container mx-auto flex justify-between items-center p-2">
           <div className="flex items-center space-x-2">
             <DocumentArrowUpIcon className="w-6 h-6 text-indigo-600" />
             <span className="font-bold text-lg">ClarifyOps</span>

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -36,7 +36,7 @@ export default function Login({ onLogin, addToast }) {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
-      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-4 z-20 flex justify-between items-center">
+      <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-2 z-20 flex justify-between items-center">
         <h1 className="text-xl font-bold flex items-center space-x-1">
           <img src={`/api/${localStorage.getItem('tenant') || 'default'}/logo`} alt="logo" className="h-5 w-5" />
           <span>ClarifyOps</span>

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -8,7 +8,7 @@ import HighContrastToggle from './HighContrastToggle';
 export default function TopNavbar({ title, helpTopic }) {
   const token = localStorage.getItem('token') || '';
   return (
-    <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-4 z-20">
+    <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-2 z-20">
       <h1 className="text-xl font-bold flex items-center gap-1">
         {title}
         {helpTopic && (


### PR DESCRIPTION
## Summary
- redirect users to the landing page after logout
- shrink top navigation padding to avoid overlap with sidebar

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635e2f439c832ea3de99f245c00d4f