### PR TITLE
Fix document API paths

### DIFF
--- a/frontend/src/AdaptiveDashboard.js
+++ b/frontend/src/AdaptiveDashboard.js
@@ -65,7 +65,7 @@ export default function AdaptiveDashboard() {
       fetch(`${API_BASE}/api/analytics/metadata?startDate=${prevStart}&endDate=${prevEnd}`, { headers }).then(r => r.json()),
       fetch(`${API_BASE}/api/invoices/top-vendors`, { headers }).then(r => r.json()),
       fetch(`${API_BASE}/api/invoices/cash-flow?interval=monthly`, { headers }).then(r => r.json()),
-      fetch(`${API_BASE}/api/invoices/logs?limit=20`, { headers }).then(r => r.json()),
+      fetch(`${API_BASE}/api/logs?limit=20`, { headers }).then(r => r.json()),
       fetch(`${API_BASE}/api/invoices/fraud/flagged`, { headers }).then(r => r.json()),
       fetch(`${API_BASE}/api/vendors`, { headers }).then(r => r.json()),
       fetch(`${API_BASE}/api/analytics/approvals/times?startDate=${prevStart}&endDate=${prevEnd}`, { headers }).then(r => r.json()),

--- a/frontend/src/AuditDashboard.js
+++ b/frontend/src/AuditDashboard.js
@@ -46,7 +46,7 @@ export default function AuditDashboard() {
     if (action) params.append('action', action);
     if (start) params.append('start', start);
     if (end) params.append('end', end);
-    const res = await fetch(`${API_BASE}/api/invoices/logs/export-csv?${params.toString()}`, {
+    const res = await fetch(`${API_BASE}/api/logs/export-csv?${params.toString()}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!res.ok) return;
@@ -67,7 +67,7 @@ export default function AuditDashboard() {
     if (action) params.append('action', action);
     if (start) params.append('start', start);
     if (end) params.append('end', end);
-    const res = await fetch(`${API_BASE}/api/invoices/logs?${params.toString()}`, {
+    const res = await fetch(`${API_BASE}/api/logs?${params.toString()}`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     const data = await res.json();

--- a/frontend/src/Documents.js
+++ b/frontend/src/Documents.js
@@ -571,14 +571,14 @@ const [selectedAssignee, setSelectedAssignee] = useState('');
         if (url.startsWith(API_BASE)) {
           let path = url.slice(API_BASE.length);
           if (path.startsWith('/api/invoices')) {
-            path = path.replace('/api/invoices', `/api/${tenant}/documents`);
+            path = path.replace('/api/invoices', '/api/documents');
           } else if (path.startsWith('/api/export-templates')) {
             path = path.replace('/api/export-templates', `/api/${tenant}/export-templates`);
           }
           url = API_BASE + path;
         } else if (url.startsWith('/')) {
           if (url.startsWith('/api/invoices')) {
-            url = url.replace('/api/invoices', `/api/${tenant}/documents`);
+            url = url.replace('/api/invoices', '/api/documents');
           } else if (url.startsWith('/api/export-templates')) {
             url = url.replace('/api/export-templates', `/api/${tenant}/export-templates`);
           }

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -30,7 +30,7 @@ function TeamManagement() {
   }, [headers]);
 
   const fetchLogs = useCallback(async () => {
-    const res = await fetch(`${API_BASE}/api/invoices/logs`, { headers });
+    const res = await fetch(`${API_BASE}/api/logs`, { headers });
     const data = await res.json();
     if (res.ok) setLogs(data);
   }, [headers]);

--- a/frontend/src/components/LiveFeed.js
+++ b/frontend/src/components/LiveFeed.js
@@ -11,7 +11,7 @@ export default function LiveFeed({ token, tenant }) {
 
     const fetchLogs = async () => {
       try {
-        const res = await fetch(`${API_BASE}/api/invoices/logs`, {
+        const res = await fetch(`${API_BASE}/api/logs`, {
           headers: { Authorization: `Bearer ${token}`, 'X-Tenant-Id': tenant }
         });
         if (!res.ok) {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -43,14 +43,14 @@ window.fetch = async (url, options) => {
     if (url.startsWith(API_BASE)) {
       let path = url.slice(API_BASE.length);
       if (path.startsWith('/api/invoices')) {
-        path = path.replace('/api/invoices', `/api/${tenant}/documents`);
+        path = path.replace('/api/invoices', '/api/documents');
       } else if (path.startsWith('/api/export-templates')) {
         path = path.replace('/api/export-templates', `/api/${tenant}/export-templates`);
       }
       url = API_BASE + path;
     } else if (url.startsWith('/')) {
       if (url.startsWith('/api/invoices')) {
-        url = url.replace('/api/invoices', `/api/${tenant}/documents`);
+        url = url.replace('/api/invoices', '/api/documents');
       } else if (url.startsWith('/api/export-templates')) {
         url = url.replace('/api/export-templates', `/api/${tenant}/export-templates`);
       }


### PR DESCRIPTION
## Summary
- correct API rewrite logic for invoices -> documents
- use `/api/logs` for dashboards and team pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68812fe555fc832e9642f879eb153f1c