### PR TITLE
Fix backend login by handling missing OpenAI key

### DIFF
--- a/backend/config/openrouter.js
+++ b/backend/config/openrouter.js
@@ -4,9 +4,24 @@ const { OpenAI } = require('openai');
 
 const apiKey = process.env.OPENROUTER_API_KEY || process.env.OPENAI_API_KEY;
 
-const openrouter = new OpenAI({
-  apiKey,
-  baseURL: 'https://openrouter.ai/api/v1',
-});
+let openrouter;
+
+if (apiKey) {
+  openrouter = new OpenAI({
+    apiKey,
+    baseURL: 'https://openrouter.ai/api/v1',
+  });
+} else {
+  console.warn('OPENROUTER_API_KEY or OPENAI_API_KEY not set. AI features will be disabled.');
+  openrouter = {
+    chat: {
+      completions: {
+        create: async () => {
+          throw new Error('AI client not configured');
+        },
+      },
+    },
+  };
+}
 
 module.exports = openrouter;


### PR DESCRIPTION
## Summary
- avoid crashing when OpenAI API key is absent by stubbing OpenAI client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689287dfc4ec832eb175e980c073770f