### PR TITLE
Fix login by using correct API env

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,1 +1,3 @@
-export const API_BASE = process.env.REACT_APP_API_BASE_URL || '';
+// Support both REACT_APP_API_BASE_URL and legacy REACT_APP_API_BASE
+export const API_BASE =
+  process.env.REACT_APP_API_BASE_URL || process.env.REACT_APP_API_BASE || '';


### PR DESCRIPTION
## Summary
- fix API base detection to support REACT_APP_API_BASE or REACT_APP_API_BASE_URL

## Testing
- `npm test` in `backend`
- `CI=true npm test --silent` in `frontend` *(fails: Cannot find module './App')*

------
https://chatgpt.com/codex/tasks/task_e_687ab78f1a00832e9947a2a1aeb7dcda