### PR TITLE
Refactor backend into services and add observability

### DIFF
--- a/backend/ai/chatAgent.js
+++ b/backend/ai/chatAgent.js
@@ -1,0 +1,19 @@
+const openai = require('../config/openrouter');
+const logger = require('../utils/logger');
+
+async function chatAgent(messages) {
+  const start = Date.now();
+  try {
+    const resp = await openai.chat.completions.create({
+      model: 'openai/gpt-3.5-turbo',
+      messages
+    });
+    logger.info({ latency: Date.now() - start }, 'chatAgent');
+    return resp.choices?.[0]?.message?.content?.trim();
+  } catch (err) {
+    logger.error({ err }, 'chatAgent error');
+    throw err;
+  }
+}
+
+module.exports = { chatAgent };

--- a/backend/ai/fraudDetection.js
+++ b/backend/ai/fraudDetection.js
@@ -1,0 +1,10 @@
+const { IsolationForest } = require('ml-isolation-forest');
+
+function detectFraud(data) {
+  const model = new IsolationForest();
+  model.fit(data);
+  const scores = model.scores();
+  return scores.map((s) => s < -0.5);
+}
+
+module.exports = { detectFraud };

--- a/backend/ai/summaryGenerator.js
+++ b/backend/ai/summaryGenerator.js
@@ -1,0 +1,19 @@
+const openai = require('../config/openrouter');
+const logger = require('../utils/logger');
+
+async function generateSummary(text) {
+  const start = Date.now();
+  try {
+    const resp = await openai.chat.completions.create({
+      model: 'openai/gpt-3.5-turbo',
+      messages: [{ role: 'user', content: text }]
+    });
+    logger.info({ latency: Date.now() - start }, 'summaryGenerator');
+    return resp.choices?.[0]?.message?.content?.trim();
+  } catch (err) {
+    logger.error({ err }, 'Summary generation failed');
+    throw err;
+  }
+}
+
+module.exports = { generateSummary };

--- a/backend/ai/vendorMatcher.js
+++ b/backend/ai/vendorMatcher.js
@@ -1,0 +1,17 @@
+const levenshtein = require('fast-levenshtein');
+
+function matchVendor(name, vendors) {
+  let best = null;
+  let score = 0;
+  for (const v of vendors) {
+    const dist = levenshtein.get(name.toLowerCase(), v.toLowerCase());
+    const sim = 1 - dist / Math.max(name.length, v.length);
+    if (sim > score) {
+      score = sim;
+      best = v;
+    }
+  }
+  return { vendor: best, score };
+}
+
+module.exports = { matchVendor };

--- a/backend/app.js
+++ b/backend/app.js
@@ -4,6 +4,7 @@ const express = require('express');         // web server framework
 const cors = require('cors');
 const http = require('http');
 require('dotenv').config();                 // load environment variables
+const logger = require('./utils/logger');
 const Sentry = require('@sentry/node');
 const invoiceRoutes = require('./routes/invoiceRoutes'); // we'll make this next
 const authRoutes = require('./routes/authRoutes');
@@ -54,7 +55,7 @@ const { parse } = require('url');
 const app = express();                      // create the app
 const server = http.createServer(app);
 
-console.log('🟡 Starting server...');
+logger.info('🟡 Starting server...');
 
 Sentry.init({ dsn: process.env.SENTRY_DSN || undefined });
 app.use(Sentry.Handlers.requestHandler());
@@ -120,7 +121,7 @@ app.use(Sentry.Handlers.errorHandler());
   sendPaymentReminders();
   setInterval(sendPaymentReminders, 24 * 60 * 60 * 1000);
 
-  console.log('🟢 Routes mounted');
+  logger.info('🟢 Routes mounted');
 
   initChat(server);
 
@@ -136,6 +137,6 @@ app.use(Sentry.Handlers.errorHandler());
 
   const port = process.env.PORT || 3000;
   server.listen(port, () => {
-    console.log(`🚀 Server running on http://localhost:${port}`);
+    logger.info(`🚀 Server running on http://localhost:${port}`);
   });
 })();

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -3,8 +3,9 @@
 const { Pool } = require('pg');
 const { AsyncLocalStorage } = require('async_hooks');
 require('dotenv').config(); // so we can read from .env
+const logger = require('../utils/logger');
 
-console.log('🔎 Using DATABASE_URL:', process.env.DATABASE_URL);
+logger.info('🔎 Using DATABASE_URL:', process.env.DATABASE_URL);
 
 
 // Create a connection pool using info from your .env file
