### PR TITLE
Add reusable CTA button

### DIFF
--- a/frontend/src/Documents.js
+++ b/frontend/src/Documents.js
@@ -37,6 +37,7 @@ import ActionToolbar from './components/ActionToolbar';
 import AIAssistantPanel from './components/AIAssistantPanel';
 import InvoiceSnapshotView from './components/InvoiceSnapshotView';
 import SuccessAnimation from './components/SuccessAnimation';
+import CTAButton from './components/ui/CTAButton';
 import Joyride from 'react-joyride';
 import ProgressBar from './components/ProgressBar';
 import FeatureWidget from './components/FeatureWidget';
@@ -2306,10 +2307,10 @@ useEffect(() => {
       <ProgressBar value={uploadProgress} />
     )}
 
-    <Button
+    <CTAButton
       onClick={openUploadPreview}
       disabled={!token || !files.length}
-      className="w-full flex items-center justify-center space-x-2 mt-4 sticky bottom-4 transition-all duration-200"
+      className="w-full flex items-center justify-center space-x-2 mt-4 sticky bottom-4"
     >
       {loading ? (
         <Spinner className="h-4 w-4" />
@@ -2320,7 +2321,7 @@ useEffect(() => {
       {uploadSuccess && !loading && (
         <SuccessAnimation className="h-6 w-6" />
       )}
-    </Button>
+    </CTAButton>
 
     {recentUploads.length > 0 && (
       <div className="mt-2 text-xs">

--- a/frontend/src/TeamManagement.js
+++ b/frontend/src/TeamManagement.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import Skeleton from './components/Skeleton';
 import MainLayout from './components/MainLayout';
 import { API_BASE } from './api';
+import CTAButton from './components/ui/CTAButton';
 
 function TeamManagement() {
   const token = localStorage.getItem('token') || '';
@@ -193,7 +194,7 @@ function TeamManagement() {
               <option value="forever">Forever</option>
             </select>
           </label>
-          <button onClick={saveSettings} className="bg-indigo-600 text-white px-3 py-1 rounded">Save Settings</button>
+          <CTAButton onClick={saveSettings} className="px-3 py-1">Save Settings</CTAButton>
         </div>
       </div>
     </MainLayout>

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -7,6 +7,7 @@ import DummyDataButton from './components/DummyDataButton';
 import VendorProfilePanel from './components/VendorProfilePanel';
 import InvoiceDetailModal from './components/InvoiceDetailModal';
 import VendorDetailModal from './components/VendorDetailModal';
+import CTAButton from './components/ui/CTAButton';
 import {
   PencilSquareIcon,
   DocumentChartBarIcon,
@@ -324,7 +325,7 @@ function VendorManagement() {
                         value={notesInput[v.vendor] ?? v.notes}
                         onChange={e => setNotesInput({ ...notesInput, [v.vendor]: e.target.value })}
                       />
-                      <button className="bg-indigo-600 text-white px-2 py-0.5 rounded text-sm" onClick={() => { saveNotes(v.vendor); setEditingVendor(null); }}>Save</button>
+                      <CTAButton className="text-sm px-2 py-0.5" onClick={() => { saveNotes(v.vendor); setEditingVendor(null); }}>Save</CTAButton>
                     </div>
                   ) : (
                     <div className="flex items-center justify-between">

--- a/frontend/src/components/EmptyState.js
+++ b/frontend/src/components/EmptyState.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { DocumentArrowUpIcon } from '@heroicons/react/24/outline';
+import CTAButton from './ui/CTAButton';
 
 export default function EmptyState({
   icon = <DocumentArrowUpIcon className="w-16 h-16 text-gray-400" />,
@@ -30,12 +31,9 @@ export default function EmptyState({
           {description}
         </p>
         {onCta && (
-          <button
-            onClick={onCta}
-            className="mt-2 px-3 py-1 rounded bg-indigo-600 text-white text-sm transition-all duration-300 ease-in-out hover:bg-indigo-700"
-          >
+          <CTAButton onClick={onCta} className="mt-2 text-sm px-3 py-1">
             {cta}
-          </button>
+          </CTAButton>
         )}
         {children}
       </motion.div>

--- a/frontend/src/components/InvoiceDetailModal.js
+++ b/frontend/src/components/InvoiceDetailModal.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import TagEditor from './TagEditor';
+import CTAButton from './ui/CTAButton';
 import { API_BASE } from '../api';
 
 export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate, token }) {
@@ -237,7 +238,7 @@ export default function InvoiceDetailModal({ open, invoice, onClose, onUpdate, t
         <div className="mt-4 flex justify-end space-x-2">
           {editMode ? (
             <>
-              <button onClick={handleSave} className="bg-indigo-600 text-white px-3 py-1 rounded transition-all duration-300 ease-in-out" title="Save">Save</button>
+              <CTAButton onClick={handleSave} title="Save">Save</CTAButton>
               <button onClick={() => setEditMode(false)} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 transition-all duration-300 ease-in-out" title="Cancel">Cancel</button>
             </>
           ) : (

--- a/frontend/src/components/RuleModal.js
+++ b/frontend/src/components/RuleModal.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import CTAButton from './ui/CTAButton';
 
 export default function RuleModal({ open, onClose, onSave, initial }) {
   const [type, setType] = useState('spend');
@@ -32,7 +33,7 @@ export default function RuleModal({ open, onClose, onSave, initial }) {
         )}
         <div className="flex justify-end space-x-2">
           <button className="btn" onClick={onClose}>Cancel</button>
-          <button className="btn btn-primary" onClick={handleSave}>Save</button>
+          <CTAButton onClick={handleSave}>Save</CTAButton>
         </div>
       </div>
     </div>

--- a/frontend/src/components/ui/CTAButton.js
+++ b/frontend/src/components/ui/CTAButton.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function CTAButton({ className = '', children, ...props }) {
+  return (
+    <button
+      className={`bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md shadow-sm ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add `CTAButton` component for consistent call-to-action buttons
- use `CTAButton` for Upload Document
- use `CTAButton` for Save buttons and empty states

## Testing
- `npm test --silent` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688308337d68832ea3b4a772066e2e6a