### PR TITLE
Fix API base path normalization

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,3 +1,11 @@
 // Support both REACT_APP_API_BASE_URL and legacy REACT_APP_API_BASE
-export const API_BASE =
+// Some deployments accidentally include the `/api` prefix in the env variable
+// which results in requests like `/api/api/...`.  Normalize the base URL to
+// exclude a trailing `/api` so the fetch helpers can append paths consistently.
+const rawBase =
   process.env.REACT_APP_API_BASE_URL || process.env.REACT_APP_API_BASE || '';
+let base = rawBase.replace(/\/+$/, '');
+if (base.endsWith('/api')) {
+  base = base.slice(0, -4);
+}
+export const API_BASE = base;


### PR DESCRIPTION
## Summary
- sanitize API base in the frontend to avoid double `/api` path

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e8bbc0b44832e9bbf180bb6e4747f