### PR TITLE
Improve sidebar positioning

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2100,7 +2100,7 @@ useEffect(() => {
           <aside
           className={`order-last md:order-first bg-white dark:bg-gray-800 shadow-lg w-full md:w-64 md:flex-shrink-0 ${
             filterSidebarOpen ? '' : 'hidden md:block'
-          } border-r border-gray-200 dark:border-gray-700 max-h-screen overflow-y-auto sticky top-12 z-20`}
+          } border-r border-gray-200 dark:border-gray-700 max-h-screen overflow-y-auto sticky top-16 z-20`}
         >
           <div className="p-4 space-y-4 overflow-y-auto h-full">
             <SidebarNav notifications={notifications} />

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -28,7 +28,7 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
 
   return (
     <aside
-      className={`hidden sm:block fixed left-0 top-12 h-[calc(100vh-3rem)] overflow-y-auto bg-indigo-700 dark:bg-indigo-900 shadow-lg border-r z-20 ${open ? 'w-64' : 'w-16'} p-4 space-y-2 transition-all`}
+      className={`hidden sm:block fixed left-0 top-16 h-[calc(100vh-4rem)] overflow-y-auto bg-gradient-to-b from-indigo-700 to-indigo-800 dark:from-indigo-800 dark:to-indigo-950 shadow-xl border-r z-20 ${open ? 'w-64' : 'w-16'} p-4 space-y-2 transition-all`}
     >
       <button
         onClick={() => setOpen(!open)}


### PR DESCRIPTION
## Summary
- tweak SidebarNav style so it sits below the header and has a gradient
- adjust invoices sidebar offset to prevent overlap

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f5bab8bec832e90a8cdcd222c2dca