### PR TITLE
Add reporting PDF and doc activity websocket

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -58,6 +58,7 @@ const { WebSocketServer } = require('ws');
 const { setupWSConnection } = require('@y/websocket-server/utils');
 const tenantContext = require('./middleware/tenantMiddleware');
 const { parse } = require('url');
+const { initDocActivity } = require('./utils/docActivityServer');
 
 const app = express();                      // create the app
 const server = http.createServer(app);
@@ -138,6 +139,7 @@ app.use(Sentry.Handlers.errorHandler());
   logger.info('🟢 Routes mounted');
 
   initChat(server);
+  initDocActivity(server);
 
   const wss = new WebSocketServer({ noServer: true });
   server.on('upgrade', (request, socket, head) => {

--- a/backend/routes/documentRoutes.js
+++ b/backend/routes/documentRoutes.js
@@ -13,6 +13,7 @@ const {
   checkCompliance,
   getEntityTotals,
   searchDocuments,
+  exportSummaryPDF,
 } = require('../controllers/documentController');
 const { authMiddleware } = require('../controllers/userController');
 
@@ -43,5 +44,6 @@ router.put('/:id/lifecycle', authMiddleware, updateLifecycle);
 router.post('/:id/compliance', authMiddleware, checkCompliance);
 router.get('/totals-by-entity', authMiddleware, getEntityTotals);
 router.get('/search', authMiddleware, searchDocuments);
+router.get('/report/pdf', authMiddleware, exportSummaryPDF);
 
 module.exports = router;

--- a/backend/utils/activityLogger.js
+++ b/backend/utils/activityLogger.js
@@ -1,5 +1,6 @@
 const pool = require('../config/db');
 const { broadcastActivity } = require('./chatServer');
+const { broadcastDocActivity } = require('./docActivityServer');
 const { logAudit } = require('./auditLogger');
 
 async function logActivity(userId, action, invoiceId = null, username = null) {
@@ -9,6 +10,9 @@ async function logActivity(userId, action, invoiceId = null, username = null) {
       [userId, username, action, invoiceId]
     );
     broadcastActivity?.(rows[0]);
+    if (['upload_invoice', 'approve_invoice', 'flag_invoice'].includes(action)) {
+      broadcastDocActivity?.({ action, invoiceId });
+    }
     await logActivityDetailed('default', userId, username, action, { invoiceId });
     if (['upload_invoice', 'approve_invoice', 'flag_invoice', 'unflag_invoice'].includes(action)) {
       await logAudit(action, invoiceId, userId, username);

--- a/backend/utils/docActivityServer.js
+++ b/backend/utils/docActivityServer.js
@@ -1,0 +1,25 @@
+const { WebSocketServer } = require('ws');
+const { parse } = require('url');
+let wss;
+
+function initDocActivity(server) {
+  wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (request, socket, head) => {
+    const { pathname } = parse(request.url);
+    if (pathname === '/ws/doc-activity') {
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        wss.emit('connection', ws, request);
+      });
+    }
+  });
+}
+
+function broadcastDocActivity(data) {
+  if (!wss) return;
+  const msg = JSON.stringify(data);
+  for (const client of wss.clients) {
+    if (client.readyState === client.OPEN) client.send(msg);
+  }
+}
+
+module.exports = { initDocActivity, broadcastDocActivity };


### PR DESCRIPTION
## Summary
- generate summary PDF for document analytics
- expose `/report/pdf` under document routes
- broadcast upload/approval/flag events over `/ws/doc-activity`
- wire websocket server into app startup

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_688009f9f15c832eaa6ebbcca02fd353