### PR TITLE
feat: add claim document types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ npm install --legacy-peer-deps
 ## Features
 
 - Smart document router for all document types
+- Claim-specific types like `claim_invoice`, `medical_bill`, and `fnol_form`
+- Healthcare claim extraction for CPT codes, ICD-10, and policy IDs
+- Claim validation rules for deductible thresholds and benefit maximums
 - Schema-free data extractor with confidence scores
 - Real-time ops timeline via WebSocket
 - Conversational agent with pgvector embeddings

--- a/backend/ai/claimFieldExtractor.js
+++ b/backend/ai/claimFieldExtractor.js
@@ -11,19 +11,29 @@ const schema = {
     date_of_incident: { type: 'string' },
     policy_number: { type: 'string' },
     total_claimed_amount: { type: 'string' },
-    loss_description: { type: 'string' }
+    loss_description: { type: 'string' },
+    cpt_codes: {
+      type: 'array',
+      items: { type: 'string' }
+    },
+    icd10_codes: {
+      type: 'array',
+      items: { type: 'string' }
+    },
+    policy_id: { type: 'string' }
   },
   additionalProperties: true
 };
 
-const model = 'openai/gpt-3.5-turbo';
+// tuned for healthcare/claim domain extraction
+const model = 'openai/gpt-4o-mini';
 
 async function extractClaimFields(text) {
   const start = Date.now();
   try {
     const prompt =
-      'Extract structured fields from this insurance claim text. ' +
-      'Return JSON with the following keys: claim_id, claimant_name, date_of_incident, policy_number, total_claimed_amount, loss_description.';
+      'Extract structured fields from this healthcare insurance claim text. ' +
+      'Return JSON with the following keys: claim_id, claimant_name, date_of_incident, policy_number, policy_id, total_claimed_amount, loss_description, cpt_codes (array), icd10_codes (array).';
     const resp = await openrouter.chat.completions.create({
       model,
       messages: [{ role: 'user', content: `${prompt}\n\n${text}` }]

--- a/backend/controllers/rulesController.js
+++ b/backend/controllers/rulesController.js
@@ -6,7 +6,13 @@ exports.listRules = (_req, res) => {
 
 exports.addRule = (req, res) => {
   const rule = req.body;
-  const hasMatchField = rule && (rule.vendor || rule.amountGreaterThan || rule.descriptionContains);
+  const hasMatchField =
+    rule &&
+    (rule.vendor ||
+      rule.amountGreaterThan ||
+      rule.descriptionContains ||
+      rule.deductibleGreaterThan ||
+      rule.benefitMax);
   const hasAction = rule && (rule.category || rule.flagReason);
   if (!hasMatchField || !hasAction) {
     return res.status(400).json({ message: 'Invalid rule' });

--- a/backend/enums/documentType.js
+++ b/backend/enums/documentType.js
@@ -4,6 +4,9 @@ const DocumentType = Object.freeze({
   CONTRACT: 'contract',
   FORM: 'form',
   CLAIM: 'claim',
+  CLAIM_INVOICE: 'claim_invoice',
+  MEDICAL_BILL: 'medical_bill',
+  FNOL_FORM: 'fnol_form',
   OTHER: 'other'
 });
 


### PR DESCRIPTION
## Summary
- add insurance claim document types (claim_invoice, medical_bill, fnol_form)
- update claim upload classification to return new types
- document claim-specific types in README
- expand claim extraction with CPT/ICD templates and dedicated endpoint
- extend rules engine and API with deductible and benefit thresholds

## Testing
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893afdacdf8832e991c8e5f508c322f