### PR TITLE
Fix backend startup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ cp .env.example .env   # Add your DATABASE_URL and OpenRouter API key
 # Set DATA_ENCRYPTION_KEY to enable at-rest encryption of sensitive fields
 # Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER if you want SMS alerts
 # Set GOOGLE_SERVICE_ACCOUNT_KEY and EMAIL_INBOX to enable email-to-upload support
+# GOOGLE_SERVICE_ACCOUNT_KEY should point to a service account JSON file and
+# EMAIL_INBOX should be the Gmail address to monitor for incoming invoices
 npm start
 ```
 

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -580,11 +580,13 @@ exports.suggestTagColors = async (req, res) => {
     const colors = {};
     const unknown = [];
     tags.forEach((t) => {
-      const key = t.toLowerCase();
+      if (t === undefined || t === null) return;
+      const tagStr = String(t);
+      const key = tagStr.toLowerCase();
       if (baseMap[key]) {
-        colors[t] = baseMap[key];
+        colors[tagStr] = baseMap[key];
       } else {
-        unknown.push(t);
+        unknown.push(tagStr);
       }
     });
 

--- a/backend/utils/emailSync.js
+++ b/backend/utils/emailSync.js
@@ -62,6 +62,10 @@ async function processMessage(gmail, message) {
 
 async function fetchEmailAttachments() {
   try {
+    if (!process.env.GOOGLE_SERVICE_ACCOUNT_KEY || !process.env.EMAIL_INBOX) {
+      console.log('Skipping email sync: missing GOOGLE_SERVICE_ACCOUNT_KEY or EMAIL_INBOX');
+      return;
+    }
     const auth = new google.auth.GoogleAuth({
       keyFile: process.env.GOOGLE_SERVICE_ACCOUNT_KEY,
       scopes: ['https://www.googleapis.com/auth/gmail.modify'],


### PR DESCRIPTION
## Summary
- handle missing Gmail credentials gracefully in `emailSync`
- guard against non-string values for tag colors
- clarify README instructions for Gmail setup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877c50dda54832eba621ecdb496d9d8