### PR TITLE
Rename Documents component and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ClarifyOps AI Document Ops Engine
+# ClarifyOps AI Claims Data Extractor
 
-This is a full-stack **AI Document Ops Engine** delivering operational clarity for any document through automated intelligence workflows, built using:
+This is a full-stack **AI Claims Data Extractor** delivering operational clarity for insurance claim files through automated intelligence workflows, built using:
 
 - **React + Tailwind CSS** (frontend)
 - **Express + PostgreSQL** (backend)
@@ -9,7 +9,7 @@ This is a full-stack **AI Document Ops Engine** delivering operational clarity f
 The backend no longer relies on Redis queues or background workers. All document
 processing happens directly through the Express API for a simpler deployment.
 
-The API has been consolidated to a single `/api/documents` namespace (with `/api/invoices` kept as an alias) and the old invoice controller has been removed. Experimental features like feedback collection and the automation builder now live under `/api/labs/*`.
+The API has been consolidated to a single `/api/claims` namespace (with `/api/invoices` kept as an alias) and the old invoice controller has been removed. Experimental features like feedback collection and the automation builder now live under `/api/labs/*`.
 
 Originally this project focused solely on invoice processing. It is now evolving into a general **Document AI Platform** that handles invoices, contracts and more. See [docs/TRANSFORMATION_PLAN.md](docs/TRANSFORMATION_PLAN.md) for the roadmap. A quick feature comparison against other tools is available in [docs/MARKET_POSITIONING.md](docs/MARKET_POSITIONING.md).
 
@@ -155,12 +155,12 @@ npm install --legacy-peer-deps
 - Blockchain-backed invoice validation with PDF hashing for tamper-proof records
 ### Recent Backend Updates
 - Unified `documents` table with flexible JSON fields (`party_name` and `fields`).
-- `/api/documents/:id/extract` for AI entity extraction.
-- `/api/documents/:id/versions` and `/api/documents/:id/versions/:versionId/restore` for document comparison.
-- `/api/documents/:id/summary` for AI summarization.
+- `/api/claims/:id/extract` for AI entity extraction.
+- `/api/claims/:id/versions` and `/api/claims/:id/versions/:versionId/restore` for document comparison.
+- `/api/claims/:id/summary` for AI summarization.
 - `/api/document-workflows` for doc-type specific workflows.
 - `/api/ai/categorize` suggests document categories.
-- `/api/documents/:id/compliance` checks contracts for missing clauses.
+- `/api/claims/:id/compliance` checks contracts for missing clauses.
 - Lifecycle rules support `retention_policy`, `expires_at` and `archived`.
 - **Enterprise Add-On**: `/api/signing/:id/start` returns a placeholder link for e-signing.
 - Enterprise features include org-wide settings, SOC2 audit logs, usage analytics and role delegation.
@@ -337,15 +337,15 @@ workflow based on the `approval_chain`.
 Define your own invoice categorization logic. Add rules via `POST /api/analytics/rules` with fields like `vendor`, `descriptionContains`, `amountGreaterThan`, and a resulting `category` or `flagReason`. All rules are returned from `GET /api/analytics/rules`.
 
 Once rules are created you can automatically tag an invoice with
-`POST /api/documents/:id/auto-categorize`. The AI model suggests categories such
+`POST /api/claims/:id/auto-categorize`. The AI model suggests categories such
 as "Marketing", "Legal", or "Recurring" when no rule matches.
 
 ### New Endpoints
 
-- `POST /api/documents/budgets` – create/update a monthly or quarterly budget by vendor or tag
-- `GET /api/documents/budgets/warnings` – check if spending has exceeded 90% of a budget
-- `GET /api/documents/budgets/forecast` – predict next month's spend by department
-- `GET /api/documents/anomalies` – list vendors with unusual spending spikes
+- `POST /api/claims/budgets` – create/update a monthly or quarterly budget by vendor or tag
+- `GET /api/claims/budgets/warnings` – check if spending has exceeded 90% of a budget
+- `GET /api/claims/budgets/forecast` – predict next month's spend by department
+- `GET /api/claims/anomalies` – list vendors with unusual spending spikes
 - `GET /api/workflows` – list saved workflows
 - `POST /api/workflows` – create or update a workflow
 - `POST /api/workflows/evaluate` – test workflow rules against a payload
@@ -359,51 +359,51 @@ The `/workflow-builder` page lets admins design approval chains and rules with a
 interactive expression builder. Test expressions are sent to `POST /api/workflows/evaluate`
 to see how rules would route a sample invoice.
 The `/inbox` page shows newly uploaded documents waiting for approval.
