### PR TITLE
Fix documents routing

### DIFF
--- a/frontend/src/LoginPage.jsx
+++ b/frontend/src/LoginPage.jsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
         onLogin={(tok, role) => {
           localStorage.setItem('token', tok);
           localStorage.setItem('role', role);
-          navigate('/invoices');
+          navigate('/documents');
         }}
         addToast={addToast}
       />

--- a/frontend/src/OnboardingWizard.js
+++ b/frontend/src/OnboardingWizard.js
@@ -108,7 +108,7 @@ export default function OnboardingWizard() {
           <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow text-center">
             <h2 className="text-lg font-semibold">All set!</h2>
             <p className="text-sm">Your template has been saved. You're ready to start uploading invoices.</p>
-            <Button onClick={() => (window.location.href = '/invoices')}>Go to App</Button>
+            <Button onClick={() => (window.location.href = '/documents')}>Go to App</Button>
           </div>
         )}
       </div>

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -336,7 +336,7 @@ function VendorManagement() {
                 <td className="p-2 flex space-x-2">
                   <button onClick={() => setEditingVendor(v.vendor)} title="Edit"><PencilSquareIcon className="w-4 h-4" /></button>
                   <button onClick={() => setDetailVendor(v.vendor)} title="Details"><DocumentChartBarIcon className="w-4 h-4" /></button>
-                  <button onClick={() => navigate(`/invoices?vendor=${encodeURIComponent(v.vendor)}`)} title="View Invoices"><EyeIcon className="w-4 h-4" /></button>
+                  <button onClick={() => navigate(`/documents?vendor=${encodeURIComponent(v.vendor)}`)} title="View Documents"><EyeIcon className="w-4 h-4" /></button>
                   <button onClick={async () => { if (window.confirm('Delete vendor?')) { await fetch(`${API_BASE}/api/vendors/${encodeURIComponent(v.vendor)}`, { method: 'DELETE', headers }); fetchVendors(); } }} title="Delete"><TrashIcon className="w-4 h-4 text-red-600" /></button>
                 </td>
               </tr>

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -54,8 +54,8 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
               <span>Adaptive</span>
             </Link>
             <Link
-              to="/invoices"
-              className={`nav-link border-l-4 ${location.pathname === '/invoices' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
+              to="/documents"
+              className={`nav-link border-l-4 ${location.pathname === '/documents' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <FileText className="w-5 h-5" />
               <span>Documents</span>


### PR DESCRIPTION
## Summary
- update sidebar link to `/documents`
- route users to `/documents` after login
- redirect onboarding wizard button to `/documents`
- open vendor invoices with `/documents?vendor=...`

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module './App')*

------
https://chatgpt.com/codex/tasks/task_e_687abcd7c7d8832ebff359bf0c7969af