### PR TITLE
Fix navbar overlap with sticky positions

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2095,12 +2095,12 @@ useEffect(() => {
         />
       )}
 
-      <div className="pt-16 flex flex-col md:flex-row md:gap-4 min-h-screen">
+      <div className="flex flex-col md:flex-row md:gap-4 min-h-screen">
         {token && (
           <aside
           className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 md:flex-shrink-0 ${
             filterSidebarOpen ? '' : 'hidden md:block'
-          } border-r border-gray-200 dark:border-gray-700 max-h-screen overflow-y-auto sticky top-16 z-40`}
+          } border-r border-gray-200 dark:border-gray-700 max-h-screen overflow-y-auto sticky top-0 z-40`}
         >
           <div className="p-4 space-y-4 overflow-y-auto h-full">
             <SidebarNav notifications={notifications} />

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -44,7 +44,7 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen flex flex-col bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
       <nav className="sticky top-0 bg-white/80 backdrop-blur dark:bg-gray-900/80 shadow z-30">
-        <div className="container mx-auto flex justify-between items-center p-2">
+        <div className="container mx-auto flex justify-between items-center p-4">
           <div className="flex items-center space-x-2">
             <DocumentArrowUpIcon className="w-6 h-6 text-indigo-600" />
             <span className="font-bold text-lg">ClarifyOps</span>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -70,7 +70,7 @@ export default function Navbar({
   }, [tenant, token]);
 
   return (
-    <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow z-20">
+    <nav className="sticky top-0 z-30 bg-indigo-700 dark:bg-indigo-900 text-white shadow">
       <div className="max-w-5xl mx-auto flex flex-wrap justify-between items-center gap-4 p-2">
         <div className="flex items-center space-x-2">
           <Link to="/invoices" className="flex items-center space-x-1" onClick={() => { setMenuOpen(false); setUserOpen(false); }}>

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -25,7 +25,9 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
   const role = localStorage.getItem('role') || '';
 
   return (
-    <aside className={`hidden sm:block bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 shadow-lg ${open ? 'w-64' : 'w-16'} p-4 space-y-2 transition-all`}>
+    <aside
+      className={`hidden sm:block sticky top-0 self-start h-screen bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 shadow-lg ${open ? 'w-64' : 'w-16'} p-4 space-y-2 transition-all`}
+    >
       <button
         onClick={() => setOpen(!open)}
         className="w-full text-left font-semibold mb-2 focus:outline-none focus:ring-2 focus:ring-indigo-400"

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -8,7 +8,7 @@ import HighContrastToggle from './HighContrastToggle';
 export default function TopNavbar({ title, helpTopic }) {
   const token = localStorage.getItem('token') || '';
   return (
-    <nav className="sticky top-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-2 z-20">
+    <nav className="sticky top-0 z-30 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex justify-between items-center p-2">
       <h1 className="text-xl font-bold flex items-center gap-1">
         {title}
         {helpTopic && (


### PR DESCRIPTION
## Summary
- keep landing page nav padding larger
- make the top navigation and sidebar sticky so they align
- adjust layout offsets to match sticky nav

## Testing
- `npm test` (fails: react-scripts not found)
- `npm test` in backend (fails: missing script)


------
https://chatgpt.com/codex/tasks/task_e_6863631c1644832eafd053ea908ce48d