### PR TITLE
Fix DB connection config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # Database connection
 DATABASE_URL=postgres://postgres:postgres@db:5432/invoices
+# Individual DB settings (override DATABASE_URL if needed)
+DB_HOST=db
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=invoices
 # OpenRouter API key for AI features
 OPENROUTER_API_KEY=
 # Email credentials

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -5,11 +5,19 @@ const { AsyncLocalStorage } = require('async_hooks');
 require('dotenv').config(); // so we can read from .env
 
 // Create a connection pool using info from your .env file
-const pool = new Pool({
-  connectionString:
-    process.env.DATABASE_URL ||
-    'postgres://postgres:postgres@localhost:5432/invoices',
-});
+const dbConfig = {
+  host: process.env.DB_HOST || 'db',
+  port: parseInt(process.env.DB_PORT || '5432', 10),
+  user: process.env.DB_USER || 'postgres',
+  password: process.env.DB_PASSWORD || 'postgres',
+  database: process.env.DB_NAME || 'invoices',
+};
+
+if (process.env.DATABASE_URL) {
+  dbConfig.connectionString = process.env.DATABASE_URL;
+}
+
+const pool = new Pool(dbConfig);
 
 const als = new AsyncLocalStorage();
 


### PR DESCRIPTION
## Summary
- allow overriding DB connection settings in backend
- document DB host/port/user/password in `.env.example`

## Testing
- `npm run lint` in backend
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686491723f30832eabc8fe94fdbd8c53