-- `GET /api/documents/fraud/flagged` – list flagged documents with reasons
-- `GET /api/documents/fraud/ml-detect` – list documents with high anomaly scores
-- `POST /api/documents/fraud/:id/label` – mark invoice as confirmed fraud or not
-- `GET /api/documents/:id/timeline` – view a timeline of state changes for an invoice
+- `GET /api/claims/fraud/flagged` – list flagged documents with reasons
+- `GET /api/claims/fraud/ml-detect` – list documents with high anomaly scores
+- `POST /api/claims/fraud/:id/label` – mark invoice as confirmed fraud or not
+- `GET /api/claims/:id/timeline` – view a timeline of state changes for an invoice
 - `GET /api/:tenantId/export-templates` – list saved CSV templates
 - `POST /api/:tenantId/export-templates` – create a new export template
 - `GET /api/:tenantId/export-templates/:id/export` – export documents using a template
-- `PATCH /api/documents/:id/retention` – update an invoice retention policy (6m, 2y, forever)
-- `POST /api/documents/payment-risk` – predict payment delay risk for a vendor
-- `POST /api/documents/payment-behavior` – predict expected payment date and confidence
-- `POST /api/documents/nl-chart` – run a natural language query and return data for charts
-- `POST /api/documents/cash-flow/scenario` – recalculate cash flow under payment delay scenarios
+- `PATCH /api/claims/:id/retention` – update an invoice retention policy (6m, 2y, forever)
+- `POST /api/claims/payment-risk` – predict payment delay risk for a vendor
+- `POST /api/claims/payment-behavior` – predict expected payment date and confidence
+- `POST /api/claims/nl-chart` – run a natural language query and return data for charts
+- `POST /api/claims/cash-flow/scenario` – recalculate cash flow under payment delay scenarios
 - `GET /api/scenarios` – list saved cash flow scenarios
 - `POST /api/scenarios` – save a cash flow scenario
 - `GET /api/scenarios/:id` – run a saved scenario
-- `POST /api/documents/:id/vendor-reply` – generate or send a polite vendor email when an invoice is flagged or rejected
-- `GET /api/documents/:id/payment-request` – download a JSON payload for a payment request form
-- `GET /api/documents/:id/payment-request/pdf` – download a PDF payment request
-- `GET /api/documents/:id/explain` – AI summary of an invoice with anomaly score
+- `POST /api/claims/:id/vendor-reply` – generate or send a polite vendor email when an invoice is flagged or rejected
+- `GET /api/claims/:id/payment-request` – download a JSON payload for a payment request form
+- `GET /api/claims/:id/payment-request/pdf` – download a PDF payment request
+- `GET /api/claims/:id/explain` – AI summary of an invoice with anomaly score
 - `POST /api/feedback` – submit a rating for an AI-generated result
 - `GET /api/feedback` – view average ratings by endpoint
-- `GET /api/documents/vendor-scorecards` – view vendor responsiveness and payment metrics
-- `GET /api/documents/graph` – network graph data linking vendors and duplicate documents
+- `GET /api/claims/vendor-scorecards` – view vendor responsiveness and payment metrics
+- `GET /api/claims/graph` – network graph data linking vendors and duplicate documents
 - `GET /api/vendors` – list vendors with last invoice date and total spend
 - `PATCH /api/vendors/:vendor/notes` – update notes for a vendor
 - `GET /api/vendors/match?q=name` – fuzzy match vendor names
-- `GET /api/documents/amount-suggestions?q=100` – suggest close historical amounts
-- `POST /api/documents/:id/copilot` – context-aware chat about an invoice
+- `GET /api/claims/amount-suggestions?q=100` – suggest close historical amounts
+- `POST /api/claims/:id/copilot` – context-aware chat about an invoice
 - `GET /api/vendors/export` – download vendors as CSV
 - `POST /api/vendors/import` – import vendors from CSV
-- `PATCH /api/documents/:id/payment-status` – update payment status
-- `POST /api/documents/import-csv` – upload a CSV of documents
+- `PATCH /api/claims/:id/payment-status` – update payment status
+- `POST /api/claims/import-csv` – upload a CSV of documents
 - Header names are case and space insensitive (e.g. "Invoice Number" works).
