### PR TITLE
Implement rate limiting for uploads and AI routes

### DIFF
--- a/backend/middleware/rateLimit.js
+++ b/backend/middleware/rateLimit.js
@@ -1,0 +1,19 @@
+const rateLimit = require('express-rate-limit');
+
+const uploadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 30,
+  message: 'Too many uploads from this IP, please try again later.',
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+const aiLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 20,
+  message: 'Too many AI requests, please slow down.',
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+module.exports = { uploadLimiter, aiLimiter };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -25,6 +25,7 @@
         "dotenv": "^16.3.1",
         "exceljs": "4.4.0",
         "express": "^4.18.2",
+        "express-rate-limit": "^6.7.0",
         "fast-levenshtein": "^2.0.6",
         "googleapis": "^125.0.0",
         "ioredis": "^5.6.1",
@@ -3364,6 +3365,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-6.11.2.tgz",
+      "integrity": "sha512-a7uwwfNTh1U60ssiIkuLFWHt4hAC5yxlLGU2VP0X4YNlyEDZAqF4tK3GD3NSitVBrCQmQ0++0uOyFOgC2y4DDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      },
+      "peerDependencies": {
+        "express": "^4 || ^5"
       }
     },
     "node_modules/extend": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^16.3.1",
     "exceljs": "4.4.0",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
     "fast-levenshtein": "^2.0.6",
     "googleapis": "^125.0.0",
     "ioredis": "^5.6.1",

--- a/backend/routes/aiRoutes.js
+++ b/backend/routes/aiRoutes.js
@@ -2,6 +2,9 @@ const express = require('express');
 const router = express.Router();
 const { categorizeDocument } = require('../controllers/aiController');
 const { authMiddleware } = require('../controllers/userController');
+const { aiLimiter } = require('../middleware/rateLimit');
+
+router.use(aiLimiter);
 
 router.post('/categorize', authMiddleware, categorizeDocument);
 

--- a/backend/routes/brandingRoutes.js
+++ b/backend/routes/brandingRoutes.js
@@ -9,9 +9,10 @@ const {
   getAccentColor,
 } = require('../controllers/brandingController');
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
+const { uploadLimiter } = require('../middleware/rateLimit');
 
 router.get('/', getLogo);
-router.post('/', authMiddleware, authorizeRoles('admin'), upload.single('logo'), uploadLogo);
+router.post('/', uploadLimiter, authMiddleware, authorizeRoles('admin'), upload.single('logo'), uploadLogo);
 router.get('/color', getAccentColor);
 router.post('/color', authMiddleware, authorizeRoles('admin'), setAccentColor);
 

--- a/backend/routes/documentRoutes.js
+++ b/backend/routes/documentRoutes.js
@@ -29,14 +29,15 @@ const upload = multer({
   }
 });
 const fileSizeLimit = require('../middleware/fileSizeLimit');
+const { uploadLimiter } = require('../middleware/rateLimit');
 
-router.post('/upload', authMiddleware, upload.single('file'), fileSizeLimit, uploadDocument);
+router.post('/upload', uploadLimiter, authMiddleware, upload.single('file'), fileSizeLimit, uploadDocument);
 router.post('/:id/extract', authMiddleware, extractDocument);
 router.post('/:id/corrections', authMiddleware, saveCorrections);
 router.get('/:id/summary', authMiddleware, summarizeDocument);
 router.get('/:id/versions', authMiddleware, getDocumentVersions);
 router.post('/:id/versions/:versionId/restore', authMiddleware, restoreDocumentVersion);
-router.post('/:id/version', authMiddleware, upload.single('file'), uploadDocumentVersion);
+router.post('/:id/version', uploadLimiter, authMiddleware, upload.single('file'), uploadDocumentVersion);
 router.put('/:id/lifecycle', authMiddleware, updateLifecycle);
 router.post('/:id/compliance', authMiddleware, checkCompliance);
 router.get('/totals-by-entity', authMiddleware, getEntityTotals);

--- a/backend/routes/invoiceRoutes.js
+++ b/backend/routes/invoiceRoutes.js
@@ -17,6 +17,7 @@ const upload = multer({
     cb(null, true);
   }
 });
+const { uploadLimiter, aiLimiter } = require('../middleware/rateLimit');
 const { exportFilteredInvoices, exportAllInvoices, importInvoicesCSV } = require('../controllers/invoiceController');
 
 const { login, refreshToken, logout, authMiddleware, authorizeRoles } = require('../controllers/userController');