@@ -36,7 +37,7 @@ if (process.env.DATABASE_URL) {
   }
 }
 
-console.log('Postgres config:', dbConfig);
+logger.info('Postgres config:', dbConfig);
 
 const pool = new Pool(dbConfig);
 
@@ -74,7 +75,7 @@ pool.query = (text, params, callback) => {
 
 // Log when it connects
 pool.on('connect', () => {
-  console.log('🟢 Connected to PostgreSQL');
+  logger.info('🟢 Connected to PostgreSQL');
 });
 
 pool.als = als;

--- a/backend/middleware/errorHandler.js
+++ b/backend/middleware/errorHandler.js
@@ -1,0 +1,17 @@
+const logger = require('../utils/logger');
+
+function errorHandler(err, req, res, next) {
+  logger.error(err);
+  if (res.headersSent) return next(err);
+  res.status(500).json({ message: 'Server error' });
+}
+
+process.on('unhandledRejection', (reason) => {
+  logger.error({ reason }, 'Unhandled Rejection');
+});
+
+process.on('uncaughtException', (err) => {
+  logger.fatal(err, 'Uncaught Exception');
+});
+
+module.exports = errorHandler;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "archiver": "^5.3.2",
         "axios": "^1.9.0",
         "bcryptjs": "^3.0.2",
+        "bree": "^9.2.4",
         "chrono-node": "^2.8.3",
         "cors": "^2.8.5",
         "csv-parser": "^3.0.0",
@@ -35,6 +36,7 @@
         "pdf2pic": "^3.2.0",
         "pdfkit": "^0.17.1",
         "pg": "^8.11.1",
+        "pino": "^8.17.0",
         "socket.io": "^4.8.1",
         "stripe": "^12.18.0",
         "swagger-ui-express": "^4.6.3",
@@ -630,6 +632,15 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@breejs/later": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@breejs/later/-/later-4.2.0.tgz",
+      "integrity": "sha512-EVMD0SgJtOuFeg0lAVbCwa+qeTKILb87jqvLyUtQswGD9+ce2nB52Y5zbTF1Hc0MDFfbydcMcxb47jSdhikVHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@dmsnell/diff-match-patch": {
       "version": "1.1.0",
@@ -1612,6 +1623,15 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
@@ -1885,6 +1905,13 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1907,6 +1934,33 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bree": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/bree/-/bree-9.2.4.tgz",
+      "integrity": "sha512-3GDVYbRYxPIIKgqu00FlIDD//q/0XkMC+zq74sp/qRRQQUWdc39lsFkdHW2g2lTlhaxbqkHd97p8oRMm/YeSJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@breejs/later": "^4.2.0",
+        "boolean": "^3.2.0",
+        "combine-errors": "^3.0.3",
+        "cron-validate": "^1.4.5",
+        "human-interval": "^2.0.1",
+        "is-string-and-not-blank": "^0.0.2",
+        "is-valid-path": "^0.1.1",
+        "ms": "^2.1.3",
+        "p-wait-for": "3",
+        "safe-timers": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12.17.0 <13.0.0-0||>=13.2.0"
+      }
+    },
+    "node_modules/bree/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/brotli": {
       "version": "1.3.3",
@@ -2257,6 +2311,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combine-errors": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/combine-errors/-/combine-errors-3.0.3.tgz",
+      "integrity": "sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==",
+      "dependencies": {
+        "custom-error-instance": "2.1.1",
+        "lodash.uniqby": "4.5.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2468,6 +2531,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/cron-validate": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/cron-validate/-/cron-validate-1.5.2.tgz",
+      "integrity": "sha512-WYyUAgYlaaLCi4gF4tK/by+ky+i82E9H5ekTAOk50GtpSDyBt4HMBTdsjxTGWOCtEygmgm2zMLVD/AszcsmS+w==",
+      "license": "MIT",
+      "dependencies": {
+        "yup": "1.6.1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2505,6 +2577,12 @@
       "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.5.2.tgz",
       "integrity": "sha512-RFPahj0sXcmUyjrObAK+DOWtMvMIFV328n4qZJhgX3x2RqkQgOTU2mCUmiFR0CzM6AzChlRSUErjiJeEt8BaQA==",
       "license": "MIT"
+    },
+    "node_modules/custom-error-instance": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/custom-error-instance/-/custom-error-instance-2.1.1.tgz",
+      "integrity": "sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==",
+      "license": "ISC"
     },
     "node_modules/dayjs": {
       "version": "1.11.13",
@@ -2955,6 +3033,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/exceljs": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/exceljs/-/exceljs-4.4.0.tgz",
@@ -3131,6 +3218,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -3750,6 +3846,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/human-interval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-2.0.1.tgz",
+      "integrity": "sha512-r4Aotzf+OtKIGQCB3odUowy4GfUDTy3aTWTfLd7ZF2gBCy3XW3v/dJLRefZnOFFnjqs5B1TypvS8WarpBkYUNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "numbered": "^1.1.0"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3951,6 +4056,15 @@
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3969,6 +4083,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-glob": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -3993,11 +4131,41 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string-and-not-blank": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/is-string-and-not-blank/-/is-string-and-not-blank-0.0.2.tgz",
+      "integrity": "sha512-FyPGAbNVyZpTeDCTXnzuwbu9/WpNXbCfbHXLpCRpN4GANhS00eEIP5Ef+k5HYSNIzIhdN9zRDoBj6unscECvtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-string-blank": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
+      }
+    },
+    "node_modules/is-string-blank": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
+      "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw==",
+      "license": "MIT"
+    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
       "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
       "license": "MIT"
