### PR TITLE
Disable email import & SMS logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,6 @@ EMAIL_USER=
 # If using Gmail with 2FA, set EMAIL_PASS to an App Password
 EMAIL_PASS=
 EMAIL_TO=
-# Gmail API service account key for email ingestion
-GOOGLE_SERVICE_ACCOUNT_KEY=
-# Inbox to poll for forwarded invoices
-EMAIL_INBOX=upload@yourdomain.com
 # Stripe secret key for billing
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
@@ -29,10 +25,6 @@ SENTRY_DSN=
 # Webhook URLs for notifications
 SLACK_WEBHOOK_URL=
 TEAMS_WEBHOOK_URL=
-# Twilio SMS settings
-TWILIO_ACCOUNT_SID=
-TWILIO_AUTH_TOKEN=
-TWILIO_FROM_NUMBER=
 # External risk scoring service
 RISK_SCORE_URL=
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,6 @@ npm install --legacy-peer-deps
 - Multi-currency support with automatic VAT/GST calculations
 - Automation marketplace integrations (Zapier/Make) for Slack and Google Sheets, plus connectors for your accounting platform, via `/api/integrations`
 - RPA automation engine triggers post-approval exports to your ERP system
-- Scheduled email fetch imports PDF documents automatically
-- Forward documents to `upload@yourdomain.com` and attachments are parsed via Gmail API
 - Low-code automation builder (`/api/automations`) for if‑then API workflows
 - Blockchain-backed invoice validation with PDF hashing for tamper-proof records
 ### Recent Backend Updates
@@ -176,10 +174,6 @@ cp .env.example .env   # Add your DATABASE_URL and OpenRouter API key
 # Set either OPENROUTER_API_KEY or OPENAI_API_KEY in .env
 # Optional: adjust DUE_REMINDER_DAYS and APPROVAL_REMINDER_DAYS in .env to tweak reminder timing
 # Set DATA_ENCRYPTION_KEY to enable at-rest encryption of sensitive fields
-# Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN and TWILIO_FROM_NUMBER if you want SMS alerts
-# Set GOOGLE_SERVICE_ACCOUNT_KEY and EMAIL_INBOX to enable email-to-upload support
-# GOOGLE_SERVICE_ACCOUNT_KEY should point to a service account JSON file and
-# EMAIL_INBOX should be the Gmail address to monitor for incoming documents
 npm start
 ```
 
@@ -189,6 +183,11 @@ Set an `X-Tenant-Id` header on every API request. Invoices are filtered by this
 tenant ID and new uploads will be associated with it. The default tenant is
 `"default"` if no header is provided.
 Admin users can aggregate data across all tenants by sending `X-Tenant-Id: all`.
+
+### Future Roadmap
+
+- Email-to-upload via Gmail API (requires OAuth and service accounts)
+- SMS alerts powered by Twilio
 
 ### Database Update
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -51,7 +51,6 @@ const { initDb } = require('./utils/dbInit');
 const { initChat } = require('./utils/chatServer');
 const { loadCorrections } = require('./utils/parserTrainer');
 const { loadModel, trainFromCorrections } = require('./utils/ocrAgent');
-const { startEmailSync } = require('./utils/emailSync');
 const { loadSchedules } = require('./utils/automationScheduler');
 const { scheduleReports } = require('./utils/reportScheduler');
 const { scheduleAnomalyScan } = require('./utils/anomalyScanner');
@@ -126,7 +125,7 @@ app.use(Sentry.Handlers.errorHandler());
   setInterval(trainFromCorrections, 6 * 60 * 60 * 1000); // retrain regularly
 
   await loadSchedules();
-  startEmailSync();
+  // startEmailSync();
   scheduleReports();
   scheduleAnomalyScan();
 

--- a/backend/utils/emailSync.js
+++ b/backend/utils/emailSync.js
@@ -5,6 +5,8 @@ const { google } = require('googleapis');
 const { sendMail } = require('./email');
 const { uploadInvoice } = require('../controllers/invoiceController');
 
+// Gmail ingestion temporarily disabled
+
 const inbox = process.env.EMAIL_INBOX || 'invoices@company.com';
 
 async function processMessage(gmail, message) {
@@ -94,7 +96,7 @@ async function fetchEmailAttachments() {
 
 function startEmailSync() {
   const { schedule } = require('./cronManager');
-  schedule('emailSync', '*/5 * * * *', fetchEmailAttachments);
+  // schedule('emailSync', '*/5 * * * *', fetchEmailAttachments);
 }
 
 module.exports = { startEmailSync };

--- a/backend/utils/mlDetector.js
+++ b/backend/utils/mlDetector.js
@@ -1,27 +1,8 @@
-const IsolationForest = require('ml-isolation-forest').default;
+// ML-based detection disabled for now
 
-function prepareData(rows) {
-  const vendorMap = {};
-  let idx = 0;
-  const data = rows.map(r => {
-    const v = r.vendor ? r.vendor.toLowerCase() : '';
-    if (!(v in vendorMap)) vendorMap[v] = idx++;
-    const hour = new Date(r.created_at).getHours();
-    return [parseFloat(r.amount || 0), hour, vendorMap[v]];
-  });
-  return data;
-}
-
-function detectAnomalies(rows, threshold = 0.65) {
-  if (!rows.length) return [];
-  const data = prepareData(rows);
-  const forest = new IsolationForest();
-  forest.fit(data);
-  const scores = forest.scores();
-  return rows
-    .map((r, i) => ({ id: r.id, score: scores[i] }))
-    .filter(r => r.score >= threshold)
-    .sort((a, b) => b.score - a.score);
+function detectAnomalies(rows) {
+  // ML scoring disabled; return neutral scores
+  return rows.map((r) => ({ id: r.id, score: 0.5 }));
 }
 
 module.exports = { detectAnomalies };

--- a/backend/utils/notify.js
+++ b/backend/utils/notify.js
@@ -30,13 +30,5 @@ exports.sendEmailNotification = async (to, subject, message) => {
 };
 
 exports.sendSmsNotification = async (to, message) => {
-  const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_FROM_NUMBER } = process.env;
-  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_FROM_NUMBER || !to) return;
-  const url = `https://api.twilio.com/2010-04-01/Accounts/${TWILIO_ACCOUNT_SID}/Messages.json`;
-  const payload = new URLSearchParams({ From: TWILIO_FROM_NUMBER, To: to, Body: message });
-  try {
-    await axios.post(url, payload, { auth: { username: TWILIO_ACCOUNT_SID, password: TWILIO_AUTH_TOKEN } });
-  } catch (err) {
-    console.error('SMS notification error:', err.message);
-  }
+  console.log('SMS alert stub:', { to, message });
 };


### PR DESCRIPTION
## Summary
- clean up by removing Gmail and Twilio env vars
- disable Gmail watcher and SMS notifications
- stub anomaly scoring logic
- document simplified setup and future roadmap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fdb726cd0832eafd50d9cfe066dcd