@@ -126,11 +127,11 @@ const { scenarioCashFlow } = require('../controllers/scenarioController');
 router.get('/export-archived', authMiddleware, exportArchivedInvoicesCSV);
 router.patch('/:id/payment-status', authMiddleware, authorizeRoles('accountant','admin'), setPaymentStatus);
 router.post('/:id/mark-paid', authMiddleware, authorizeRoles('accountant','admin'), markInvoicePaid);
-router.post('/suggest-vendor', suggestVendor);
-router.post('/suggest-voucher', suggestVoucher);
+router.post('/suggest-vendor', aiLimiter, suggestVendor);
+router.post('/suggest-voucher', aiLimiter, suggestVoucher);
 router.post('/send-email', sendSummaryEmail);
 router.post('/draft-smart-email', authMiddleware, smartDraftEmail);
-router.post('/upload', authMiddleware, authorizeRoles('admin'), (req, res) => {
+router.post('/upload', uploadLimiter, authMiddleware, authorizeRoles('admin'), (req, res) => {
   const busboy = new Busboy({ headers: req.headers });
   const fileData = [];
 
@@ -153,36 +154,36 @@ router.post('/upload', authMiddleware, authorizeRoles('admin'), (req, res) => {
   req.pipe(busboy);
 });
 // allow unauthenticated access for free trial sample parsing
-router.post('/parse-sample', upload.single('invoiceFile'), parseInvoiceSample);
-router.post('/import-csv', authMiddleware, authorizeRoles('admin'), upload.single('file'), importInvoicesCSV);
-router.post('/voice-upload', authMiddleware, authorizeRoles('admin'), voiceUpload);
-router.post('/nl-upload', authMiddleware, authorizeRoles('admin'), conversationalUpload);
+router.post('/parse-sample', uploadLimiter, upload.single('invoiceFile'), parseInvoiceSample);
+router.post('/import-csv', uploadLimiter, authMiddleware, authorizeRoles('admin'), upload.single('file'), importInvoicesCSV);
+router.post('/voice-upload', uploadLimiter, authMiddleware, authorizeRoles('admin'), voiceUpload);
+router.post('/nl-upload', uploadLimiter, authMiddleware, authorizeRoles('admin'), conversationalUpload);
 router.get('/', getAllInvoices);
 router.delete('/clear', authMiddleware, authorizeRoles('admin'), clearAllInvoices);
 router.delete('/:id', authMiddleware, authorizeRoles('admin'), deleteInvoiceById);
 router.get('/search', searchInvoicesByVendor);
-router.post('/nl-query', authMiddleware, naturalLanguageQuery);
-router.post('/nl-search', authMiddleware, naturalLanguageSearch);
-router.post('/smart-search', authMiddleware, smartSearchParse);
-router.post('/nl-chart', authMiddleware, nlChartQuery);
-router.post('/quality-score', authMiddleware, invoiceQualityScore);
-router.post('/payment-risk', authMiddleware, paymentRiskScore);
-router.post('/payment-likelihood', authMiddleware, paymentLikelihood);
-router.post('/payment-behavior', authMiddleware, paymentBehaviorByVendor);
-router.post('/assistant', authMiddleware, assistantQuery);
-router.post('/billing-query', authMiddleware, billingQuery);
-router.post('/:id/think-suggestion', authMiddleware, thinkSuggestion);
-router.post('/:id/overdue-email', authMiddleware, overdueEmailTemplate);
-router.post('/:id/copilot', authMiddleware, invoiceCopilot);
-router.get('/help/onboarding', authMiddleware, onboardingHelp);
-router.post('/summarize-errors', summarizeUploadErrors);
-router.post('/suggest-fixes', authMiddleware, suggestFixes);
+router.post('/nl-query', aiLimiter, authMiddleware, naturalLanguageQuery);
+router.post('/nl-search', aiLimiter, authMiddleware, naturalLanguageSearch);
+router.post('/smart-search', aiLimiter, authMiddleware, smartSearchParse);
+router.post('/nl-chart', aiLimiter, authMiddleware, nlChartQuery);
+router.post('/quality-score', aiLimiter, authMiddleware, invoiceQualityScore);
+router.post('/payment-risk', aiLimiter, authMiddleware, paymentRiskScore);
+router.post('/payment-likelihood', aiLimiter, authMiddleware, paymentLikelihood);
+router.post('/payment-behavior', aiLimiter, authMiddleware, paymentBehaviorByVendor);
+router.post('/assistant', aiLimiter, authMiddleware, assistantQuery);
+router.post('/billing-query', aiLimiter, authMiddleware, billingQuery);
+router.post('/:id/think-suggestion', aiLimiter, authMiddleware, thinkSuggestion);
+router.post('/:id/overdue-email', aiLimiter, authMiddleware, overdueEmailTemplate);
+router.post('/:id/copilot', aiLimiter, authMiddleware, invoiceCopilot);
+router.get('/help/onboarding', aiLimiter, authMiddleware, onboardingHelp);
+router.post('/summarize-errors', aiLimiter, summarizeUploadErrors);
+router.post('/suggest-fixes', aiLimiter, authMiddleware, suggestFixes);
 router.post('/login', login);
 router.post('/refresh', refreshToken);
 router.post('/logout', logout);
 router.post('/export-filtered', authMiddleware, exportFilteredInvoicesCSV);
 router.get('/export-all', authMiddleware, exportAllInvoices);
-router.post('/summarize-vendor-data', summarizeVendorData);
+router.post('/summarize-vendor-data', aiLimiter, summarizeVendorData);
 router.get('/monthly-insights', authMiddleware, getMonthlyInsights);
 router.get('/cash-flow', authMiddleware, getCashFlow);
 router.post('/cash-flow/scenario', authMiddleware, scenarioCashFlow);

--- a/backend/routes/poRoutes.js
+++ b/backend/routes/poRoutes.js
@@ -3,9 +3,10 @@ const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
 const router = express.Router();
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
+const { uploadLimiter } = require('../middleware/rateLimit');
 const { uploadPOs, getPOs } = require('../controllers/purchaseOrderController');
 
-router.post('/upload', authMiddleware, authorizeRoles('admin'), upload.single('poFile'), uploadPOs);
+router.post('/upload', uploadLimiter, authMiddleware, authorizeRoles('admin'), upload.single('poFile'), uploadPOs);
 router.get('/', authMiddleware, authorizeRoles('admin','approver','accountant'), getPOs);
 
 module.exports = router;

--- a/backend/routes/vendorPortalRoutes.js
+++ b/backend/routes/vendorPortalRoutes.js
@@ -1,11 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const portal = require('../controllers/vendorPortalController');
+const { uploadLimiter } = require('../middleware/rateLimit');
 
 router.post('/login', portal.login);
 router.use(portal.auth);
 router.get('/invoices', portal.listInvoices);
-router.post('/upload', portal.uploadInvoice);
+router.post('/upload', uploadLimiter, portal.uploadInvoice);
 router.get('/bank', portal.getBankInfo);
 router.patch('/bank', portal.updateBankInfo);
 router.get('/payments', portal.paymentStatus);

--- a/backend/routes/vendorRoutes.js
+++ b/backend/routes/vendorRoutes.js
@@ -22,19 +22,20 @@ const {
 const multer = require('multer');
 const upload = multer({ dest: 'uploads/' });
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
+const { uploadLimiter, aiLimiter } = require('../middleware/rateLimit');
 
 router.get('/', authMiddleware, listVendors);
 router.get('/export', authMiddleware, authorizeRoles('admin'), exportVendorsCSV);
-router.post('/import', authMiddleware, authorizeRoles('admin'), upload.single('file'), importVendorsCSV);
+router.post('/import', uploadLimiter, authMiddleware, authorizeRoles('admin'), upload.single('file'), importVendorsCSV);
 router.get('/match', authMiddleware, matchVendors);
-router.post('/ai-match', authMiddleware, aiVendorMatch);
+router.post('/ai-match', aiLimiter, authMiddleware, aiVendorMatch);
 router.post('/suggestions/:id/feedback', authMiddleware, vendorMatchFeedback);
 router.get('/behavior-flags', authMiddleware, authorizeRoles('admin'), getBehaviorFlags);
 router.get('/duplicates', authMiddleware, authorizeRoles('admin'), getDuplicateVendors);
 router.get('/:vendor/anomalies', authMiddleware, getVendorAnomalies);
 router.patch('/:vendor/notes', authMiddleware, authorizeRoles('admin'), updateVendorNotes);
 router.get('/:vendor/info', authMiddleware, getVendorInfo);
-router.get('/:vendor/predict', authMiddleware, predictVendorBehavior);
+router.get('/:vendor/predict', aiLimiter, authMiddleware, predictVendorBehavior);
 router.get('/:vendor/profile', authMiddleware, getVendorAnalytics);
 router.patch('/:vendor/country', authMiddleware, authorizeRoles('admin'), updateVendorCountry);
 router.patch('/:vendor/profile', authMiddleware, authorizeRoles('admin'), updateVendorProfile);


### PR DESCRIPTION
## Summary
- add express-rate-limit dependency
- create rate limiting middleware
- apply upload and AI chat limits to relevant routes

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687f311e1a88832ebe5d7c166e597b62