### PR TITLE
Rebrand to AI Document Ops Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ClarifyOps Document Uploader + AI Error Summarizer
+# ClarifyOps AI Document Ops Engine
 
-This is a full-stack document uploader tool with AI-powered CSV error summarization, built using:
+This is a full-stack **AI Document Ops Engine** delivering operational clarity for any document through automated intelligence workflows, built using:
 
 - **React + Tailwind CSS** (frontend)
 - **Express + PostgreSQL** (backend)
@@ -97,6 +97,10 @@ npm install --legacy-peer-deps
 - Drag-and-drop upload with real-time field mapping
 - AI explanations for why an invoice was flagged
 - Admin settings panel with auto-archive toggle, custom AI tone and upload limits
+- Org-wide settings per tenant with custom branding
+- SOC2-ready audit logs for every action
+- Usage analytics dashboard for document volume and workflow metrics
+- Role delegation so approvers can temporarily assign their duties
 - Invoice expiration auto-closes past-due invoices or flags them for review
 - "Why did AI say this?" links show confidence and reasoning
 - AI-powered bulk categorization of uploaded invoices

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -18,7 +18,7 @@ exports.summarizeUploadErrors = async (req, res) => {
     // ✅ Define errorText from the errors array
     const errorText = errors.join('\n');
 
-    const prompt = `You are a helpful assistant for a CSV invoice uploader tool.
+    const prompt = `You are a helpful assistant for the ClarifyOps AI Document Ops Engine.
 Given the following upload validation errors, provide a concise summary. Then list bullet points under "Possible Fixes" and, if relevant, a "Warnings" section.
 \n\n${errorText}`;
 

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -32,7 +32,7 @@ async function generateErrorSummary(errors) {
   if (!process.env.OPENROUTER_API_KEY) return null;
   const start = Date.now();
   try {
-    const prompt = `You are a helpful assistant for a CSV invoice uploader tool. Given these validation errors, provide a short summary with possible fixes.\n\n${errors.join('\n')}`;
+    const prompt = `You are a helpful assistant for the ClarifyOps AI Document Ops Engine. Given these validation errors, provide a short summary with possible fixes.\n\n${errors.join('\n')}`;
     const aiRes = await openai.chat.completions.create({
       model: 'openai/gpt-3.5-turbo',
       messages: [

--- a/docs/TRANSFORMATION_PLAN.md
+++ b/docs/TRANSFORMATION_PLAN.md
@@ -1,6 +1,6 @@
 # ClarifyOps Transformation Plan
 
-This document outlines a high level path to move the existing invoice uploader toward a more general AI Ops platform. Key steps include abstracting invoice-only logic and expanding the data model so other document types can be supported.
+This document outlines a high level path to evolve ClarifyOps from an invoice uploader into an **AI Document Ops Engine**. The brand now emphasizes **AI Document Intelligence + Automation** to deliver operational clarity for any document. Key steps include abstracting invoice-only logic and expanding the data model so other document types can be supported.
 
 ## 1. Generalize data model
 
@@ -37,3 +37,10 @@ This document outlines a high level path to move the existing invoice uploader t
 - **Compliance Checker** – `/api/documents/:id/compliance` flags missing clauses for contracts.
 - **Document Lifecycle Rules** – `retention_policy`, `expires_at` and `archived` now apply to all documents.
 - **Secure Signing** – New `/api/signing/:id/start` endpoint stores a blockchain hash and redirects to DocuSign.
+
+## 7. Enterprise Readiness
+
+- **Org-wide Settings** – Centralized configuration scoped to each organization with support for custom branding and tenant preferences.
+- **SOC2-ready Audit Logs** – Immutable `audit_logs` table capturing every user action with timestamp, IP and metadata.
+- **Usage Analytics** – `/api/analytics/usage` aggregates document volumes and workflow stats per tenant for admins.
+- **Role Delegation** – Administrators can delegate temporary roles and approval authority via `/api/roles/delegate`.

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -11,21 +11,21 @@
     />
     <link rel="icon" href="/favicon.ico" />
     <meta name="theme-color" content="#4338ca" />
-    <title>ClarifyOps – AI Invoice Automation</title>
+    <title>ClarifyOps – AI Document Intelligence + Automation</title>
     <meta
       name="description"
-      content="AI invoice automation with built‑in validation and real‑time analytics."
+      content="Operational clarity for any document with automated intelligence and workflows."
     />
     <meta property="og:title" content="ClarifyOps" />
     <meta
       property="og:description"
-      content="Streamline accounts payable with AI-driven validation and instant analytics."
+      content="Streamline document operations with AI-driven validation and instant analytics."
     />
     <meta property="og:image" content="/logo512.png" />
     <meta property="og:url" content="https://clarifyops.com/" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="ClarifyOps – AI Invoice Automation" />
-    <meta name="twitter:description" content="Streamline accounts payable with AI-driven validation and instant analytics." />
+    <meta name="twitter:title" content="ClarifyOps – AI Document Intelligence + Automation" />
+    <meta name="twitter:description" content="Streamline document operations with AI-driven validation and instant analytics." />
     <meta name="twitter:image" content="/logo512.png" />
     <link rel="canonical" href="https://clarifyops.com/" />
   </head>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
   "short_name": "ClarifyOps",
-  "name": "ClarifyOps – AI Invoice Automation",
+  "name": "ClarifyOps – AI Document Intelligence + Automation",
   "icons": [
     {
       "src": "favicon.ico",

--- a/frontend/src/components/HeroSection.jsx
+++ b/frontend/src/components/HeroSection.jsx
@@ -23,10 +23,10 @@ export default function HeroSection({ onRequestDemo }) {
         >
           <>
             <h1 className="text-6xl md:text-7xl font-extrabold tracking-tight">
-              ClarifyOps – AI-Powered Document Intelligence for Modern Teams
+              ClarifyOps – AI Document Intelligence + Automation
             </h1>
             <p className="text-xl md:text-2xl max-w-xl mx-auto md:mx-0 text-gray-600 dark:text-gray-300">
-              Extract, validate, and automate any business document — not just invoices.
+              Operational clarity for any document with automated intelligence and workflows.
             </p>
           </>
           <div className="flex justify-center md:justify-start">


### PR DESCRIPTION
## Summary
- rename the product as ClarifyOps AI Document Ops Engine
- update brand messaging and hero copy
- adjust AI prompts for new branding
- outline enterprise readiness in transformation plan
- update manifest and metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c43132bc832e92751e99619a10b9