### PR TITLE
Add unified page headers

### DIFF
--- a/frontend/src/Board.js
+++ b/frontend/src/Board.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
 import MainLayout from './components/MainLayout';
+import PageHeader from './components/PageHeader';
 import { API_BASE } from './api';
 
 export default function Board() {
@@ -71,7 +72,7 @@ export default function Board() {
 
   return (
     <MainLayout title="Approval Board">
-      <h1 className="text-xl font-semibold mb-4">Approval Board</h1>
+      <PageHeader title="ClarifyOps / AI Dashboard" subtitle="Approval Board" />
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="flex space-x-4 overflow-x-auto">
             {renderColumn('pending', 'Pending', columns.pending)}

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -13,6 +13,7 @@ import {
 } from 'recharts';
 import MainLayout from './components/MainLayout';
 import Skeleton from './components/Skeleton';
+import PageHeader from './components/PageHeader';
 import { API_BASE } from './api';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
@@ -128,7 +129,7 @@ export default function DashboardBuilder() {
 
   return (
     <MainLayout title="Dashboard Builder">
-      <h1 className="text-xl font-semibold mb-4">Create Your Dashboard</h1>
+      <PageHeader title="ClarifyOps / AI Dashboard" subtitle="Create Your Dashboard" />
         <DragDropContext onDragEnd={handleDragEnd}>
           <Droppable droppableId="widgets">
             {(provided) => (

--- a/frontend/src/DemoSandbox.js
+++ b/frontend/src/DemoSandbox.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ProgressBar from './components/ProgressBar';
 import { API_BASE } from './api';
+import PageHeader from './components/PageHeader';
 
 export default function DemoSandbox() {
   const [csvText, setCsvText] = useState('');
@@ -56,7 +57,9 @@ export default function DemoSandbox() {
   return (
     <div className="min-h-screen p-6 flex flex-col items-center bg-gradient-to-br from-purple-50 via-indigo-100 to-indigo-200 dark:from-purple-900 dark:via-indigo-900 dark:to-gray-900 text-gray-900 dark:text-gray-100">
       <div className="max-w-2xl w-full space-y-6">
-        <h1 className="text-3xl font-bold text-center">Interactive Demo Sandbox</h1>
+        <div className="text-center">
+          <PageHeader title="ClarifyOps / AI Dashboard" subtitle="Interactive Demo Sandbox" />
+        </div>
         {step === 1 && (
           <>
             <p className="text-sm text-center">Preview of sample invoice CSV:</p>

--- a/frontend/src/Documents.js
+++ b/frontend/src/Documents.js
@@ -6,6 +6,7 @@ import { API_BASE } from './api';
 import LiveFeed from './components/LiveFeed';
 import Navbar from './components/Navbar';
 import SidebarNav from './components/SidebarNav';
+import PageHeader from './components/PageHeader';
 import {
   BarChart,
   Bar,
@@ -55,7 +56,6 @@ import {
   ClockIcon,
   CurrencyDollarIcon,
   FlagIcon,
-  DocumentArrowDownIcon,
   LightBulbIcon,
   TagIcon,
   EyeIcon,
@@ -2206,10 +2206,7 @@ useEffect(() => {
 
       <main className="flex-1 w-full bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 m-4">
         <div className="flex justify-between items-center mb-4">
-          <h1 className="text-3xl font-bold text-gray-800 dark:text-gray-100 flex items-center space-x-1">
-            <DocumentArrowDownIcon className="w-6 h-6" />
-            <span>ClarifyOps</span>
-          </h1>
+          <PageHeader title="ClarifyOps / AI Dashboard" />
           <LiveFeed token={token} tenant={tenant} />
         </div>
   

--- a/frontend/src/InstantTrial.js
+++ b/frontend/src/InstantTrial.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import ProgressBar from './components/ProgressBar';
 import { API_BASE } from './api';
 import { Link } from 'react-router-dom';
+import PageHeader from './components/PageHeader';
 
 export default function InstantTrial() {
   const [csvText, setCsvText] = useState('');
@@ -61,7 +62,9 @@ export default function InstantTrial() {
   return (
     <div className="min-h-screen p-6 flex flex-col items-center bg-gradient-to-br from-purple-50 via-indigo-100 to-indigo-200 dark:from-purple-900 dark:via-indigo-900 dark:to-gray-900 text-gray-900 dark:text-gray-100">
       <div className="max-w-2xl w-full space-y-6">
-        <h1 className="text-3xl font-bold text-center">Instant Free Trial</h1>
+        <div className="text-center">
+          <PageHeader title="ClarifyOps / AI Dashboard" subtitle="Instant Free Trial" />
+        </div>
         {step === 1 && (
           <div className="space-y-4">
             <input type="file" accept=".csv" onChange={handleFile} />

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -4,6 +4,7 @@ import { Card } from './components/ui/Card';
 import { API_BASE } from './api';
 import DarkModeToggle from './components/DarkModeToggle';
 import HighContrastToggle from './components/HighContrastToggle';
+import PageHeader from './components/PageHeader';
 
 export default function Login({ onLogin, addToast }) {
   const [username, setUsername] = useState('');
@@ -49,7 +50,7 @@ export default function Login({ onLogin, addToast }) {
       <div className="flex-1 flex items-center justify-center pt-20">
         <Card className="w-80 space-y-4">
           <form onSubmit={(e) => { e.preventDefault(); handleLogin(); }} className="space-y-4">
-          <h1 className="text-xl font-bold text-center">Login</h1>
+          <PageHeader title="ClarifyOps / AI Dashboard" subtitle="Login" />
 
           {error && (
             <div className="bg-red-100 text-red-700 p-2 mb-4 text-sm rounded" role="alert">{error}</div>

--- a/frontend/src/NotFound.js
+++ b/frontend/src/NotFound.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import PageHeader from './components/PageHeader';
 
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center text-center p-4">
-      <h1 className="text-3xl font-bold mb-4">404 - Page Not Found</h1>
+      <PageHeader title="ClarifyOps / AI Dashboard" subtitle="404 - Page Not Found" />
       <p className="mb-4">The page you are looking for does not exist.</p>
       <Link to="/operations" className="text-indigo-600 underline">
         Go to Operations Dashboard

--- a/frontend/src/components/PageHeader.js
+++ b/frontend/src/components/PageHeader.js
@@ -1,0 +1,8 @@
+export default function PageHeader({ title, subtitle }) {
+  return (
+    <div className="mb-4">
+      <h1 className="text-2xl font-semibold text-gray-800">{title}</h1>
+      {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `PageHeader` React component
- use `PageHeader` across major pages for consistent branding

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688292ca0de0832e9d91de9f7c0f7549