### PR TITLE
Add claim field version tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ The `/inbox` page shows newly uploaded documents waiting for approval.
 - `DELETE /api/claims/bulk/delete` – delete multiple documents
 - `PATCH /api/claims/bulk/edit` – bulk update invoice fields
 - `POST /api/claims/:id/extract` – extract key entities from a document
+- `POST /api/claims/:id/extract-fields` – AI claim field extraction (stores version and timestamp)
 - `POST /api/claims/:id/auto-tag` – AI auto-tag from common categories
 - `POST /api/claims/suggest-voucher` – recommend a voucher description
 - `POST /api/claims/share` – generate a share link for selected documents

--- a/backend/ai/claimFieldExtractor.js
+++ b/backend/ai/claimFieldExtractor.js
@@ -1,0 +1,50 @@
+const openrouter = require('../config/openrouter');
+const logger = require('../utils/logger');
+const Ajv = require('ajv');
+
+const ajv = new Ajv();
+const schema = {
+  type: 'object',
+  properties: {
+    claim_id: { type: 'string' },
+    claimant_name: { type: 'string' },
+    date_of_incident: { type: 'string' },
+    policy_number: { type: 'string' },
+    total_claimed_amount: { type: 'string' },
+    loss_description: { type: 'string' }
+  },
+  additionalProperties: true
+};
+
+const model = 'openai/gpt-3.5-turbo';
+
+async function extractClaimFields(text) {
+  const start = Date.now();
+  try {
+    const prompt =
+      'Extract structured fields from this insurance claim text. ' +
+      'Return JSON with the following keys: claim_id, claimant_name, date_of_incident, policy_number, total_claimed_amount, loss_description.';
+    const resp = await openrouter.chat.completions.create({
+      model,
+      messages: [{ role: 'user', content: `${prompt}\n\n${text}` }]
+    });
+    logger.info({ latency: Date.now() - start }, 'claimFieldExtractor');
+    const raw = resp.choices?.[0]?.message?.content || '{}';
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch {
+      data = { raw };
+    }
+    if (!ajv.validate(schema, data)) {
+      logger.warn({ errors: ajv.errors }, 'Invalid claim fields');
+      throw new Error('Invalid claim field format');
+    }
+    return { fields: data, version: model };
+  } catch (err) {
+    console.error('AI extraction failed:', err.message);
+    throw new Error('Could not extract claim fields at this time.');
+  }
+}
+
+module.exports = { extractClaimFields };

--- a/backend/routes/claimRoutes.js
+++ b/backend/routes/claimRoutes.js
@@ -4,6 +4,7 @@ const path = require('path');
 const {
   uploadDocument,
   extractDocument,
+  extractClaimFields,
   saveCorrections,
   summarizeDocument,
   listDocuments,
@@ -38,6 +39,7 @@ const { uploadLimiter } = require('../middleware/rateLimit');
 router.post('/upload', uploadLimiter, authMiddleware, upload.single('file'), fileSizeLimit, uploadDocument);
 router.get('/', authMiddleware, listDocuments);
 router.post('/:id/extract', authMiddleware, extractDocument);
+router.post('/:id/extract-fields', authMiddleware, extractClaimFields);
 router.post('/:id/corrections', authMiddleware, saveCorrections);
 router.get('/:id/summary', authMiddleware, summarizeDocument);
 router.get('/:id/versions', authMiddleware, getDocumentVersions);

--- a/backend/test/routes.test.js
+++ b/backend/test/routes.test.js
@@ -18,6 +18,8 @@ const signingRouter = express.Router();
 signingRouter.post('/api/signing/1/start', authMiddleware, (req, res) => res.json({ url: 'ok' }));
 const entityRouter = express.Router();
 entityRouter.get('/api/claims/totals-by-entity', authMiddleware, (req, res) => res.json({ totals: [] }));
+const fieldRouter = express.Router();
+fieldRouter.post('/api/claims/1/extract-fields', authMiddleware, (req, res) => res.json({ ok: true }));
 
 const app = express();
 app.use(express.json());
@@ -27,6 +29,7 @@ app.use(uploadRouter);
 app.use(anomalyRouter);
 app.use(signingRouter);
 app.use(entityRouter);
+app.use(fieldRouter);
 
 const db = require('../config/db');
 
@@ -64,6 +67,11 @@ describe('Auth and documents', () => {
 
   test('signing route requires auth', async () => {
     const res = await request(app).post('/api/signing/1/start');
+    expect(res.statusCode).toBe(401);
+  });
+
+  test('claim field extraction requires auth', async () => {
+    const res = await request(app).post('/api/claims/1/extract-fields');
     expect(res.statusCode).toBe(401);
   });
 });

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -417,6 +417,19 @@ async function initDb() {
       label BOOLEAN,
       created_at TIMESTAMP DEFAULT NOW()
     )`);
+
+    await pool.query(`CREATE TABLE IF NOT EXISTS claim_fields (
+      id SERIAL PRIMARY KEY,
+      document_id INTEGER UNIQUE REFERENCES documents(id) ON DELETE CASCADE,
+      fields JSONB,
+      version TEXT,
+      extracted_at TIMESTAMP DEFAULT NOW(),
+      created_at TIMESTAMP DEFAULT NOW()
+    )`);
+    await pool.query("ALTER TABLE claim_fields ADD COLUMN IF NOT EXISTS version TEXT");
+    await pool.query(
+      "ALTER TABLE claim_fields ADD COLUMN IF NOT EXISTS extracted_at TIMESTAMP DEFAULT NOW()"
+    );
   } catch (err) {
     console.error('Database init error:', err);
   }


### PR DESCRIPTION
## Summary
- add version and extracted_at columns for claim field storage
- validate claim field output with Ajv
- upsert version info on repeated extractions
- document new timestamped extraction endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688325ce2c24832ebd7fd07565fc2c65