### PR TITLE
Fix login path for document API

### DIFF
--- a/frontend/src/Documents.js
+++ b/frontend/src/Documents.js
@@ -1492,7 +1492,7 @@ useEffect(() => {
       return;
     }
     try {
-      const res = await fetch('/api/invoices/login', {
+      const res = await fetch('/documents/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -12,7 +12,7 @@ export default function Login({ onLogin, addToast }) {
 
   const handleLogin = async () => {
     try {
-      const res = await fetch(`${API_BASE}/api/invoices/login`, {
+      const res = await fetch(`${API_BASE}/documents/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -43,14 +43,14 @@ window.fetch = async (url, options) => {
     if (url.startsWith(API_BASE)) {
       let path = url.slice(API_BASE.length);
       if (path.startsWith('/api/invoices')) {
-        path = path.replace('/api/invoices', `/api/${tenant}/invoices`);
+        path = path.replace('/api/invoices', `/api/${tenant}/documents`);
       } else if (path.startsWith('/api/export-templates')) {
         path = path.replace('/api/export-templates', `/api/${tenant}/export-templates`);
       }
       url = API_BASE + path;
     } else if (url.startsWith('/')) {
       if (url.startsWith('/api/invoices')) {
-        url = url.replace('/api/invoices', `/api/${tenant}/invoices`);
+        url = url.replace('/api/invoices', `/api/${tenant}/documents`);
       } else if (url.startsWith('/api/export-templates')) {
         url = url.replace('/api/export-templates', `/api/${tenant}/export-templates`);
       }
@@ -82,7 +82,7 @@ const savedFont = localStorage.getItem(`fontFamily_${currentTenant}`);
 if (savedFont) document.documentElement.style.setProperty('--font-base', savedFont);
 
 if (API_BASE) {
-  fetch(`${API_BASE}/api/invoices`).catch((err) => {
+  fetch(`${API_BASE}/api/documents`).catch((err) => {
     console.error('API connection failed', err);
   });
 }


### PR DESCRIPTION
## Summary
- update login path in `Login.js` and `Documents.js`
- rewrite `/api/invoices` to `/api/<tenant>/documents` in fetch wrapper
- adjust initial API connection check

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6879e240a428832e9d8ea11c13e36a77