### PR TITLE
Fix reverse proxy routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,13 @@ cp .env.example .env
 docker-compose up --build
 ```
 
-The frontend is served on `http://localhost:3001` while the API runs on `http://localhost:3000`.
+The new `nginx` service proxies API requests to the backend so you can simply visit
+`http://localhost` (or your domain) to reach the app. The frontend container
+handles client‑side routing and is still available on `http://localhost:3001`
+if you need it directly, while the API runs on `http://localhost:3000`.
+The proxy keeps the `/api` prefix when forwarding requests so routes like
+`/api/invoices/login` resolve correctly and all other paths are passed through to
+the frontend container which serves `index.html` for unknown routes.
 
 ### Troubleshooting
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -6,6 +6,7 @@ const http = require('http');
 require('dotenv').config();                 // load environment variables
 const Sentry = require('@sentry/node');
 const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
+const authRoutes = require('./routes/authRoutes');
 const exportTemplateRoutes = require('./routes/exportTemplateRoutes');
 const brandingRoutes = require('./routes/brandingRoutes');
 const feedbackRoutes = require('./routes/feedbackRoutes');
@@ -63,6 +64,7 @@ app.use(express.json());                    // allow reading JSON data
 app.use(tenantContext);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 app.use(auditLog);
+app.use('/api/invoices', authRoutes);
 app.use('/api/:tenantId/invoices', invoiceRoutes);
 app.use('/api/:tenantId/export-templates', exportTemplateRoutes);
 app.use('/api/:tenantId/logo', brandingRoutes);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const { login, refreshToken, logout } = require('../controllers/userController');
+
+router.post('/login', login);
+router.post('/refresh', refreshToken);
+router.post('/logout', logout);
+
+module.exports = router;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,18 @@ services:
       - REACT_APP_API_BASE_URL=https://clarifyops.com
     restart: unless-stopped
 
+  nginx:
+    image: nginx:1.28
+    container_name: clarifyops-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+    depends_on:
+      - frontend
+      - backend
+    restart: unless-stopped
+
   db:
     image: postgres:15
     container_name: clarifyops-db

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,6 +6,8 @@ RUN rm -rf /usr/share/nginx/html/*
 
 # Copy locally built frontend files into Nginx's public directory
 COPY build /usr/share/nginx/html
+# Replace default nginx config to support client-side routing
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 # Expose the default Nginx port
 EXPOSE 80

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,33 @@
+upstream frontend {
+    server frontend:80;
+}
+
+upstream backend {
+    server backend:3000;
+}
+
+server {
+    listen 80;
+    server_name _;
+
+    # Forward API requests to the backend without stripping the /api prefix
+    location /api {
+        proxy_pass http://backend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location / {
+        # Simply pass everything to the frontend container
+        # which serves index.html for unknown paths
+        proxy_pass http://frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary
- tweak the nginx proxy so it just forwards unknown paths to the frontend
- document that the proxy passes everything except `/api` to the frontend

## Testing
- `npm run lint --silent` *(backend: No lint configured)*
- `npm run lint --silent` *(frontend: produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_686db729b9ac832e9fa2e9d9307e5e64