### PR TITLE
Fix crash on invoice upload

### DIFF
--- a/backend/controllers/invoiceController.js
+++ b/backend/controllers/invoiceController.js
@@ -608,7 +608,11 @@ exports.getAllInvoices = async (req, res) => {
       conditions.push(`tenant_id = $${params.length}`);
     }
     const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
-    const query = `SELECT * FROM invoices ${where} ORDER BY id DESC`;
+    const limit = parseInt(req.query.limit, 10) || 500;
+    const offset = parseInt(req.query.offset, 10) || 0;
+    params.push(limit, offset);
+    const query = `SELECT * FROM invoices ${where} ORDER BY id DESC LIMIT $${
+      params.length - 1} OFFSET $${params.length}`;
 
     const result = await client.query(query, params);
     res.json(result.rows);

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -1,7 +1,9 @@
 
 const express = require('express');
 const multer = require('multer');
-const upload = multer({ dest: 'uploads/' });
+const settings = require('../config/settings');
+const maxSize = Math.max(settings.csvSizeLimitMB, settings.pdfSizeLimitMB) * 1024 * 1024;
+const upload = multer({ dest: 'uploads/', limits: { fileSize: maxSize } });
 const { exportFilteredInvoices, exportAllInvoices, importInvoicesCSV } = require('../controllers/invoiceController');
 
 const { login, refreshToken, logout, authMiddleware, authorizeRoles } = require('../controllers/userController');


### PR DESCRIPTION
## Summary
- limit upload file size via `multer`
- paginate invoice list to avoid returning huge payloads

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687060f29660832ea5c7435f01864806