### PR TITLE
Fix websocket URL causing Chrome crash

### DIFF
--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -1,6 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
-import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, ScatterChart, Scatter, XAxis, YAxis, ZAxis } from 'recharts';
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
 import { API_BASE } from './api';

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,14 +1,14 @@
 // src/Login.js
 import React, { useState } from 'react';
 import { Card } from './components/ui/Card';
-import { API_BASE } from './api';
+// import { API_BASE } from './api';
 import DarkModeToggle from './components/DarkModeToggle';
 import HighContrastToggle from './components/HighContrastToggle';
 
 export default function Login({ onLogin, addToast }) {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
+  const [error] = useState('');
 
   const handleLogin = async () => {
    

--- a/frontend/src/components/CollaborativeCommentInput.js
+++ b/frontend/src/components/CollaborativeCommentInput.js
@@ -15,7 +15,8 @@ export default function CollaborativeCommentInput({ invoiceId, onSubmit, onChang
 
   useEffect(() => {
     const ydoc = new Y.Doc();
-    const provider = new WebsocketProvider('ws://localhost:3000/yjs', `invoice-comment-${invoiceId}`, ydoc);
+    const origin = window.location.origin.replace(/^http/, 'ws');
+    const provider = new WebsocketProvider(`${origin}/yjs`, `invoice-comment-${invoiceId}`, ydoc);
     providerRef.current = provider;
     const ytext = ydoc.getText('text');
     ytextRef.current = ytext;

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -17,7 +17,6 @@ import {
   ArchiveBoxIcon,
   ArrowUpTrayIcon,
   UsersIcon,
-  UserCircleIcon,
   QuestionMarkCircleIcon,
   Squares2X2Icon,
   FlagIcon,


### PR DESCRIPTION
## Summary
- adjust `CollaborativeCommentInput` to use current origin for Yjs websocket

## Testing
- `npm install --legacy-peer-deps`
- `NODE_OPTIONS="--max-old-space-size=2048" npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870763dc7b8832e8586a60112519f8a