### PR TITLE
Fix blank pages by handling API errors

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -355,6 +355,9 @@ const [selectedAssignee, setSelectedAssignee] = useState('');
         });
 
         const data = await res.json();
+        if (!res.ok || !Array.isArray(data)) {
+          throw new Error(`HTTP ${res.status}`);
+        }
         setInvoices(data);
         data.forEach((inv) => socket.emit('joinInvoice', inv.id));
         localStorage.setItem('cachedInvoices', JSON.stringify(data));
@@ -374,9 +377,11 @@ const [selectedAssignee, setSelectedAssignee] = useState('');
               },
               body: JSON.stringify({ tags: uniqueTags }),
             });
-            const colorData = await colorRes.json();
-            if (colorRes.ok && colorData.colors) {
-              setTagColors(colorData.colors);
+            if (colorRes.ok) {
+              const colorData = await colorRes.json();
+              if (colorData.colors) {
+                setTagColors(colorData.colors);
+              }
             }
           } catch (e) {
             console.error('Tag color fetch failed:', e);

--- a/frontend/src/Inbox.js
+++ b/frontend/src/Inbox.js
@@ -44,10 +44,12 @@ export default function Inbox() {
     try {
       const res = await fetch(`${API_BASE}/api/${tenant}/invoices?status=Pending`, { headers });
       const data = await res.json();
-      if (res.ok) {
+      if (res.ok && Array.isArray(data)) {
         setInvoices(data);
         setVendorList([...new Set(data.map((i) => i.vendor).filter(Boolean))]);
         setAssigneeList([...new Set(data.map((i) => i.assignee).filter(Boolean))]);
+      } else {
+        throw new Error(`HTTP ${res.status}`);
       }
     } catch (err) {
       console.error('Inbox fetch error:', err);

--- a/frontend/src/components/LiveFeed.js
+++ b/frontend/src/components/LiveFeed.js
@@ -14,8 +14,11 @@ export default function LiveFeed({ token, tenant }) {
         const res = await fetch('http://localhost:3000/api/invoices/logs', {
           headers: { Authorization: `Bearer ${token}`, 'X-Tenant-Id': tenant }
         });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
         const data = await res.json();
-        if (isMounted) setLogs(data.slice(0, 20));
+        if (isMounted) setLogs(Array.isArray(data) ? data.slice(0, 20) : []);
       } catch (err) {
         console.error('Feed fetch error:', err);
       }

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -56,7 +56,14 @@ window.fetch = async (url, options) => {
       url = `${API_BASE}${url}`;
     }
   }
-  return originalFetch(url, options);
+  const res = await originalFetch(url, options);
+  if (res.status === 401) {
+    localStorage.removeItem('token');
+    if (!window.location.pathname.startsWith('/login')) {
+      window.location.href = '/login';
+    }
+  }
+  return res;
 };
 
 const currentTenant = localStorage.getItem('tenant') || 'default';


### PR DESCRIPTION
## Summary
- guard against failed API responses in LiveFeed and invoices fetch
- check response status before using tag color suggestions
- validate Inbox invoice fetch results
- redirect to login on global 401 errors

## Testing
- `npm test -- -t 'renders login heading' --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6877cad938f0832ebaaf35ab1ef3c47b