### PR TITLE
Standardize dashboard headers

### DIFF
--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import SidebarNav from './SidebarNav';
-import TopNavbar from './TopNavbar';
+import Navbar from './Navbar';
 import BottomNav from './BottomNav';
 
 export default function MainLayout({ title, helpTopic, children, collapseSidebar = false }) {
@@ -8,12 +8,21 @@ export default function MainLayout({ title, helpTopic, children, collapseSidebar
     const saved = localStorage.getItem('notifications');
     return saved ? JSON.parse(saved) : [];
   });
+  const [tenant, setTenant] = React.useState(() => localStorage.getItem('tenant') || 'default');
+  const token = localStorage.getItem('token') || '';
+  const role = localStorage.getItem('role') || '';
   const sidebarOffset = collapseSidebar ? 'ml-16' : 'ml-64';
   return (
     <div className="flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-900">
       <SidebarNav notifications={notifications} collapsed={collapseSidebar} />
       <div className={`flex-1 flex flex-col overflow-y-auto pb-16 sm:pb-0 ${sidebarOffset}`}>
-        <TopNavbar title={title} helpTopic={helpTopic} />
+        <Navbar
+          tenant={tenant}
+          onTenantChange={setTenant}
+          notifications={notifications}
+          role={role}
+          token={token}
+        />
         <div className="container mx-auto px-6 py-8 flex-grow">
           {children}
         </div>


### PR DESCRIPTION
## Summary
- switch `MainLayout` to use `Navbar` instead of `TopNavbar`
- pull tenant/role/token from local storage and pass them to `Navbar`

## Testing
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68827e1b9d44832e90d9543efbcf50cb