+    },
+    "node_modules/is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-invalid-path": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -5159,6 +5327,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash._baseiteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseiteratee/-/lodash._baseiteratee-4.7.0.tgz",
+      "integrity": "sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._stringtopath": "~4.8.0"
+      }
+    },
+    "node_modules/lodash._basetostring": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
+      "integrity": "sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._baseuniq": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
+      "integrity": "sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._createset": "~4.0.0",
+        "lodash._root": "~3.0.0"
+      }
+    },
+    "node_modules/lodash._createset": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
+      "integrity": "sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash._stringtopath": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash._stringtopath/-/lodash._stringtopath-4.8.0.tgz",
+      "integrity": "sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._basetostring": "~4.12.0"
+      }
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -5280,6 +5494,16 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
+    },
+    "node_modules/lodash.uniqby": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.5.0.tgz",
+      "integrity": "sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash._baseiteratee": "~4.7.0",
+        "lodash._baseuniq": "~4.6.0"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5656,6 +5880,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/numbered": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/numbered/-/numbered-1.1.0.tgz",
+      "integrity": "sha512-pv/ue2Odr7IfYOO0byC1KgBI10wo5YDauLhxY6/saNzAdAs0r1SotGCPzzCLNPL0xtrAwWRialLu23AAu9xO1g==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5675,6 +5905,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/on-finished": {
@@ -5753,6 +5992,15 @@
         "opencollective-postinstall": "index.js"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5798,6 +6046,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -5806,6 +6066,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-wait-for": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pako": {
@@ -6049,6 +6324,93 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-8.21.0.tgz",
+      "integrity": "sha512-ip4qdzjkAyDDZklUaZkcRFb2iA118H9SgRh8yzTkSQK8HilsOJF7rSY8HoW5+I0M46AZgX/pxbprf2vvzQCE0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^1.2.0",
+        "pino-std-serializers": "^6.0.0",
+        "process-warning": "^3.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^3.7.0",
+        "thread-stream": "^2.6.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.0.0",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/pino-abstract-transport/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz",
+      "integrity": "sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -6144,10 +6506,25 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-3.0.0.tgz",
+      "integrity": "sha512-mqn0kFRl0EoqhnL0GQ0veqFHyIN1yig9RHh/InzORTUiZHFRAur+aMtRkELNwGs9aNwKS6tg/An4NYBPGwvtzQ==",
       "license": "MIT"
     },
     "node_modules/prompts": {
@@ -6163,6 +6540,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -6221,6 +6604,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -6302,6 +6691,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -6432,6 +6830,21 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/safe-timers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-timers/-/safe-timers-1.1.0.tgz",
+      "integrity": "sha512-9aqY+v5eMvmRaluUEtdRThV1EjlSElzO7HuCj0sTW9xvp++8iJ9t/RWGNWV6/WHcUJLHpyT2SNf/apoKTU2EpA==",
       "license": "MIT"
     },
     "node_modules/safer-buffer": {
@@ -6777,6 +7190,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -7160,6 +7582,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.7.0.tgz",
+      "integrity": "sha512-qQiRWsU/wvNolI6tbbCKd9iKaTnCXsTwVxhhKM6nctPdujTyztjlbUkUTUymidWcMnZ5pWR0ej4a0tjsW021vw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -7203,6 +7640,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -7671,6 +8114,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
+      }
+    },
+    "node_modules/yup/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,8 @@
     "ml-isolation-forest": "^0.1.0",
     "multer": "^1.4.5-lts.1",
     "node-cron": "^3.0.2",