-- `DELETE /api/documents/bulk/delete` – delete multiple documents
-- `PATCH /api/documents/bulk/edit` – bulk update invoice fields
-- `POST /api/documents/:id/extract` – extract key entities from a document
-- `POST /api/documents/:id/auto-tag` – AI auto-tag from common categories
-- `POST /api/documents/suggest-voucher` – recommend a voucher description
-- `POST /api/documents/share` – generate a share link for selected documents
-- `GET /api/documents/shared/:token` – access a shared invoice view
-- `POST /api/documents/dashboard/share` – generate a public dashboard link
-- `GET /api/documents/dashboard/shared/:token` – view a restricted dashboard
-- `GET /api/documents/:id/versions` – list prior versions of an invoice
-- `POST /api/documents/:id/versions/:versionId/restore` – restore a previous version
-- `GET /api/documents/:id/summary` – AI generated summary of any document
+- `DELETE /api/claims/bulk/delete` – delete multiple documents
+- `PATCH /api/claims/bulk/edit` – bulk update invoice fields
+- `POST /api/claims/:id/extract` – extract key entities from a document
+- `POST /api/claims/:id/auto-tag` – AI auto-tag from common categories
+- `POST /api/claims/suggest-voucher` – recommend a voucher description
+- `POST /api/claims/share` – generate a share link for selected documents
+- `GET /api/claims/shared/:token` – access a shared invoice view
+- `POST /api/claims/dashboard/share` – generate a public dashboard link
+- `GET /api/claims/dashboard/shared/:token` – view a restricted dashboard
+- `GET /api/claims/:id/versions` – list prior versions of an invoice
+- `POST /api/claims/:id/versions/:versionId/restore` – restore a previous version
+- `GET /api/claims/:id/summary` – AI generated summary of any document
 - `POST /api/payments/:id/link` – generate a payment link for an invoice
 - `POST /api/payments/stripe/webhook` – Stripe webhook endpoint for status updates
 - `POST /api/pos/upload` – upload a CSV of purchase orders
@@ -420,7 +420,7 @@ The `/inbox` page shows newly uploaded documents waiting for approval.
 Request a draft:
 
 ```bash
-POST /api/documents/42/vendor-reply
+POST /api/claims/42/vendor-reply
 {
   "status": "flagged",
   "reason": "Incorrect PO number"
@@ -442,7 +442,7 @@ Example response:
 Send after manual edits:
 
 ```bash
