### PR TITLE
Enhance pricing options UI

### DIFF
--- a/frontend/src/components/AddOnsTable.jsx
+++ b/frontend/src/components/AddOnsTable.jsx
@@ -1,12 +1,52 @@
 import React from 'react';
 import { Card } from './ui/Card';
+import Tippy from '@tippyjs/react';
+import 'tippy.js/dist/tippy.css';
+import {
+  PlusCircleIcon,
+  UserPlusIcon,
+  EnvelopeIcon,
+  BuildingOffice2Icon,
+  SparklesIcon,
+  ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
 
 const addOns = [
-  { feature: '+1,000 invoices', price: '$10', best: 'High-volume months' },
-  { feature: 'Extra team member', price: '$5/user', best: 'Adding finance or AI support' },
-  { feature: 'Slack/Email alerts', price: '$20', best: 'Real-time ops workflows' },
-  { feature: 'Dedicated tenant setup', price: '$50', best: 'Enterprises & white-label clients' },
-  { feature: 'Smart vendor scoring', price: '$100', best: 'Vendor prioritization & risk reduction' },
+  {
+    feature: '+1,000 invoices',
+    price: '$10',
+    best: 'High-volume months',
+    icon: PlusCircleIcon,
+    color: 'text-green-600',
+  },
+  {
+    feature: 'Extra team member',
+    price: '$5/user',
+    best: 'Adding finance or AI support',
+    icon: UserPlusIcon,
+    color: 'text-blue-600',
+  },
+  {
+    feature: 'Slack/Email alerts',
+    price: '$20',
+    best: 'Real-time ops workflows',
+    icon: EnvelopeIcon,
+    color: 'text-indigo-600',
+  },
+  {
+    feature: 'Dedicated tenant setup',
+    price: '$50',
+    best: 'Enterprises & white-label clients',
+    icon: BuildingOffice2Icon,
+    color: 'text-yellow-600',
+  },
+  {
+    feature: 'Smart vendor scoring',
+    price: '$100',
+    best: 'Vendor prioritization & risk reduction',
+    icon: SparklesIcon,
+    color: 'text-pink-600',
+  },
 ];
 
 export default function AddOnsTable() {
@@ -26,7 +66,15 @@ export default function AddOnsTable() {
             <tbody className="divide-y">
               {addOns.map(a => (
                 <tr key={a.feature}>
-                  <td className="px-4 py-2">{a.feature}</td>
+                  <td className="px-4 py-2">
+                    <div className="flex items-center">
+                      <a.icon className={`w-5 h-5 mr-1 ${a.color}`} />
+                      <span>{a.feature}</span>
+                      <Tippy content="Not included in your current plan">
+                        <ExclamationCircleIcon className="w-4 h-4 text-yellow-500 ml-1" />
+                      </Tippy>
+                    </div>
+                  </td>
                   <td className="px-4 py-2">{a.price}</td>
                   <td className="px-4 py-2">{a.best}</td>
                 </tr>

--- a/frontend/src/components/FeatureComparisonTable.jsx
+++ b/frontend/src/components/FeatureComparisonTable.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import { Card } from './ui/Card';
+import Tippy from '@tippyjs/react';
+import 'tippy.js/dist/tippy.css';
+import { CheckCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
 
 const rows = [
   { label: 'Invoice Limit', starter: '500', growth: '2,500', pro: '10,000', enterprise: 'Unlimited' },
@@ -10,6 +13,10 @@ const rows = [
   { label: 'Dedicated Manager', starter: '❌', growth: '❌', pro: '❌', enterprise: '✅' },
   { label: 'API Access', starter: '❌', growth: '✅', pro: '✅', enterprise: '✅' },
 ];
+
+const planOrder = ['starter', 'growth', 'pro', 'enterprise'];
+const upgradeText = plan =>
+  plan === 'growth' ? 'Get this with Growth' : `Unlock in ${plan.charAt(0).toUpperCase() + plan.slice(1)}`;
 
 export default function FeatureComparisonTable() {
   return (
@@ -29,10 +36,37 @@ export default function FeatureComparisonTable() {
             {rows.map(row => (
               <tr key={row.label}>
                 <td className="px-4 py-2 text-left">{row.label}</td>
-                <td className="px-4 py-2">{row.starter}</td>
-                <td className="px-4 py-2">{row.growth}</td>
-                <td className="px-4 py-2">{row.pro}</td>
-                <td className="px-4 py-2">{row.enterprise}</td>
+                {planOrder.map(plan => {
+                  const value = row[plan];
+                  if (value === '✅') {
+                    return (
+                      <td key={plan} className="px-4 py-2">
+                        <CheckCircleIcon className="w-5 h-5 mx-auto text-green-500" />
+                      </td>
+                    );
+                  }
+                  if (value === '❌') {
+                    const currentIndex = planOrder.indexOf(plan);
+                    const nextPlan = planOrder.slice(currentIndex + 1).find(p => row[p] !== '❌');
+                    return (
+                      <td key={plan} className="px-4 py-2">
+                        <div className="flex flex-col items-center space-y-1">
+                          <Tippy content="Available with upgrade">
+                            <XMarkIcon className="w-5 h-5 text-gray-300" />
+                          </Tippy>
+                          {nextPlan && (
+                            <span className="text-[10px] bg-indigo-100 text-indigo-600 px-1.5 rounded-full">
+                              {upgradeText(nextPlan)}
+                            </span>
+                          )}
+                        </div>
+                      </td>
+                    );
+                  }
+                  return (
+                    <td key={plan} className="px-4 py-2">{value}</td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## Summary
- add hero icon visuals to Optional Add‑Ons table
- show exclamation tooltip for add-ons
- replace ❌ symbols with icons in Feature Comparison
- display small upgrade hint for locked features

## Testing
- `npm test --silent --yes`

------
https://chatgpt.com/codex/tasks/task_e_687879a2ca90832e9943e80456040648