+    "pino": "^8.17.0",
+    "bree": "^9.2.4",
     "nodemailer": "^7.0.3",
     "openai": "^4.97.0",
     "pdf-parse": "^1.1.1",

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -1,0 +1,51 @@
+const openai = require('../config/openrouter');
+const logger = require('../utils/logger');
+
+async function aiDuplicateCheck(filename, invoice_number, amount, vendor, flags) {
+  if (!process.env.OPENROUTER_API_KEY) return { flag: false };
+  const start = Date.now();
+  try {
+    const prompt = `Filename similar: ${flags.similarFile}; Duplicate combo: ${flags.dupCombo}; Off-hours: ${flags.offHours}. Invoice #: ${invoice_number}, Amount: $${amount}, Vendor: ${vendor}. Should this be flagged? Respond with JSON {"flag":true|false,"reason":"reason"}`;
+    const resp = await openai.chat.completions.create({
+      model: 'openai/gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You detect duplicate or suspicious invoices.' },
+        { role: 'user', content: prompt }
+      ]
+    });
+    logger.info({ latency: Date.now() - start }, 'aiDuplicateCheck');
+    const txt = resp.choices?.[0]?.message?.content?.trim();
+    if (!txt) return { flag: false };
+    try {
+      return JSON.parse(txt);
+    } catch {
+      const flag = /yes|true|1/i.test(txt);
+      return { flag, reason: txt };
+    }
+  } catch (err) {
+    logger.error({ err }, 'AI duplicate check error');
+    return { flag: false };
+  }
+}
+
+async function generateErrorSummary(errors) {
+  if (!process.env.OPENROUTER_API_KEY) return null;
+  const start = Date.now();
+  try {
+    const prompt = `You are a helpful assistant for a CSV invoice uploader tool. Given these validation errors, provide a short summary with possible fixes.\n\n${errors.join('\n')}`;
+    const aiRes = await openai.chat.completions.create({
+      model: 'openai/gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: 'You explain CSV upload errors in plain English.' },
+        { role: 'user', content: prompt },
+      ]
+    });
+    logger.info({ latency: Date.now() - start }, 'generateErrorSummary');
+    return aiRes.choices?.[0]?.message?.content?.trim() || null;
+  } catch (e) {
+    logger.error({ err: e }, 'AI summary error');
+    return null;
+  }
+}
+
+module.exports = { aiDuplicateCheck, generateErrorSummary };

--- a/backend/services/invoiceService.js
+++ b/backend/services/invoiceService.js
@@ -1,0 +1,44 @@
+const pool = require('../config/db');
+const { recordInvoiceVersion } = require('../utils/versionLogger');
+const { triggerAutomations } = require('../utils/automationEngine');
+const logger = require('../utils/logger');
+
+async function autoAssignInvoice(invoiceId, vendor, tags = []) {
+  let assignee;
+  try {
+    const { getAssigneeFromVendorHistory, getAssigneeFromTags } = require('../utils/assignment');
+    assignee = await getAssigneeFromVendorHistory(vendor);
+    if (!assignee) assignee = getAssigneeFromTags(tags);
+    if (!assignee && vendor && vendor.toLowerCase().includes('figma')) assignee = 'Design Team';
+    if (!assignee && tags.map(t => t.toLowerCase()).includes('marketing')) assignee = 'Alice';
+    if (assignee) {
+      await pool.query('UPDATE invoices SET assignee = $1 WHERE id = $2', [assignee, invoiceId]);
+    }
+  } catch (err) {
+    logger.error({ err }, 'Auto-assign error');
+  }
+}
+
+async function insertInvoice(inv, tenantId) {
+  const {
+    invoice_number, date, amount, vendor, tags = [], category = null,
+    assignee = null, flagged = false, flag_reason, approval_chain = ['Manager','Finance','CFO'], current_step = 0,
+    integrity_hash, content_hash, blockchain_tx = null, retention_policy, delete_at = null,
+    approval_status = 'Pending', department = null, original_amount, currency,
+    exchange_rate, vat_percent, vat_amount, expires_at = null, encrypted_payload = null
+  } = inv;
+  const res = await pool.query(
+    `INSERT INTO invoices (invoice_number, date, amount, vendor, tags, category, assignee, flagged, flag_reason, approval_chain, current_step, integrity_hash, content_hash, blockchain_tx, retention_policy, delete_at, tenant_id, approval_status, department, original_amount, currency, exchange_rate, vat_percent, vat_amount, expires_at, expired, encrypted_payload)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28) RETURNING id`,
+    [invoice_number, date, amount, vendor, tags, category, assignee, flagged, flag_reason, JSON.stringify(approval_chain), current_step, integrity_hash, content_hash, blockchain_tx, retention_policy, delete_at, tenantId, approval_status, department, original_amount, currency, exchange_rate, vat_percent, vat_amount, expires_at, false, encrypted_payload]
+  );
+  const newId = res.rows[0].id;
+  const afterRes = await pool.query('SELECT * FROM invoices WHERE id = $1', [newId]);
+  if (afterRes.rows.length) {
+    await recordInvoiceVersion(newId, {}, afterRes.rows[0], inv.editor_id, inv.editor_name);
+  }
+  triggerAutomations('invoice_created', { invoice: afterRes.rows[0] });
+  return newId;
+}
+
+module.exports = { autoAssignInvoice, insertInvoice };

