### PR TITLE
Enable full-text search for documents

### DIFF
--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -100,6 +100,20 @@
         "responses": { "200": { "description": "Entity totals" } }
       }
     },
+    "/api/documents/search": {
+      "get": {
+        "summary": "Search documents",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": { "200": { "description": "Search results" } }
+      }
+    },
     "/api/validation/validate-row": {
       "post": {
         "summary": "Validate an invoice row",

--- a/backend/routes/documentRoutes.js
+++ b/backend/routes/documentRoutes.js
@@ -12,6 +12,7 @@ const {
   updateLifecycle,
   checkCompliance,
   getEntityTotals,
+  searchDocuments,
 } = require('../controllers/documentController');
 const { authMiddleware } = require('../controllers/userController');
 
@@ -41,5 +42,6 @@ router.post('/:id/version', uploadLimiter, authMiddleware, upload.single('file')
 router.put('/:id/lifecycle', authMiddleware, updateLifecycle);
 router.post('/:id/compliance', authMiddleware, checkCompliance);
 router.get('/totals-by-entity', authMiddleware, getEntityTotals);
+router.get('/search', authMiddleware, searchDocuments);
 
 module.exports = router;

--- a/backend/services/documentService.js
+++ b/backend/services/documentService.js
@@ -22,6 +22,7 @@ async function parseAndExtract(doc) {
     category: result.fields.category,
   };
   await pool.query('UPDATE documents SET fields = $1 WHERE id = $2', [norm, doc.id]);
+  await pool.query("UPDATE documents SET searchable = to_tsvector('english', fields::text) WHERE id = $1", [doc.id]);
 
   const embeddingRes = await openrouter.embeddings.create({
     model: 'openai/text-embedding-ada-002',

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -124,6 +124,10 @@ async function initDb() {
     await pool.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS content_hash TEXT");
     await pool.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS doc_title TEXT");
 
+    await pool.query("ALTER TABLE documents ADD COLUMN IF NOT EXISTS searchable tsvector");
+    await pool.query("CREATE INDEX IF NOT EXISTS idx_searchable ON documents USING GIN(searchable)");
+    await pool.query("UPDATE documents SET searchable = to_tsvector('english', fields::text) WHERE searchable IS NULL");
+
     await pool.query(`CREATE TABLE IF NOT EXISTS document_versions (
       id SERIAL PRIMARY KEY,
       document_id INTEGER REFERENCES documents(id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary
- add `searchable` tsvector column and index in DB init
- update document operations to refresh the search vector
- expose `/api/documents/search` endpoint
- document the new endpoint in Swagger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fd147ae08832e95c570d55cd40dd1