### PR TITLE
Fix login route

### DIFF
--- a/frontend/src/Documents.js
+++ b/frontend/src/Documents.js
@@ -1494,7 +1494,7 @@ useEffect(() => {
       return;
     }
     try {
-      const res = await fetch('/documents/login', {
+      const res = await fetch(`${API_BASE}/api/documents/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -12,7 +12,7 @@ export default function Login({ onLogin, addToast }) {
 
   const handleLogin = async () => {
     try {
-      const res = await fetch(`${API_BASE}/documents/login`, {
+      const res = await fetch(`${API_BASE}/api/documents/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),


### PR DESCRIPTION
## Summary
- update login calls to use `/api/documents/login`

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend -- --watchAll=false` *(fails: Cannot find module './App' from 'src/App.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_687e96b83998832e9c9ee92f1ef02c1c