### PR TITLE
Add CLI dummy data seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,14 @@ If your database is empty, the dashboard charts now display sample data automati
 POST /api/invoices/seed-dummy
 ```
 
-This inserts a few demo invoices so charts like *Top Vendors* and *Approval Timeline* look populated during testing.
+This inserts a few demo invoices so charts like *Top Vendors* and *Approval Timeline* look populated during testing. If you prefer to seed from the command line instead of hitting the API, run:
+
+```bash
+cd backend
+npm run seed-dummy
+```
+
+Make sure you log in again to obtain a fresh token if you see a `401` response when calling the endpoint.
 
 ### Docker Deployment
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
   "main": "app.js",
   "scripts": {
     "start": "PORT=3000 node app.js",
-    "lint": "echo \"No lint configured\""
+    "lint": "echo \"No lint configured\"",
+    "seed-dummy": "node utils/seedDummyData.js"
   },
   "dependencies": {
     "@sentry/node": "^7.103.0",

--- a/backend/utils/seedDummyData.js
+++ b/backend/utils/seedDummyData.js
@@ -1,0 +1,28 @@
+const pool = require('../config/db');
+
+(async function seedDummy() {
+  const client = await pool.connect();
+  try {
+    const vendors = ['Acme Corp', 'Globex', 'Soylent', 'Initech', 'Umbrella'];
+    const categories = ['Office Supplies', 'Software', 'Travel', 'Utilities'];
+    let inserted = 0;
+    for (let i = 0; i < 20; i++) {
+      const vendor = vendors[Math.floor(Math.random() * vendors.length)];
+      const amount = (Math.random() * 900 + 100).toFixed(2);
+      const date = new Date(Date.now() - Math.random() * 60 * 86400000);
+      const category = categories[Math.floor(Math.random() * categories.length)];
+      await client.query(
+        'INSERT INTO invoices (invoice_number, date, amount, vendor, category) VALUES ($1,$2,$3,$4,$5)',
+        [`DEMO-${Date.now()}-${i}`, date, amount, vendor, category]
+      );
+      inserted++;
+    }
+    console.log(`Seeded ${inserted} dummy invoices`);
+  } catch (err) {
+    console.error('Seed demo data error:', err);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    pool.end();
+  }
+})();


### PR DESCRIPTION
## Summary
- document how to seed demo invoices from the CLI
- add `seed-dummy` npm script and supporting utility

## Testing
- `npm run lint` *(backend)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ef18fa0b0832e823d9f5a73afd197