### PR TITLE
Persist user accounts in database

### DIFF
--- a/backend/controllers/inviteController.js
+++ b/backend/controllers/inviteController.js
@@ -38,10 +38,10 @@ exports.acceptInvite = async (req, res) => {
     ) {
       return res.status(400).json({ message: 'Invalid or expired invite' });
     }
-    if (userExists(username)) {
+    if (await userExists(username)) {
       return res.status(400).json({ message: 'User exists' });
     }
-    const user = createUser(username, password, rows[0].role);
+    const user = await createUser(username, password, rows[0].role);
     await pool.query('UPDATE invites SET used = TRUE WHERE token = $1', [token]);
     res.json({ id: user.id, username: user.username, role: user.role });
   } catch (err) {

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,72 +1,60 @@
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
+const pool = require('../config/db');
 const { logActivity } = require('../utils/activityLogger');
 
-const USERS = [
-  {
-    id: 1,
-    username: 'admin',
-    passwordHash: bcrypt.hashSync('password123', 10),
-    role: 'admin',
-  },
-  {
-    id: 2,
-    username: 'accountant',
-    passwordHash: bcrypt.hashSync('accountantpass', 10),
-    role: 'accountant',
-  },
-  {
-    id: 3,
-    username: 'approver',
-    passwordHash: bcrypt.hashSync('approverpass', 10),
-    role: 'approver',
-  },
-];
-
-function userExists(username) {
-  return USERS.some((u) => u.username === username);
+async function userExists(username) {
+  const { rows } = await pool.query('SELECT 1 FROM users WHERE username = $1', [username]);
+  return rows.length > 0;
 }
 
-function createUser(username, password, role) {
-  const id = USERS.length ? Math.max(...USERS.map((u) => u.id)) + 1 : 1;
-  const passwordHash = bcrypt.hashSync(password, 10);
-  const user = { id, username, passwordHash, role };
-  USERS.push(user);
-  return user;
+async function createUser(username, password, role) {
+  const passwordHash = await bcrypt.hash(password, 10);
+  const { rows } = await pool.query(
+    'INSERT INTO users (username, password_hash, role) VALUES ($1,$2,$3) RETURNING id, username, role',
+    [username, passwordHash, role]
+  );
+  return rows[0];
 }
 
 const REFRESH_TOKENS = [];
 
-exports.login = (req, res) => {
+exports.login = async (req, res) => {
   const { username, password } = req.body;
-  const user = USERS.find((u) => u.username === username);
+  try {
+    const { rows } = await pool.query('SELECT * FROM users WHERE username = $1', [username]);
+    const user = rows[0];
+    if (!user || !(await bcrypt.compare(password, user.password_hash))) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
 
-  if (!user || !bcrypt.compareSync(password, user.passwordHash)) {
-    return res.status(401).json({ message: 'Invalid credentials' });
+    const token = jwt.sign(
+      { userId: user.id, role: user.role, username: user.username },
+      'secretKey123',
+      { expiresIn: '15m' }
+    );
+    const refreshToken = jwt.sign(
+      { userId: user.id },
+      'refreshSecret123',
+      { expiresIn: '7d' }
+    );
+    REFRESH_TOKENS.push(refreshToken);
+    res.json({ token, refreshToken, role: user.role, username: user.username });
+  } catch (err) {
+    console.error('Login error:', err);
+    res.status(500).json({ message: 'Failed to login' });
   }
-
-  const token = jwt.sign(
-    { userId: user.id, role: user.role, username: user.username },
-    'secretKey123',
-    { expiresIn: '15m' }
-  );
-  const refreshToken = jwt.sign(
-    { userId: user.id },
-    'refreshSecret123',
-    { expiresIn: '7d' }
-  );
-  REFRESH_TOKENS.push(refreshToken);
-  res.json({ token, refreshToken, role: user.role, username: user.username });
 };
 
-exports.refreshToken = (req, res) => {
+exports.refreshToken = async (req, res) => {
   const { refreshToken } = req.body;
   if (!refreshToken || !REFRESH_TOKENS.includes(refreshToken)) {
     return res.status(401).json({ message: 'Invalid refresh token' });
   }
   try {
     const decoded = jwt.verify(refreshToken, 'refreshSecret123');
-    const user = USERS.find((u) => u.id === decoded.userId);
+    const { rows } = await pool.query('SELECT * FROM users WHERE id = $1', [decoded.userId]);
+    const user = rows[0];
     if (!user) return res.status(401).json({ message: 'Invalid user' });
     const token = jwt.sign(
       { userId: user.id, role: user.role, username: user.username },
@@ -88,11 +76,9 @@ exports.logout = (req, res) => {
 
 exports.authMiddleware = (req, res, next) => {
   const authHeader = req.headers.authorization;
-
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ message: 'No token provided' });
   }
-
   const token = authHeader.split(' ')[1];
   try {
     const decoded = jwt.verify(token, 'secretKey123');
@@ -110,45 +96,66 @@ exports.authorizeRoles = (...roles) => (req, res, next) => {
   next();
 };
 
-exports.getUsers = (_req, res) => {
-  const sanitized = USERS.map(({ passwordHash, ...rest }) => rest);
-  res.json(sanitized);
+exports.getUsers = async (_req, res) => {
+  try {
+    const { rows } = await pool.query('SELECT id, username, role FROM users ORDER BY id');
+    res.json(rows);
+  } catch (err) {
+    console.error('Get users error:', err);
+    res.status(500).json({ message: 'Failed to fetch users' });
+  }
 };
 
-exports.addUser = (req, res) => {
+exports.addUser = async (req, res) => {
   const { username, password, role } = req.body;
   if (!username || !password || !role) {
     return res.status(400).json({ message: 'Missing fields' });
   }
-  if (userExists(username)) {
-    return res.status(400).json({ message: 'User exists' });
+  try {
+    if (await userExists(username)) {
+      return res.status(400).json({ message: 'User exists' });
+    }
+    const user = await createUser(username, password, role);
+    await logActivity(req.user?.userId, 'add_user', null, req.user?.username);
+    res.json(user);
+  } catch (err) {
+    console.error('Add user error:', err);
+    res.status(500).json({ message: 'Failed to add user' });
   }
-  const user = createUser(username, password, role);
-  logActivity(req.user?.userId, 'add_user', null, req.user?.username);
-  res.json({ id: user.id, username: user.username, role: user.role });
 };
 
-exports.deleteUser = (req, res) => {
+exports.deleteUser = async (req, res) => {
   const { id } = req.params;
-  const idx = USERS.findIndex((u) => u.id === parseInt(id, 10));
-  if (idx === -1) {
-    return res.status(404).json({ message: 'User not found' });
+  try {
+    const { rowCount } = await pool.query('DELETE FROM users WHERE id = $1', [id]);
+    if (rowCount === 0) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    await logActivity(req.user?.userId, 'delete_user', null, req.user?.username);
+    res.json({ message: 'User deleted' });
+  } catch (err) {
+    console.error('Delete user error:', err);
+    res.status(500).json({ message: 'Failed to delete user' });
   }
-  USERS.splice(idx, 1);
-  logActivity(req.user?.userId, 'delete_user', null, req.user?.username);
-  res.json({ message: 'User deleted' });
 };
 
-exports.updateUserRole = (req, res) => {
+exports.updateUserRole = async (req, res) => {
   const { id } = req.params;
   const { role } = req.body;
-  const user = USERS.find((u) => u.id === parseInt(id, 10));
-  if (!user) {
-    return res.status(404).json({ message: 'User not found' });
+  try {
+    const { rows } = await pool.query(
+      'UPDATE users SET role = $1 WHERE id = $2 RETURNING id, username, role',
+      [role, id]
+    );
+    if (rows.length === 0) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    await logActivity(req.user?.userId, 'update_user_role', null, req.user?.username);
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Update user role error:', err);
+    res.status(500).json({ message: 'Failed to update user role' });
   }
-  user.role = role;
-  logActivity(req.user?.userId, 'update_user_role', null, req.user?.username);
-  res.json({ id: user.id, username: user.username, role: user.role });
 };
 
 exports.createUser = createUser;


### PR DESCRIPTION
## Summary
- create `users` table and seed admin user during DB init
- store and query users from PostgreSQL instead of in-memory
- update invite handling to use async DB helpers

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6864ce83e190832e9d77e29e0bcf076d