-POST /api/documents/42/vendor-reply
+POST /api/claims/42/vendor-reply
 {
   "status": "flagged",
   "manualEdit": "Hi team, please resend with the right PO",
@@ -461,7 +461,7 @@ Response:
 Have the AI translate CSV upload errors into plain English:
 
 ```bash
-POST /api/documents/summarize-errors
+POST /api/claims/summarize-errors
 {
   "errors": ["Row 1: Missing vendor", "Row 2: Amount invalid"]
 }
@@ -497,7 +497,7 @@ Example response:
 Request payment data:
 
 ```bash
-GET /api/documents/42/payment-request
+GET /api/claims/42/payment-request
 ```
 
 Example response:
@@ -550,7 +550,7 @@ Offline sync is currently disabled in the MVP. The service worker is unregistere
 If your database is empty, the dashboard charts now display sample data automatically. To generate more realistic demo data in the backend, log in as an admin and click **Seed Dummy Data** on the Vendors page or call:
 
 ```bash
-POST /api/documents/seed-dummy
+POST /api/claims/seed-dummy
 ```
 
 This inserts a few demo documents so charts like *Top Vendors* and *Approval Timeline* look populated during testing. If you prefer to seed from the command line instead of hitting the API, run:
@@ -572,7 +572,7 @@ node migrations/migrateInvoicesToDocuments.js
 
 This backs up the old table, renames it to `documents` and adds `type`, `title`,
 `entity`, `fileType` and `contentHash` columns. Existing API calls under
-`/api/documents` continue to work via the `/api/documents` routes.
+`/api/claims` continue to work via the `/api/claims` routes.
 
 Make sure you log in again to obtain a fresh token if you see a `401` response when calling the endpoint.
 

--- a/backend/app.js
+++ b/backend/app.js
@@ -29,7 +29,7 @@ const reminderRoutes = require('./routes/reminderRoutes');
 const automationRoutes = require('./routes/automationRoutes');
 const tenantRoutes = require('./routes/tenantRoutes');
 const agentRoutes = require('./routes/agentRoutes');
-const documentRoutes = require('./routes/documentRoutes');
+const claimRoutes = require('./routes/claimRoutes');
 const timelineRoutes = require('./routes/timelineRoutes');
 const pluginRoutes = require('./routes/pluginRoutes');
 const complianceRoutes = require('./routes/complianceRoutes');
@@ -45,7 +45,7 @@ const piiMask = require('./middleware/piiMask');
 const { runRecurringInvoices } = require('./controllers/recurringController');
 const { processFailedPayments, sendPaymentReminders } = require('./controllers/paymentController');
 const { sendApprovalReminders } = require('./controllers/reminderController'); // used for optional manual trigger
-const { autoDeleteExpiredDocuments } = require('./controllers/documentController');
+const { autoDeleteExpiredDocuments } = require('./controllers/claimController');
 const { initDb } = require('./utils/dbInit');
 const { initChat } = require('./utils/chatServer');
 const { loadCorrections } = require('./utils/parserTrainer');
@@ -75,8 +75,8 @@ app.use(tenantContext);
 app.use('/health', healthRoutes);
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use(auditLog);
-// Allow auth endpoints under the new documents scope
-app.use('/api/documents', authRoutes);
+// Allow auth endpoints under the new claims scope
+app.use('/api/claims', authRoutes);
 app.use('/api/invoices', authRoutes); // backwards compat
 app.use('/api/:tenantId/export-templates', exportTemplateRoutes);
 app.use('/api/:tenantId/logo', brandingRoutes);
@@ -103,8 +103,8 @@ app.use('/api/logs', logRoutes);
 app.use('/api/tenants', tenantRoutes);
 app.use('/api/agents', agentRoutes);
 app.use('/api/ai', aiRoutes);
-app.use('/api/documents', documentRoutes);
-app.use('/api/invoices', documentRoutes); // backwards compat
+app.use('/api/claims', claimRoutes);
+app.use('/api/invoices', claimRoutes); // backwards compat
 app.use('/api/timeline', timelineRoutes);
 app.use('/api/plugins', pluginRoutes);
 app.use('/api/compliance', complianceRoutes);

--- a/backend/controllers/claimController.js
+++ b/backend/controllers/claimController.js
@@ -25,8 +25,8 @@ exports.listDocuments = async (req, res) => {
     );
     res.json(rows);
   } catch (err) {
-    console.error('List documents error:', err);
-    res.status(500).json({ message: 'Failed to fetch documents' });
+    console.error('List claim documents error:', err);
+    res.status(500).json({ message: 'Failed to fetch claim documents' });
   }
 };
 

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5,9 +5,9 @@
     "version": "1.0.0"
   },
   "paths": {
-    "/api/{tenantId}/documents": {
+    "/api/{tenantId}/claims": {
       "get": {
-        "summary": "List documents",
+        "summary": "List claim documents",
         "parameters": [
           {
             "name": "tenantId",
@@ -21,9 +21,9 @@
       }
     }
   },
-    "/api/{tenantId}/documents/upload": {
+    "/api/{tenantId}/claims/upload": {
       "post": {
-        "summary": "Upload document",
+        "summary": "Upload claim file",
         "parameters": [
           {
             "name": "tenantId",
@@ -49,7 +49,7 @@
         }
       }
     },
-    "/api/documents/summarize-errors": {
+    "/api/claims/summarize-errors": {
       "post": {
         "summary": "AI summarize CSV errors",
         "requestBody": {
@@ -94,13 +94,13 @@
         "responses": { "200": { "description": "Vendor suggestion" } }
       }
     },
-    "/api/documents/totals-by-entity": {
+    "/api/claims/totals-by-entity": {
       "get": {
         "summary": "Totals by entity",
         "responses": { "200": { "description": "Entity totals" } }
       }
     },
-    "/api/documents/search": {
+    "/api/claims/search": {
       "get": {
         "summary": "Search documents",
         "parameters": [

--- a/backend/routes/claimRoutes.js
+++ b/backend/routes/claimRoutes.js
@@ -16,7 +16,7 @@ const {
   getEntityTotals,
   searchDocuments,
   exportSummaryPDF,
-} = require('../controllers/documentController');
+} = require('../controllers/claimController');
 const { authMiddleware } = require('../controllers/userController');
 
 const router = express.Router();

--- a/backend/test/routes.test.js
+++ b/backend/test/routes.test.js
@@ -11,17 +11,17 @@ const authRoutes = require('../routes/authRoutes');
 const { authMiddleware } = require('../controllers/userController');
 
 const uploadRouter = express.Router();
-uploadRouter.post('/api/documents/upload', authMiddleware, (req, res) => res.json({ ok: true }));
+uploadRouter.post('/api/claims/upload', authMiddleware, (req, res) => res.json({ ok: true }));
 const anomalyRouter = express.Router();
-anomalyRouter.get('/api/:tenantId/documents/anomalies', authMiddleware, (req, res) => res.json({ anomalies: [] }));
+anomalyRouter.get('/api/:tenantId/claims/anomalies', authMiddleware, (req, res) => res.json({ anomalies: [] }));
 const signingRouter = express.Router();
 signingRouter.post('/api/signing/1/start', authMiddleware, (req, res) => res.json({ url: 'ok' }));
 const entityRouter = express.Router();
-entityRouter.get('/api/documents/totals-by-entity', authMiddleware, (req, res) => res.json({ totals: [] }));
+entityRouter.get('/api/claims/totals-by-entity', authMiddleware, (req, res) => res.json({ totals: [] }));
 
 const app = express();
 app.use(express.json());
-app.use('/api/documents', authRoutes);
+app.use('/api/claims', authRoutes);
 app.use('/api/invoices', authRoutes);
 app.use(uploadRouter);
 app.use(anomalyRouter);
@@ -34,7 +34,7 @@ describe('Auth and documents', () => {
   test('login returns token', async () => {
     const hash = await bcrypt.hash('pass', 10);
     db.query.mockResolvedValueOnce({ rows: [{ id: 1, username: 'user', password_hash: hash, role: 'admin' }] });
-    const res = await request(app).post('/api/documents/login').send({ username: 'user', password: 'pass' });
+    const res = await request(app).post('/api/claims/login').send({ username: 'user', password: 'pass' });
     expect(res.statusCode).toBe(200);
     expect(res.body.token).toBeDefined();
   });
@@ -48,17 +48,17 @@ describe('Auth and documents', () => {
   });
 
   test('upload requires auth', async () => {
-    const res = await request(app).post('/api/documents/upload');
+    const res = await request(app).post('/api/claims/upload');
     expect(res.statusCode).toBe(401);
   });
 
   test('anomaly route requires auth', async () => {
-    const res = await request(app).get('/api/1/documents/anomalies');
+    const res = await request(app).get('/api/1/claims/anomalies');
     expect(res.statusCode).toBe(401);
   });
 
   test('entity totals route requires auth', async () => {
-    const res = await request(app).get('/api/documents/totals-by-entity');
+    const res = await request(app).get('/api/claims/totals-by-entity');
     expect(res.statusCode).toBe(401);
   });
 

--- a/backend/utils/emailSync.js
+++ b/backend/utils/emailSync.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { google } = require('googleapis');
 const { sendMail } = require('./email');
-// Use the generic document upload since invoice controller was removed
-const { uploadDocument } = require('../controllers/documentController');
+// Use the generic claim upload
+const { uploadDocument } = require('../controllers/claimController');
 
 // Gmail ingestion temporarily disabled
 

--- a/docs/TRANSFORMATION_PLAN.md
+++ b/docs/TRANSFORMATION_PLAN.md
@@ -35,19 +35,19 @@ This document outlines a high level path to evolve ClarifyOps into an **AI Docum
 
 ## 4. New AI Ops features
 
-- **AI Entity Extraction** – Added `POST /api/documents/:id/extract` which uses OpenRouter to pull dates, terms, parties and clauses from any uploaded document.
-- **Document Comparison** – Every document edit now records a version in the new `document_versions` table. `GET /api/documents/:id/versions` returns diffs and `POST /api/documents/:id/versions/:versionId/restore` restores old snapshots.
-- **Document Summarization** – New `GET /api/documents/:id/summary` endpoint summarizes any document.
+- **AI Entity Extraction** – Added `POST /api/claims/:id/extract` which uses OpenRouter to pull dates, terms, parties and clauses from any uploaded document.
+- **Document Comparison** – Every document edit now records a version in the new `document_versions` table. `GET /api/claims/:id/versions` returns diffs and `POST /api/claims/:id/versions/:versionId/restore` restores old snapshots.
+- **Document Summarization** – New `GET /api/claims/:id/summary` endpoint summarizes any document.
 
 ## 5. Roadmap to Full AI Ops Platform
 
 - **Auto-categorization** – `/api/ai/categorize` suggests top categories like HR, Legal or Expense for uploaded text.
 - **Document Workflows** – `/api/document-workflows` replaces the old workflows route and stores `doc_type` and optional `conditions` for each department.
-- **Versioned Uploads** – `POST /api/documents/:id/version` lets users upload new versions while `/api/documents/:id/versions` provides a timeline of edits.
+- **Versioned Uploads** – `POST /api/claims/:id/version` lets users upload new versions while `/api/claims/:id/versions` provides a timeline of edits.
 
 ## 6. Compliance & Lifecycle Enhancements
 
-- **Compliance Checker** – `/api/documents/:id/compliance` flags missing clauses for contracts.
+- **Compliance Checker** – `/api/claims/:id/compliance` flags missing clauses for contracts.
 - **Document Lifecycle Rules** – `retention_policy`, `expires_at` and `archived` now apply to all documents.
 - **Enterprise Add-On: Secure Signing** – `/api/signing/:id/start` now returns a placeholder link; blockchain hashing removed from the MVP.
 

--- a/frontend/src/Claims.js
+++ b/frontend/src/Claims.js
@@ -69,7 +69,7 @@ const teamMembers = ['Alice', 'Bob', 'Charlie'];
 
 
 
-function Documents() {
+function ClaimsPage() {
   const [visibleColumns, setVisibleColumns] = useState({
   id: true,
   invoice_number: true,
@@ -542,14 +542,14 @@ const [selectedAssignee, setSelectedAssignee] = useState('');
         if (url.startsWith(API_BASE)) {
           let path = url.slice(API_BASE.length);
           if (path.startsWith('/api/invoices')) {
-            path = path.replace('/api/invoices', '/api/documents');
+            path = path.replace('/api/invoices', '/api/claims');
           } else if (path.startsWith('/api/export-templates')) {
             path = path.replace('/api/export-templates', `/api/${tenant}/export-templates`);
           }
           url = API_BASE + path;
         } else if (url.startsWith('/')) {
           if (url.startsWith('/api/invoices')) {
-            url = url.replace('/api/invoices', '/api/documents');
+            url = url.replace('/api/invoices', '/api/claims');
           } else if (url.startsWith('/api/export-templates')) {
             url = url.replace('/api/export-templates', `/api/${tenant}/export-templates`);
           }
@@ -1399,7 +1399,7 @@ useEffect(() => {
         }
       }, 5000);
 
-      addToast(`Document #${id} deleted`, 'success', {
+      addToast(`Claim Document #${id} deleted`, 'success', {
         duration: 5000,
         actionText: 'Undo',
         onAction: undo,
@@ -1427,7 +1427,7 @@ useEffect(() => {
       return;
     }
     try {
-      const res = await fetch(`${API_BASE}/api/documents/login`, {
+      const res = await fetch(`${API_BASE}/api/claims/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),
@@ -2215,12 +2215,12 @@ useEffect(() => {
           <>
 
 <div className="mt-6 mb-6">
-  <h2 className="text-xl font-bold text-gray-800 mb-2">Upload New Document</h2>
+  <h2 className="text-xl font-bold text-gray-800 mb-2">Upload New Claim File</h2>
   <hr className="mb-4" />
   <fieldset className="p-6 rounded-xl shadow-xl bg-gradient-to-br from-white via-gray-50 to-gray-100 dark:from-gray-800 dark:via-gray-900 dark:to-gray-700 border border-gray-200 dark:border-gray-700 flex flex-col gap-4 space-y-4 relative">
     <legend className="text-xl font-bold px-2 flex items-center gap-1">
       <CloudArrowUpIcon className="w-5 h-5 text-indigo-600" />
-      <span>Upload Document</span>
+      <span>Upload Claim File</span>
     </legend>
     <ol className="flex space-x-4 text-sm text-gray-600 mb-2">
       <li className="flex items-center space-x-1">
@@ -2317,7 +2317,7 @@ useEffect(() => {
       ) : (
         <ArrowUpTrayIcon className="h-5 w-5" />
       )}
-      <span>{loading ? 'Uploading...' : 'Upload Document'}</span>
+      <span>{loading ? 'Uploading...' : 'Upload Claim File'}</span>
       {uploadSuccess && !loading && (
         <SuccessAnimation className="h-6 w-6" />
       )}
@@ -2502,7 +2502,7 @@ useEffect(() => {
 
 
                 <h2 className="text-lg font-semibold mt-8 mb-2 text-gray-800">
-                  Document Totals by Entity
+                  Claim Totals by Entity
                 </h2>
                 <div className="mb-4 flex flex-wrap gap-4">
                   {Object.keys(visibleColumns).map((col) => (
@@ -2707,7 +2707,7 @@ useEffect(() => {
                     </th>
                     <th className="border px-4 py-2">ID</th>
                     <th className="border px-4 py-2 cursor-pointer" onClick={() => handleSort('invoice_number')}>
-                      Document #
+                      Claim Document #
                       {sortConfig.key === 'invoice_number' && (
                         <span>{sortConfig.direction === 'asc' ? ' ⬆' : ' ⬇'}</span>
                       )}
@@ -2755,8 +2755,8 @@ useEffect(() => {
                     <EmptyState
                       onCta={() => fileInputRef.current?.click()}
                       headline="Let's get started!"
-                      description="Upload your first document to begin tracking spend, surfacing anomalies, and unlocking AI insights."
-                      cta="Upload Document"
+                      description="Upload your first claim file to begin tracking spend, surfacing anomalies, and unlocking AI insights."
+                      cta="Upload Claim File"
                     />
                   </td>
                 </tr>
@@ -3322,8 +3322,8 @@ useEffect(() => {
           <button
             onClick={openUploadPreview}
             className="fixed bottom-4 right-20 p-3 rounded-full bg-indigo-600 text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-white z-30"
-            title="Upload Document"
-            aria-label="Upload document"
+            title="Upload Claim File"
+            aria-label="Upload claim file"
           >
             <ArrowUpTrayIcon className="w-6 h-6" />
           </button>
@@ -3384,4 +3384,4 @@ useEffect(() => {
   );
 }
 
-export default Documents;
+export default ClaimsPage;

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -13,7 +13,7 @@ export default function Login({ onLogin, addToast }) {
 
   const handleLogin = async () => {
     try {
-      const res = await fetch(`${API_BASE}/api/documents/login`, {
+      const res = await fetch(`${API_BASE}/api/claims/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),

--- a/frontend/src/LoginPage.jsx
+++ b/frontend/src/LoginPage.jsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
         onLogin={(tok, role) => {
           localStorage.setItem('token', tok);
           localStorage.setItem('role', role);
-          navigate('/documents');
+          navigate('/claims');
         }}
         addToast={addToast}
       />

--- a/frontend/src/OnboardingWizard.js
+++ b/frontend/src/OnboardingWizard.js
@@ -108,7 +108,7 @@ export default function OnboardingWizard() {
           <div className="space-y-4 bg-white dark:bg-gray-800 p-6 rounded shadow text-center">
             <h2 className="text-lg font-semibold">All set!</h2>
             <p className="text-sm">Your template has been saved. You're ready to start uploading invoices.</p>
-            <Button onClick={() => (window.location.href = '/documents')}>Go to App</Button>
+            <Button onClick={() => (window.location.href = '/claims')}>Go to App</Button>
           </div>
         )}
       </div>

--- a/frontend/src/OperationsDashboard.js
+++ b/frontend/src/OperationsDashboard.js
@@ -42,8 +42,8 @@ import { API_BASE } from './api';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff8042', '#8dd1e1', '#a4de6c'];
 const METRIC_LABELS = {
-  total: '💵 Total Document Spend This Month',
-  pending: '🧾 Documents Pending',
+  total: '💵 Total Claim Document Spend This Month',
+  pending: '🧾 Claim Documents Pending',
   anomalies: '⚠️ Anomalies Found',
   ai: '🤖 AI Suggestions Available',
 };
@@ -347,7 +347,7 @@ function OperationsDashboard() {
                               {m === 'pending' && (
                                 <StatCard
                                   icon={<InboxIcon className="w-5 h-5" />}
-                                  title="Documents Pending"
+                                  title="Claim Documents Pending"
                                   value={stats?.invoicesPending || 0}
                                   cta="Go to Inbox"
                                   onCta={() => navigate('/inbox')}

--- a/frontend/src/SharedDashboard.js
+++ b/frontend/src/SharedDashboard.js
@@ -23,10 +23,10 @@ function SharedDashboard() {
   return (
     <MainLayout title="Shared Dashboard">
       <div className="space-y-4">
-        <div>Total Documents: {data.totalInvoices}</div>
+        <div>Total Claim Documents: {data.totalInvoices}</div>
         <div>Total Amount: {data.totalAmount}</div>
-        <div>Total Document Spend This Month: {data.totalInvoicedThisMonth}</div>
-        <div>Documents Pending: {data.invoicesPending}</div>
+        <div>Total Claim Document Spend This Month: {data.totalInvoicedThisMonth}</div>
+        <div>Claim Documents Pending: {data.invoicesPending}</div>
         <div>Anomalies Found: {data.anomaliesFound}</div>
         <div>AI Suggestions: {data.aiSuggestions}</div>
       </div>

--- a/frontend/src/VendorManagement.js
+++ b/frontend/src/VendorManagement.js
@@ -337,7 +337,7 @@ function VendorManagement() {
                 <td className="p-2 flex space-x-2">
                   <button onClick={() => setEditingVendor(v.vendor)} title="Edit"><PencilSquareIcon className="w-4 h-4" /></button>
                   <button onClick={() => setDetailVendor(v.vendor)} title="Details"><DocumentChartBarIcon className="w-4 h-4" /></button>
-                  <button onClick={() => navigate(`/documents?vendor=${encodeURIComponent(v.vendor)}`)} title="View Documents"><EyeIcon className="w-4 h-4" /></button>
+                  <button onClick={() => navigate(`/claims?vendor=${encodeURIComponent(v.vendor)}`)} title="View Documents"><EyeIcon className="w-4 h-4" /></button>
                   <button onClick={async () => { if (window.confirm('Delete vendor?')) { await fetch(`${API_BASE}/api/vendors/${encodeURIComponent(v.vendor)}`, { method: 'DELETE', headers }); fetchVendors(); } }} title="Delete"><TrashIcon className="w-4 h-4 text-red-600" /></button>
                 </td>
               </tr>

--- a/frontend/src/components/BottomNav.js
+++ b/frontend/src/components/BottomNav.js
@@ -12,7 +12,7 @@ export default function BottomNav() {
   const location = useLocation();
   const items = [
     { to: '/operations', icon: HomeIcon, label: 'Home' },
-    { to: '/documents', icon: DocumentIcon, label: 'Documents' },
+    { to: '/claims', icon: DocumentIcon, label: 'Claim Documents' },
     { to: '/inbox', icon: InboxIcon, label: 'Inbox' },
     { to: '/archive', icon: ArchiveBoxIcon, label: 'Archive' },
   ];

--- a/frontend/src/components/LiveFeed.js
+++ b/frontend/src/components/LiveFeed.js
@@ -10,7 +10,7 @@ export default function LiveFeed({ token, tenant }) {
     if (!action) return 'Unknown activity';
     const lower = action.toLowerCase();
     if (lower.includes('/login')) return 'User logged in';
-    if (lower.includes('/documents')) return 'Document uploaded';
+    if (lower.includes('/claims')) return 'Claim document uploaded';
     return 'Unknown activity';
   };
 

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -70,7 +70,7 @@ export default function Navbar({
     <nav className="sticky top-0 z-30 bg-indigo-700/60 dark:bg-indigo-900/60 backdrop-blur text-white shadow">
       <div className="max-w-5xl mx-auto flex flex-wrap justify-between items-center gap-4 p-2">
         <div className="flex items-center space-x-2">
-          <Link to="/documents" className="flex items-center space-x-1" onClick={() => { setMenuOpen(false); setUserOpen(false); }}>
+          <Link to="/claims" className="flex items-center space-x-1" onClick={() => { setMenuOpen(false); setUserOpen(false); }}>
             <img
               src={`/api/${tenant}/logo`}
               alt="logo"
@@ -102,7 +102,7 @@ export default function Navbar({
           value={smartQuery}
           onChange={(e) => onSmartQueryChange?.(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && onSmartSearch?.()}
-          placeholder="Documents from Amazon last quarter > $1,000"
+          placeholder="Claim Documents from Amazon last quarter > $1,000"
           aria-label="Smart search"
           className="input text-gray-800 dark:text-gray-100 h-7 text-sm w-52"
         />

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -54,11 +54,11 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
               <span>Adaptive</span>
             </Link>
             <Link
-              to="/documents"
-              className={`nav-link border-l-4 ${location.pathname === '/documents' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
+              to="/claims"
+              className={`nav-link border-l-4 ${location.pathname === '/claims' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <FileText className="w-5 h-5" />
-              <span>Documents</span>
+              <span>Claim Documents</span>
             </Link>
             <Link
               to="/inbox"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Documents from './Documents';
+import ClaimsPage from './Claims';
 import OperationsDashboard from './OperationsDashboard';
 import AdaptiveDashboard from './AdaptiveDashboard';
 import SharedDashboard from './SharedDashboard';
@@ -43,14 +43,14 @@ window.fetch = async (url, options) => {
     if (url.startsWith(API_BASE)) {
       let path = url.slice(API_BASE.length);
       if (path.startsWith('/api/invoices')) {
-        path = path.replace('/api/invoices', '/api/documents');
+        path = path.replace('/api/invoices', '/api/claims');
       } else if (path.startsWith('/api/export-templates')) {
         path = path.replace('/api/export-templates', `/api/${tenant}/export-templates`);
       }
       url = API_BASE + path;
     } else if (url.startsWith('/')) {
       if (url.startsWith('/api/invoices')) {
-        url = url.replace('/api/invoices', '/api/documents');
+        url = url.replace('/api/invoices', '/api/claims');
       } else if (url.startsWith('/api/export-templates')) {
         url = url.replace('/api/export-templates', `/api/${tenant}/export-templates`);
       }
@@ -82,8 +82,8 @@ const savedFont = localStorage.getItem(`fontFamily_${currentTenant}`);
 if (savedFont) document.documentElement.style.setProperty('--font-base', savedFont);
 
 if (API_BASE) {
-  // Hit the health endpoint instead of /api/documents since the
-  // documents listing route may not exist in some deployments.
+  // Hit the health endpoint instead of /api/claims since the
+  // claims listing route may not exist in some deployments.
   fetch(`${API_BASE}/health`).catch((err) => {
     console.error('API connection failed', err);
   });
@@ -110,7 +110,7 @@ function AnimatedRoutes() {
         <Route path="/operations" element={<PageWrapper><OperationsDashboard /></PageWrapper>} />
         <Route path="/adaptive" element={<PageWrapper><AdaptiveDashboard /></PageWrapper>} />
         <Route path="/dashboard/shared/:token" element={<PageWrapper><SharedDashboard /></PageWrapper>} />
-        <Route path="/documents" element={<PageWrapper><Documents /></PageWrapper>} />
+        <Route path="/claims" element={<PageWrapper><ClaimsPage /></PageWrapper>} />
         <Route path="/inbox" element={<PageWrapper><Inbox /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><AISpendAnalyticsHub /></PageWrapper>} />
         <Route path="/audit" element={<PageWrapper><AuditDashboard /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- update README and docs to use new `/api/claims` endpoints
- rename `Documents` component to `ClaimsPage`
- update route in `index.js` to use the new component

## Testing
- `npm install` (backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883196ea548832ea64d0fd6041036c3