### PR TITLE
Fix overlapping navbar

### DIFF
--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -11,7 +11,7 @@ export default function MainLayout({ title, helpTopic, children, collapseSidebar
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex">
       <SidebarNav notifications={notifications} collapsed={collapseSidebar} />
-      <div className="flex-1 pt-16 pb-16 sm:pb-0">
+      <div className="flex-1 pb-16 sm:pb-0">
         <TopNavbar title={title} helpTopic={helpTopic} />
         <div className="container mx-auto px-6 py-8">
           {children}

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -8,7 +8,7 @@ import HighContrastToggle from './HighContrastToggle';
 export default function TopNavbar({ title, helpTopic }) {
   const token = localStorage.getItem('token') || '';
   return (
-    <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-2 z-20">
+    <nav className="sticky top-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-2 z-20">
       <h1 className="text-xl font-bold flex items-center gap-1">
         {title}
         {helpTopic && (


### PR DESCRIPTION
## Summary
- adjust layout so top banner no longer overlaps sidebar navigation
- keep navbar styling consistent with the landing page

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686360a72c20832eab8c1f277f3dec40