--- a/backend/services/ocrService.js
+++ b/backend/services/ocrService.js
@@ -1,0 +1,16 @@
+const { parseCSV } = require('../utils/csvParser');
+const { parsePDF } = require('../utils/pdfParser');
+const { parseImage } = require('../utils/imageParser');
+const { parseExcel } = require('../utils/excelParser');
+const path = require('path');
+
+async function parseFile(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.csv') return parseCSV(filePath);
+  if (ext === '.pdf') return parsePDF(filePath);
+  if (ext === '.xls' || ext === '.xlsx') return parseExcel(filePath);
+  if (['.png', '.jpg', '.jpeg'].includes(ext)) return parseImage(filePath);
+  throw new Error('Unsupported file type');
+}
+
+module.exports = { parseFile };

--- a/backend/services/validationService.js
+++ b/backend/services/validationService.js
@@ -1,0 +1,54 @@
+const levenshtein = require('fast-levenshtein');
+const pool = require('../config/db');
+
+async function validateInvoiceRow(inv, rowNum) {
+  const errors = [];
+  if (!inv.invoice_number || !inv.date || !inv.amount || !inv.vendor) {
+    errors.push(`Row ${rowNum}: Missing required field`);
+  }
+  if (inv.amount && isNaN(parseFloat(inv.amount))) {
+    errors.push(`Row ${rowNum}: Amount is not a valid number`);
+  }
+  if (inv.date && isNaN(Date.parse(inv.date))) {
+    errors.push(`Row ${rowNum}: Date is not valid`);
+  }
+  const contentHash = require('crypto')
+    .createHash('sha256')
+    .update(`${inv.invoice_number}|${inv.amount}|${inv.vendor}`)
+    .digest('hex');
+  try {
+    const dupRes = await pool.query(
+      'SELECT id FROM invoices WHERE content_hash = $1 LIMIT 1',
+      [contentHash]
+    );
+    if (dupRes.rows.length) {
+      errors.push(`Row ${rowNum}: Possible duplicate of invoice ID ${dupRes.rows[0].id}`);
+    }
+  } catch (err) {
+    errors.push(`Row ${rowNum}: Duplicate check failed`);
+  }
+  return errors;
+}
+
+async function checkSimilarity(vendor, invoice_number, amount) {
+  try {
+    const { rows: recent } = await pool.query(
+      'SELECT invoice_number, amount, vendor FROM invoices WHERE vendor = $1 ORDER BY id DESC LIMIT 20',
+      [vendor]
+    );
+    const newStr = `${invoice_number}|${amount}|${vendor}`.toLowerCase();
+    for (const r of recent) {
+      const oldStr = `${r.invoice_number}|${r.amount}|${r.vendor}`.toLowerCase();
+      const distance = levenshtein.get(newStr, oldStr);
+      const similarity = 1 - distance / Math.max(newStr.length, oldStr.length);
+      if (similarity > 0.8) {
+        return `Possible duplicate (${Math.round(similarity * 100)}%)`;
+      }
+    }
+  } catch (e) {
+    return null;
+  }
+  return null;
+}
+
+module.exports = { validateInvoiceRow, checkSimilarity };

