### PR TITLE
Add document listing route and fix health check

### DIFF
--- a/backend/controllers/documentController.js
+++ b/backend/controllers/documentController.js
@@ -16,6 +16,34 @@ async function refreshSearchable(id) {
   );
 }
 
+exports.listDocuments = async (req, res) => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT id, doc_title, doc_type, file_name, fields, status
+       FROM documents WHERE tenant_id = $1 ORDER BY id DESC LIMIT 100`,
+      [req.tenantId]
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error('List documents error:', err);
+    res.status(500).json({ message: 'Failed to fetch documents' });
+  }
+};
+
+exports.getDocument = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const { rows } = await pool.query(
+      'SELECT * FROM documents WHERE id = $1 AND tenant_id = $2',
+      [id, req.tenantId]
+    );
+    if (!rows.length) return res.status(404).json({ message: 'Not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error('Get document error:', err);
+    res.status(500).json({ message: 'Failed to fetch document' });
+  }
+};
 exports.uploadDocument = async (req, res) => {
   try {
     if (!req.file) return res.status(400).json({ message: 'No file uploaded' });

--- a/backend/routes/documentRoutes.js
+++ b/backend/routes/documentRoutes.js
@@ -6,6 +6,8 @@ const {
   extractDocument,
   saveCorrections,
   summarizeDocument,
+  listDocuments,
+  getDocument,
   getDocumentVersions,
   restoreDocumentVersion,
   uploadDocumentVersion,
@@ -34,6 +36,7 @@ const fileSizeLimit = require('../middleware/fileSizeLimit');
 const { uploadLimiter } = require('../middleware/rateLimit');
 
 router.post('/upload', uploadLimiter, authMiddleware, upload.single('file'), fileSizeLimit, uploadDocument);
+router.get('/', authMiddleware, listDocuments);
 router.post('/:id/extract', authMiddleware, extractDocument);
 router.post('/:id/corrections', authMiddleware, saveCorrections);
 router.get('/:id/summary', authMiddleware, summarizeDocument);
@@ -45,5 +48,6 @@ router.post('/:id/compliance', authMiddleware, checkCompliance);
 router.get('/totals-by-entity', authMiddleware, getEntityTotals);
 router.get('/search', authMiddleware, searchDocuments);
 router.get('/report/pdf', authMiddleware, exportSummaryPDF);
+router.get('/:id', authMiddleware, getDocument);
 
 module.exports = router;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -82,7 +82,9 @@ const savedFont = localStorage.getItem(`fontFamily_${currentTenant}`);
 if (savedFont) document.documentElement.style.setProperty('--font-base', savedFont);
 
 if (API_BASE) {
-  fetch(`${API_BASE}/api/documents`).catch((err) => {
+  // Hit the health endpoint instead of /api/documents since the
+  // documents listing route may not exist in some deployments.
+  fetch(`${API_BASE}/health`).catch((err) => {
     console.error('API connection failed', err);
   });
 }


### PR DESCRIPTION
## Summary
- query documents in document controller
- expose new document list and item routes
- check API health via `/health` on page load

## Testing
- `npm test` in `backend`
- `CI=true npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68813fe72518832ebb553ea6ebcf0625