### PR TITLE
Improve fraud reports UX

### DIFF
--- a/frontend/src/FraudReport.js
+++ b/frontend/src/FraudReport.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
+import FraudHeader from './components/FraudHeader';
 import { API_BASE } from './api';
 
 function FraudReport() {
@@ -55,6 +56,10 @@ function FraudReport() {
   return (
     <MainLayout title="Fraud Reports" helpTopic="fraud">
       <div className="space-y-4">
+        <FraudHeader
+          title="Fraud Reports"
+          tooltip="Flagged suspicious documents will appear here."
+        />
         <div className="overflow-x-auto rounded-lg">
           <table className="min-w-full border text-sm rounded-lg overflow-hidden">
             <thead>
@@ -94,6 +99,11 @@ function FraudReport() {
             </tbody>
           </table>
         </div>
+        {!loading && invoices.length === 0 && (
+          <p className="text-center text-gray-500 mt-8">
+            No fraud reports found. Great job staying secure!
+          </p>
+        )}
       </div>
     </MainLayout>
   );

--- a/frontend/src/components/FraudHeader.js
+++ b/frontend/src/components/FraudHeader.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Tippy from '@tippyjs/react';
+import 'tippy.js/dist/tippy.css';
+
+export default function FraudHeader({ title, tooltip }) {
+  return (
+    <div className="flex items-center space-x-2 mb-2">
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      {tooltip && (
+        <Tippy content={tooltip} placement="right">
+          <span className="cursor-help text-gray-500">?</span>
+        </Tippy>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- show a tooltip-enabled header for the Fraud Reports page
- display a message when no fraud reports are present

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68829dfd9dd0832ebfa81ccf53172fad