--- a/backend/utils/cronManager.js
+++ b/backend/utils/cronManager.js
@@ -1,0 +1,23 @@
+const cron = require('node-cron');
+const logger = require('./logger');
+
+function schedule(name, pattern, task) {
+  const job = cron.schedule(pattern, async () => {
+    try {
+      logger.info(`Cron job ${name} started`);
+      await task();
+      logger.info(`Cron job ${name} finished`);
+    } catch (err) {
+      logger.error({ err }, `Cron job ${name} failed`);
+      if (task.retryCount === undefined) task.retryCount = 0;
+      if (task.retryCount < 3) {
+        task.retryCount += 1;
+        logger.info(`Retrying job ${name} in 1 minute`);
+        setTimeout(() => job.fireOnTick(), 60000);
+      }
+    }
+  });
+  return job;
+}
+
+module.exports = { schedule };

--- a/backend/utils/erpExport.js
+++ b/backend/utils/erpExport.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const logger = require('./logger');
 
 async function exportToErpA(invoice) {
   if (!process.env.ERP_A_URL || !process.env.ERP_A_TOKEN) return;
@@ -6,9 +7,9 @@ async function exportToErpA(invoice) {
     await axios.post(`${process.env.ERP_A_URL}/invoices`, invoice, {
       headers: { Authorization: `Bearer ${process.env.ERP_A_TOKEN}` },
     });
-    console.log('Exported invoice to ERP A');
+    logger.info('Exported invoice to ERP A');
   } catch (err) {
-    console.error('ERP A export error:', err.message);
+    logger.error({ err }, 'ERP A export error');
   }
 }
 
@@ -18,9 +19,9 @@ async function exportToErpB(invoice) {
     await axios.post(`${process.env.ERP_B_URL}/invoices`, invoice, {
       headers: { Authorization: `Bearer ${process.env.ERP_B_TOKEN}` },
     });
-    console.log('Exported invoice to ERP B');
+    logger.info('Exported invoice to ERP B');
   } catch (err) {
-    console.error('ERP B export error:', err.message);
+    logger.error({ err }, 'ERP B export error');
   }
 }
 

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,0 +1,3 @@
+const pino = require('pino');
+const logger = pino({ level: process.env.LOG_LEVEL || 'info' });
+module.exports = logger;

--- a/backend/utils/seedDummyData.js
+++ b/backend/utils/seedDummyData.js
@@ -1,4 +1,5 @@
 const pool = require('../config/db');
+const logger = require('./logger');
 
 (async function seedDummy() {
   const client = await pool.connect();
@@ -17,7 +18,7 @@ const pool = require('../config/db');
       );
       inserted++;
     }
-    console.log(`Seeded ${inserted} dummy invoices`);
+    logger.info(`Seeded ${inserted} dummy invoices`);
   } catch (err) {
     console.error('Seed demo data error:', err);
     process.exitCode = 1;

--- a/backend/utils/tenantContext.js
+++ b/backend/utils/tenantContext.js
@@ -1,0 +1,16 @@
+const pool = require('../config/db');
+
+async function getTenantContext(tenantId = 'default') {
+  const { rows } = await pool.query('SELECT feature, enabled FROM tenant_features WHERE tenant_id = $1', [tenantId]);
+  const features = {};
+  rows.forEach(r => { features[r.feature] = r.enabled; });
+  const aiKey = process.env[`OPENROUTER_API_KEY_${tenantId.toUpperCase()}`] || process.env.OPENROUTER_API_KEY;
+  return { tenantId, db: pool, features, aiKey };
+}
+
+async function checkTenantInvoiceLimit(tenantId, limit = 500) {
+  const { rows } = await pool.query("SELECT COUNT(*) AS cnt FROM invoices WHERE tenant_id = $1 AND DATE_TRUNC('month', created_at) = DATE_TRUNC('month', CURRENT_DATE)", [tenantId]);
+  return parseInt(rows[0].cnt, 10) < limit;
+}
+
+module.exports = { getTenantContext, checkTenantInvoiceLimit };


### PR DESCRIPTION
## Summary
- break invoice controller into service modules for AI, validation, OCR and DB helpers
- add AI utilities and vendor/fraud helpers
- introduce global logger using pino
- add cron manager with retry logic and integrate into schedulers
- create tenant utilities enforcing invoice limits
- improve error handling

## Testing
- `npm install --silent`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687977977264832ea4648eaabfd3bf4b