### PR TITLE
Fix inbox crash & add fraud actions

### DIFF
--- a/frontend/src/ErrorBoundary.js
+++ b/frontend/src/ErrorBoundary.js
@@ -4,10 +4,22 @@ class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
+    this.lastPath = window.location.pathname;
   }
 
-  static getDerivedStateFromError(error) {
+  static getDerivedStateFromError() {
     return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  componentDidUpdate() {
+    if (this.state.hasError && this.lastPath !== window.location.pathname) {
+      this.setState({ hasError: false });
+      this.lastPath = window.location.pathname;
+    }
   }
 
   render() {

--- a/frontend/src/FraudReport.js
+++ b/frontend/src/FraudReport.js
@@ -9,6 +9,26 @@ function FraudReport() {
   const [loading, setLoading] = useState(true);
   const [explanations, setExplanations] = useState({});
 
+  const unflagInvoice = async (id) => {
+    await fetch(`${API_BASE}/api/invoices/${id}/flag`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ flagged: false }),
+    });
+    fetchFlagged();
+  };
+
+  const approveInvoice = async (id) => {
+    await fetch(`${API_BASE}/api/invoices/${id}/approve`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    fetchFlagged();
+  };
+
   const fetchFlagged = useCallback(async () => {
     if (!token) return;
     setLoading(true);
@@ -45,12 +65,13 @@ function FraudReport() {
                 <th className="px-2 py-1">Amount</th>
                 <th className="px-2 py-1">Reason</th>
                 <th className="px-2 py-1">Explain</th>
+                <th className="px-2 py-1">Actions</th>
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan="6" className="p-4"><Skeleton rows={5} height="h-4" /></td>
+                  <td colSpan="7" className="p-4"><Skeleton rows={5} height="h-4" /></td>
                 </tr>
               ) : (
                 invoices.map(inv => (
@@ -61,7 +82,11 @@ function FraudReport() {
                     <td className="px-2 py-1">${inv.amount}</td>
                     <td className="px-2 py-1">{explanations[inv.id] || inv.flag_reason || '-'}</td>
                     <td className="px-2 py-1">
-                      <button onClick={() => loadExplanation(inv.id)} className="btn btn-primary text-xs px-2 py-1" title="Explain">AI</button>
+                      <button onClick={() => loadExplanation(inv.id)} className="btn btn-primary text-xs px-2 py-1 mr-1" title="Explain">AI</button>
+                    </td>
+                    <td className="px-2 py-1 space-x-1">
+                      <button onClick={() => unflagInvoice(inv.id)} className="btn btn-ghost text-xs" title="Unflag">Unflag</button>
+                      <button onClick={() => approveInvoice(inv.id)} className="btn btn-ghost text-xs" title="Approve">Approve</button>
                     </td>
                   </tr>
                 ))

--- a/frontend/src/Inbox.js
+++ b/frontend/src/Inbox.js
@@ -334,7 +334,7 @@ export default function Inbox() {
                         <span className="text-xs text-gray-500">-</span>
                       )}
                     </td>
-                    <td className="px-3 py-4 text-xs">{inv.tags?.join(', ') || '-'}</td>
+                    <td className="px-3 py-4 text-xs">{Array.isArray(inv.tags) ? inv.tags.join(', ') : inv.tags || '-'}</td>
                     <td className="px-3 py-4 text-center">
                       {inv.flag_reason && (
                         <Tippy content={`AI flag: ${inv.flag_reason}`}>
@@ -375,7 +375,7 @@ export default function Inbox() {
                     <tr className="bg-gray-100">
                       <td></td>
                       <td colSpan="10" className="px-4 py-2 text-xs text-left">
-                        PO#: {inv.po_number || inv.po_id || 'N/A'} | Tags: {inv.tags?.join(', ') || 'None'} | Uploaded:{' '}
+                        PO#: {inv.po_number || inv.po_id || 'N/A'} | Tags: {Array.isArray(inv.tags) ? inv.tags.join(', ') : inv.tags || 'None'} | Uploaded:{' '}
                         {inv.created_at ? new Date(inv.created_at).toLocaleString() : 'Unknown'}
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary
- prevent crash when invoice tags aren't an array
- reset `ErrorBoundary` on navigation
- allow unflagging and approving from Fraud page

## Testing
- `npm test --silent` in `frontend` *(no tests found)*
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_687f12af0914832ea34a275f8d60ceb6