### PR TITLE
Add consistent page container

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -78,7 +78,8 @@ export default function LandingPage() {
           </div>
         </div>
       </nav>
-      <HeroSection onRequestDemo={() => setDemoOpen(true)} />
+      <div className="max-w-6xl mx-auto px-4 py-6">
+        <HeroSection onRequestDemo={() => setDemoOpen(true)} />
       <ProblemSolutionSection />
       <section className="py-16">
         <h2 className="text-3xl font-bold text-center mb-6">Interactive Demo</h2>
@@ -424,6 +425,7 @@ export default function LandingPage() {
           © {new Date().getFullYear()} ClarifyOps
         </p>
       </footer>
+      </div>
       <ChatWidget />
       <ScheduleDemoModal open={demoOpen} onClose={() => setDemoOpen(false)} />
     </div>

--- a/frontend/src/components/MainLayout.js
+++ b/frontend/src/components/MainLayout.js
@@ -23,7 +23,7 @@ export default function MainLayout({ title, helpTopic, children, collapseSidebar
           role={role}
           token={token}
         />
-        <div className="container mx-auto px-6 py-8 flex-grow">
+        <div className="max-w-6xl mx-auto px-4 py-6 flex-grow">
           {children}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- apply uniform max width and padding in `MainLayout`
- wrap landing page content in a new container

## Testing
- `npm test --silent` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_68829f8ff6dc832ea8deb89c7434bf27