### PR TITLE
Add migration script for documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,20 @@ cd backend
 npm run seed-dummy
 ```
 
+### Database Migration
+
+If you're upgrading from an earlier version that only had an `invoices` table,
+run the migration script to rename it and add the new document fields:
+
+```bash
+cd backend
+node migrations/migrateInvoicesToDocuments.js
+```
+
+This backs up the old table, renames it to `documents` and adds `type`, `title`,
+`entity`, `fileType` and `contentHash` columns. Existing API calls under
+`/api/invoices` continue to work via the `/api/documents` routes.
+
 Make sure you log in again to obtain a fresh token if you see a `401` response when calling the endpoint.
 
 ### Docker Deployment

--- a/backend/migrations/migrateInvoicesToDocuments.js
+++ b/backend/migrations/migrateInvoicesToDocuments.js
@@ -1,0 +1,26 @@
+const pool = require('../config/db');
+
+(async () => {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('CREATE TABLE IF NOT EXISTS invoices_backup AS TABLE invoices');
+    const check = await client.query("SELECT to_regclass('documents') AS exists");
+    if (!check.rows[0].exists) {
+      await client.query('ALTER TABLE invoices RENAME TO documents');
+    }
+    await client.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS type TEXT");
+    await client.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS title TEXT");
+    await client.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS entity TEXT");
+    await client.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS fileType TEXT");
+    await client.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS contentHash TEXT");
+    await client.query('COMMIT');
+    console.log('✅ Migration complete');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('Migration failed:', err.message);
+  } finally {
+    client.release();
+    pool.end();
+  }
+})();

--- a/backend/utils/seedDummyData.js
+++ b/backend/utils/seedDummyData.js
@@ -13,8 +13,20 @@ const logger = require('./logger');
       const date = new Date(Date.now() - Math.random() * 60 * 86400000);
       const category = categories[Math.floor(Math.random() * categories.length)];
       await client.query(
-        'INSERT INTO invoices (invoice_number, date, amount, vendor, category) VALUES ($1,$2,$3,$4,$5)',
-        [`DEMO-${Date.now()}-${i}`, date, amount, vendor, category]
+        `INSERT INTO documents (invoice_number, date, amount, vendor, category, type, title, entity, fileType, contentHash)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+        [
+          `DEMO-${Date.now()}-${i}`,
+          date,
+          amount,
+          vendor,
+          category,
+          'invoice',
+          `DEMO-${i}`,
+          vendor,
+          'pdf',
+          null
+        ]
       );
       inserted++;
     }


### PR DESCRIPTION
## Summary
- seed dummy data into `documents` table
- provide migration script to rename the `invoices` table and add document fields
- document migration steps in README

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_687eb19c8e58832ea0f7e4a7519b48cf