### PR TITLE
Fix sidebar overlapping header

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2100,7 +2100,7 @@ useEffect(() => {
           <aside
           className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 md:flex-shrink-0 ${
             filterSidebarOpen ? '' : 'hidden md:block'
-          } border-r border-gray-200 dark:border-gray-700 max-h-screen overflow-y-auto sticky top-0 z-40`}
+          } border-r border-gray-200 dark:border-gray-700 max-h-screen overflow-y-auto sticky top-12 z-20`}
         >
           <div className="p-4 space-y-4 overflow-y-auto h-full">
             <SidebarNav notifications={notifications} />


### PR DESCRIPTION
## Summary
- ensure sidebar doesn't overlay the navbar on the invoice page

## Testing
- `npm test --silent` *(fails: useLocation may be used only in the context of a <Router> component)*

------
https://chatgpt.com/codex/tasks/task_e_686f5327f568832e822d771a71b898f5