### PR TITLE
Fix sidebar overlap

### DIFF
--- a/frontend/src/components/DarkModeToggle.js
+++ b/frontend/src/components/DarkModeToggle.js
@@ -7,11 +7,15 @@ export default function DarkModeToggle() {
   return (
     <button
       onClick={() => setDarkMode(!darkMode)}
-      className="p-2 ml-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+      className="p-2 ml-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
       aria-label="Toggle dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
-      {darkMode ? <SunIcon className="h-6 w-6" /> : <MoonIcon className="h-6 w-6" />}
+      {darkMode ? (
+        <SunIcon className="h-6 w-6 text-yellow-400 transform transition-transform duration-300 rotate-90" />
+      ) : (
+        <MoonIcon className="h-6 w-6 text-indigo-200 transform transition-transform duration-300" />
+      )}
     </button>
   );
 }

--- a/frontend/src/components/NotificationBell.js
+++ b/frontend/src/components/NotificationBell.js
@@ -1,4 +1,5 @@
 import React, { useState, useRef } from 'react';
+import { BellIcon } from '@heroicons/react/24/outline';
 import useOutsideClick from '../hooks/useOutsideClick';
 
 export default function NotificationBell({ notifications = [], onOpen }) {
@@ -15,14 +16,14 @@ export default function NotificationBell({ notifications = [], onOpen }) {
   return (
     <div className="relative" ref={wrapperRef}>
       <button
-        className="text-xl focus:outline-none"
+        className="relative focus:outline-none"
         onClick={handleToggle}
         aria-label="Notifications"
         title="Notifications"
       >
-        🔔
+        <BellIcon className="h-6 w-6" />
         {unreadCount > 0 && (
-          <span className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full px-1 text-xs">
+          <span className="absolute -top-1 -right-1 flex items-center justify-center h-4 w-4 text-[10px] bg-red-600 text-white rounded-full ring-2 ring-indigo-700">
             {unreadCount}
           </span>
         )}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -28,7 +28,7 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
 
   return (
     <aside
-      className={`hidden sm:block fixed top-0 left-0 h-full bg-gradient-to-b from-gray-50 to-white dark:from-gray-900 dark:to-gray-800 shadow-lg border-r z-20 ${open ? 'w-64' : 'w-16'} p-4 space-y-2 transition-all`}
+      className={`hidden sm:block fixed left-0 top-12 h-[calc(100vh-3rem)] overflow-y-auto bg-indigo-700 dark:bg-indigo-900 shadow-lg border-r z-20 ${open ? 'w-64' : 'w-16'} p-4 space-y-2 transition-all`}
     >
       <button
         onClick={() => setOpen(!open)}

--- a/frontend/src/components/Skeleton.js
+++ b/frontend/src/components/Skeleton.js
@@ -4,7 +4,10 @@ export default function Skeleton({ rows = 5, className = '', height = 'h-6' }) {
   return (
     <div className={`space-y-2 ${className}`}>
       {Array.from({ length: rows }).map((_, idx) => (
-        <div key={idx} className={`${height} bg-gray-200 rounded animate-pulse`} />
+        <div
+          key={idx}
+          className={`${height} bg-gradient-to-r from-gray-200 via-gray-300 to-gray-200 rounded animate-pulse`}
+        />
       ))}
     </div>
   );

--- a/frontend/src/components/Toast.js
+++ b/frontend/src/components/Toast.js
@@ -3,7 +3,7 @@ import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 
 export default function Toast({ message, type, actionText, onAction }) {
   const base =
-    'px-4 py-2 rounded shadow-lg text-white mb-2 flex items-center space-x-2';
+    'px-4 py-2 rounded-md shadow-lg ring-1 ring-black/20 text-white mb-2 flex items-center space-x-2 backdrop-blur-sm';
   const color = type === 'error' ? 'bg-red-600' : 'bg-green-600';
   const Icon = type === 'error' ? XCircleIcon : CheckCircleIcon;
   return (

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -10,8 +10,8 @@ export default function TopNavbar({ title, helpTopic }) {
   const token = localStorage.getItem('token') || '';
   const { t } = useTranslation();
   return (
-    <header className="sticky top-0 z-30 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-4 py-2 shadow-sm flex justify-between items-center">
-      <h1 className="text-lg font-semibold flex items-center space-x-2 text-gray-900 dark:text-gray-100">
+    <header className="sticky top-0 z-30 h-12 bg-indigo-700 dark:bg-indigo-900 text-white shadow flex items-center justify-between px-4">
+      <h1 className="text-lg font-semibold flex items-center space-x-2">
         <img src="/logo192.png" alt="logo" className="h-6 w-6" />
         <span>{t('title')}</span>
         <span className="opacity-70">/ {title}</span>


### PR DESCRIPTION
## Summary
- prevent sidebar from overlapping header
- refresh navbar color scheme
- improve dark mode toggle animation
- modernize notification bell, toast, and skeleton loader styles

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4bc3e828832e9311a097d70148e7