### PR TITLE
Improve CSV import

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ The `/inbox` page shows newly uploaded invoices waiting for approval.
 - `POST /api/vendors/import` – import vendors from CSV
 - `PATCH /api/invoices/:id/payment-status` – update payment status
 - `POST /api/invoices/import-csv` – upload a CSV of invoices
+- Header names are case and space insensitive (e.g. "Invoice Number" works).
 - `DELETE /api/invoices/bulk/delete` – delete multiple invoices
 - `PATCH /api/invoices/bulk/edit` – bulk update invoice fields
 - `POST /api/invoices/:id/auto-tag` – AI auto-tag from common categories

--- a/backend/utils/csvParser.js
+++ b/backend/utils/csvParser.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const csv = require('csv-parser');
+const { normalizeRow } = require('./rowNormalizer');
 
 exports.parseCSV = (filePath) => {
   return new Promise((resolve, reject) => {
@@ -9,7 +10,7 @@ exports.parseCSV = (filePath) => {
 
     fs.createReadStream(filePath)
       .pipe(csv())
-      .on('data', (row) => results.push(row))
+      .on('data', (row) => results.push(normalizeRow(row)))
       .on('end', () => resolve(results))
       .on('error', (err) => reject(err));
   });

--- a/backend/utils/excelParser.js
+++ b/backend/utils/excelParser.js
@@ -1,4 +1,5 @@
 const ExcelJS = require('exceljs');
+const { normalizeRow } = require('./rowNormalizer');
 
 exports.parseExcel = async (filePath) => {
   const workbook = new ExcelJS.Workbook();
@@ -13,7 +14,7 @@ exports.parseExcel = async (filePath) => {
     headers.forEach((h, idx) => {
       obj[h] = row.getCell(idx + 1).text;
     });
-    rows.push(obj);
+    rows.push(normalizeRow(obj));
   });
   return rows;
 };

--- a/backend/utils/rowNormalizer.js
+++ b/backend/utils/rowNormalizer.js
@@ -1,0 +1,10 @@
+function normalizeRow(row) {
+  const result = {};
+  for (const [key, value] of Object.entries(row)) {
+    const normalizedKey = key.toLowerCase().replace(/\s+/g, '_');
+    result[normalizedKey] = typeof value === 'string' ? value.trim() : value;
+  }
+  return result;
+}
+
+module.exports = { normalizeRow };


### PR DESCRIPTION
## Summary
- normalize CSV and Excel headers to allow spaces and capitalization differences
- document header normalization for invoice CSV imports

## Testing
- `npm test -- --watchAll=false` in `frontend`
- `npm test` in `backend` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870aa5972bc832eb189ef4c97f1e0d8