### PR TITLE
Add demo data fallbacks for dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,16 @@ Invites expire automatically and grant the specified role (viewer or editor).
 
 The app registers a service worker so you can view and stage invoices even without a network connection. Any actions you take while offline are queued in local storage and automatically synced when the browser comes back online. Install the PWA from your browser's "Add to home screen" option for the best experience.
 
+### Demo Chart Data
+
+If your database is empty, the dashboard charts now display sample data automatically. To generate more realistic demo data in the backend, log in as an admin and click **Seed Dummy Data** on the Vendors page or call:
+
+```bash
+POST /api/invoices/seed-dummy
+```
+
+This inserts a few demo invoices so charts like *Top Vendors* and *Approval Timeline* look populated during testing.
+
 ### Docker Deployment
 
 Run the entire stack in Docker containers:

--- a/frontend/src/AuditDashboard.js
+++ b/frontend/src/AuditDashboard.js
@@ -4,6 +4,24 @@ import Skeleton from './components/Skeleton';
 import { CalendarIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { API_BASE } from './api';
 
+// Demo logs shown when the API returns none
+const DEMO_LOGS = [
+  {
+    id: 1,
+    created_at: '2024-07-09T13:00:00Z',
+    username: 'admin',
+    action: 'Login',
+    invoice_id: null,
+  },
+  {
+    id: 2,
+    created_at: '2024-07-09T13:05:00Z',
+    username: 'admin',
+    action: 'Approved invoice #1001',
+    invoice_id: '1001',
+  },
+];
+
 export default function AuditDashboard() {
   const token = localStorage.getItem('token') || '';
   const role = localStorage.getItem('role') || '';
@@ -53,7 +71,11 @@ export default function AuditDashboard() {
       headers: { Authorization: `Bearer ${token}` },
     });
     const data = await res.json();
-    if (res.ok) setLogs(data);
+    if (res.ok && Array.isArray(data) && data.length) {
+      setLogs(data);
+    } else {
+      setLogs(DEMO_LOGS);
+    }
     setLoading(false);
   }, [token, vendor, action, start, end]);
 

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -7,6 +7,28 @@ import { API_BASE } from './api';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 
+// Demo fallbacks for empty API responses
+const DEMO_VENDORS = [
+  { vendor: 'Vendor A', total: 23 },
+  { vendor: 'Vendor B', total: 17 },
+  { vendor: 'Vendor C', total: 9 },
+];
+
+const DEMO_TIMELINE = [
+  {
+    created_at: '2024-07-01T09:00:00Z',
+    action: 'Invoice DEMO-1 uploaded',
+  },
+  {
+    created_at: '2024-07-02T15:30:00Z',
+    action: 'Invoice DEMO-1 approved',
+  },
+  {
+    created_at: '2024-07-03T11:45:00Z',
+    action: 'Payment processed',
+  },
+];
+
 const DEFAULT_WIDGETS = ['Top Vendors', 'Anomaly Heatmap', 'Approval Timeline'];
 
 export default function DashboardBuilder() {
@@ -29,10 +51,13 @@ export default function DashboardBuilder() {
     fetch(`${API_BASE}/api/invoices/top-vendors`, { headers })
       .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
       .then(({ ok, d }) => {
-        if (ok) setVendors(d.topVendors || []);
-        else setVendors([]);
+        if (ok && Array.isArray(d.topVendors) && d.topVendors.length) {
+          setVendors(d.topVendors);
+        } else {
+          setVendors(DEMO_VENDORS);
+        }
       })
-      .catch(() => setVendors([]))
+      .catch(() => setVendors(DEMO_VENDORS))
       .finally(() => setLoadingVendors(false));
 
     setLoadingHeatmap(true);
@@ -54,19 +79,23 @@ export default function DashboardBuilder() {
           fetch(`${API_BASE}/api/invoices/${id}/timeline`, { headers })
             .then((res) => res.json())
             .then((data) => {
-              if (Array.isArray(data)) setTimeline(data);
-              else if (Array.isArray(data.timeline)) setTimeline(data.timeline);
-              else setTimeline([]);
+              if (Array.isArray(data) && data.length) {
+                setTimeline(data);
+              } else if (Array.isArray(data.timeline) && data.timeline.length) {
+                setTimeline(data.timeline);
+              } else {
+                setTimeline(DEMO_TIMELINE);
+              }
             })
-            .catch(() => setTimeline([]))
+            .catch(() => setTimeline(DEMO_TIMELINE))
             .finally(() => setLoadingTimeline(false));
         } else {
-          setTimeline([]);
+          setTimeline(DEMO_TIMELINE);
           setLoadingTimeline(false);
         }
       })
       .catch(() => {
-        setTimeline([]);
+        setTimeline(DEMO_TIMELINE);
         setLoadingTimeline(false);
       });
   }, [token]);


### PR DESCRIPTION
## Summary
- show demo charts if backend returns empty data
- auto-populate audit logs when none are returned
- document how to seed demo data

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eeaa06a68832e8874041ea49d7237