### PR TITLE
Enhance audit page with export button and styling

### DIFF
--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -98,7 +98,7 @@ const { suggestVendor, suggestVoucher } = require('../controllers/aiController')
 const { naturalLanguageQuery, naturalLanguageSearch } = require("../controllers/aiController");
 const { smartSearchParse } = require('../controllers/aiController');
 const { flagSuspiciousInvoice } = require('../controllers/invoiceController');
-const { getActivityLogs, getInvoiceTimeline, exportComplianceReport, exportInvoiceHistory, exportVendorHistory } = require('../controllers/activityController');
+const { getActivityLogs, getInvoiceTimeline, exportComplianceReport, exportInvoiceHistory, exportVendorHistory, exportActivityLogsCSV } = require('../controllers/activityController');
 const { getAuditTrail, updateAuditEntry, deleteAuditEntry } = require('../controllers/auditController');
 const { setBudget, getBudgets, checkBudgetWarnings, getBudgetVsActual, getBudgetForecast } = require('../controllers/budgetController');
 const { getAnomalies } = require('../controllers/anomalyController');
@@ -197,6 +197,7 @@ router.patch('/:id/review-flag', authMiddleware, authorizeRoles('admin','approve
 router.patch('/:id/flag', authMiddleware, authorizeRoles('approver'), setFlaggedStatus);
 router.get('/logs', authMiddleware, authorizeRoles('admin'), getActivityLogs);
 router.get('/logs/export', authMiddleware, authorizeRoles('admin'), exportComplianceReport);
+router.get('/logs/export-csv', authMiddleware, authorizeRoles('admin'), exportActivityLogsCSV);
 router.get('/logs/invoice/:id/export', authMiddleware, authorizeRoles('admin'), exportInvoiceHistory);
 router.get('/logs/vendor/:vendor/export', authMiddleware, authorizeRoles('admin'), exportVendorHistory);
 router.get('/:id/timeline', authMiddleware, getInvoiceTimeline);

--- a/frontend/src/AuditDashboard.js
+++ b/frontend/src/AuditDashboard.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
+import { CalendarIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { API_BASE } from './api';
 
 export default function AuditDashboard() {
@@ -12,6 +13,33 @@ export default function AuditDashboard() {
   const [action, setAction] = useState('');
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
+
+  const resetFilters = () => {
+    setVendor('');
+    setAction('');
+    setStart('');
+    setEnd('');
+    fetchLogs();
+  };
+
+  const exportCsv = async () => {
+    const params = new URLSearchParams();
+    if (vendor) params.append('vendor', vendor);
+    if (action) params.append('action', action);
+    if (start) params.append('start', start);
+    if (end) params.append('end', end);
+    const res = await fetch(`${API_BASE}/api/invoices/logs/export-csv?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return;
+    const blob = await res.blob();
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'activity_logs.csv';
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
 
   const fetchLogs = useCallback(async () => {
     if (!token) return;
@@ -38,35 +66,56 @@ export default function AuditDashboard() {
   return (
     <MainLayout title="Audit Dashboard" helpTopic="audit">
       <div className="space-y-4">
-        <div className="flex flex-wrap items-end space-x-2 mb-2">
+        <div className="flex flex-wrap items-end gap-4 mb-2">
           <input value={vendor} onChange={e=>setVendor(e.target.value)} placeholder="Vendor" className="input" />
           <input value={action} onChange={e=>setAction(e.target.value)} placeholder="Action" className="input" />
-          <input type="date" value={start} onChange={e=>setStart(e.target.value)} className="input" />
-          <input type="date" value={end} onChange={e=>setEnd(e.target.value)} className="input" />
-          <button onClick={fetchLogs} className="btn btn-primary px-3 py-1">Search</button>
+          <div className="relative">
+            <CalendarIcon className="w-4 h-4 text-gray-500 absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none" />
+            <input type="date" value={start} onChange={e=>setStart(e.target.value)} className="input pl-8" />
+          </div>
+          <div className="relative">
+            <CalendarIcon className="w-4 h-4 text-gray-500 absolute left-2 top-1/2 -translate-y-1/2 pointer-events-none" />
+            <input type="date" value={end} onChange={e=>setEnd(e.target.value)} className="input pl-8" />
+          </div>
+          <div className="flex items-end gap-2 ml-auto">
+            <button onClick={fetchLogs} className="btn btn-primary px-3 py-1">Search</button>
+            <button onClick={resetFilters} className="btn btn-ghost px-3 py-1">Reset</button>
+            <button onClick={exportCsv} className="btn btn-secondary px-3 py-1">Export CSV</button>
+          </div>
         </div>
         <div className="overflow-x-auto rounded-xl shadow-md p-4 mb-4">
         <table className="min-w-full text-sm border rounded-xl overflow-hidden">
           <thead>
             <tr className="bg-gray-200 dark:bg-gray-700">
-              <th className="px-2 py-1">Time</th>
-              <th className="px-2 py-1">User</th>
-              <th className="px-2 py-1">Action</th>
-              <th className="px-2 py-1">Invoice</th>
+              <th className="px-2 py-1 font-bold border">Time</th>
+              <th className="px-2 py-1 font-bold border">User</th>
+              <th className="px-2 py-1 font-bold border">Action</th>
+              <th className="px-2 py-1 font-bold border">Invoice</th>
             </tr>
           </thead>
           <tbody>
             {loading ? (
               <tr><td colSpan="4" className="p-4"><Skeleton rows={5} height="h-4"/></td></tr>
             ) : (
-              logs.map(log => (
-                <tr key={log.id} className="border-t hover:bg-gray-100">
-                  <td className="px-2 py-1">{new Date(log.created_at).toLocaleString()}</td>
-                  <td className="px-2 py-1">{log.username || log.user_id}</td>
-                  <td className="px-2 py-1">{log.action}</td>
-                  <td className="px-2 py-1">{log.invoice_id || '-'}</td>
+              logs.length === 0 ? (
+                <tr>
+                  <td colSpan="4" className="p-6 text-center text-gray-500">
+                    <div className="flex flex-col items-center gap-2">
+                      <MagnifyingGlassIcon className="w-8 h-8 text-gray-400" />
+                      <p>No audit logs found. Try changing your filters or upload an invoice to begin tracking actions.</p>
+                    </div>
+                  </td>
                 </tr>
-              ))
+              ) : (
+                logs.map(log => (
+                  <tr key={log.id} className="border-t hover:bg-gray-100 even:bg-gray-50">
+                    <td className="px-2 py-1 border">{new Date(log.created_at).toLocaleString()}</td>
+                    <td className="px-2 py-1 border">{log.username || log.user_id}</td>
+                    <td className="px-2 py-1 border">{log.action}</td>
+                    <td className="px-2 py-1 border">{log.invoice_id || '-'}</td>
+                  </tr>
+                ))
+              )
             )}
           </tbody>
         </table>


### PR DESCRIPTION
## Summary
- add backend endpoint to export filtered activity logs as CSV
- wire up new route in invoiceRoutes
- update Audit Dashboard UI with calendar icons, export/reset actions, zebra striping, bold headers, and empty state

## Testing
- `npm test` *(fails: `react-scripts: not found`)*
- `npm test --silent` in backend (no output)


------
https://chatgpt.com/codex/tasks/task_e_686ee6a6a578832ebb43c903a04cce33