### PR TITLE
Fix pgvector extension error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: pgvector/pgvector:pg15
         env:
           POSTGRES_DB: invoices
           POSTGRES_USER: postgres

--- a/README.md
+++ b/README.md
@@ -608,3 +608,12 @@ This happens when the backend tries to reach PostgreSQL on the IPv6 loopback add
    If `DATABASE_URL` still points to `localhost:5433`, override it in your `.env`
    or remove the variable so the `DB_HOST` and `DB_PORT` values are used.
 
+**`Database init error: extension "vector" is not available`**
+
+The Postgres container must include the pgvector extension. Use the `pgvector/pgvector:pg15` image in `docker-compose.yml` and rebuild:
+
+```bash
+docker-compose down
+docker-compose up --build
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:15
+    image: pgvector/pgvector:pg15
     container_name: clarifyops-db
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
## Summary
- use pgvector image for PostgreSQL in docker-compose
- mirror change in CI workflow
- document fix for missing `vector` extension

## Testing
- `npm test --silent` in `backend`
- `CI=true npm test --silent -- --watchAll=false` in `frontend` *(fails: Cannot find module './App')*

------
https://chatgpt.com/codex/tasks/task_e_687e920d972c832e94cc51e026e5116f