### PR TITLE
feat: add insurance claim rules and workflows

### DIFF
--- a/backend/ai/summaryGenerator.js
+++ b/backend/ai/summaryGenerator.js
@@ -5,9 +5,12 @@ async function generateSummary(text) {
   const start = Date.now();
   try {
     const input = text.slice(0, 4000);
+    const prompt =
+      'Summarize the following insurance claim or invoice text using appropriate claims terminology. Focus on policy numbers, deductibles, benefits and key outcomes.\n\n' +
+      input;
     const resp = await openai.chat.completions.create({
       model: 'openai/gpt-3.5-turbo',
-      messages: [{ role: 'user', content: input }]
+      messages: [{ role: 'user', content: prompt }]
     });
     logger.info({ latency: Date.now() - start }, 'summaryGenerator');
     return resp.choices?.[0]?.message?.content?.trim();

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -19,7 +19,7 @@ exports.summarizeUploadErrors = async (req, res) => {
     const errorText = errors.join('\n');
 
     const prompt = `You are a helpful assistant for the ClarifyOps AI Document Ops Engine.
-Given the following upload validation errors, provide a concise summary. Then list bullet points under "Possible Fixes" and, if relevant, a "Warnings" section.
+Given the following upload validation errors for an insurance claim or invoice, provide a concise summary using insurance terminology when appropriate. Then list bullet points under "Possible Fixes" and, if relevant, a "Warnings" section.
 \n\n${errorText}`;
 
     const response = await axios.post(

--- a/backend/controllers/rulesController.js
+++ b/backend/controllers/rulesController.js
@@ -17,6 +17,20 @@ exports.addRule = (req, res) => {
   if (!hasMatchField || !hasAction) {
     return res.status(400).json({ message: 'Invalid rule' });
   }
+  if (rule.deductibleGreaterThan !== undefined) {
+    const num = Number(rule.deductibleGreaterThan);
+    if (Number.isNaN(num)) {
+      return res.status(400).json({ message: 'Invalid rule' });
+    }
+    rule.deductibleGreaterThan = num;
+  }
+  if (rule.benefitMax !== undefined) {
+    const num = Number(rule.benefitMax);
+    if (Number.isNaN(num)) {
+      return res.status(400).json({ message: 'Invalid rule' });
+    }
+    rule.benefitMax = num;
+  }
   addRule(rule);
   res.json({ message: 'Rule added', rules: getRules() });
 };
@@ -25,6 +39,20 @@ exports.updateRule = (req, res) => {
   const idx = parseInt(req.params.idx);
   const rule = req.body;
   if (isNaN(idx) || !rule) return res.status(400).json({ message: 'Invalid request' });
+  if (rule.deductibleGreaterThan !== undefined) {
+    const num = Number(rule.deductibleGreaterThan);
+    if (Number.isNaN(num)) {
+      return res.status(400).json({ message: 'Invalid rule' });
+    }
+    rule.deductibleGreaterThan = num;
+  }
+  if (rule.benefitMax !== undefined) {
+    const num = Number(rule.benefitMax);
+    if (Number.isNaN(num)) {
+      return res.status(400).json({ message: 'Invalid rule' });
+    }
+    rule.benefitMax = num;
+  }
   updateRule(idx, rule);
   res.json({ message: 'Rule updated', rules: getRules() });
 };

--- a/backend/controllers/workflowController.js
+++ b/backend/controllers/workflowController.js
@@ -44,3 +44,12 @@ exports.evaluateWorkflow = async (req, res) => {
     res.status(500).json({ message: 'Failed to evaluate workflow rules' });
   }
 };
+
+exports.getInsuranceWorkflow = (_req, res) => {
+  res.json({
+    workflow: {
+      doc_type: 'claim',
+      steps: ['fnol', 'estimate', 'final_bill']
+    }
+  });
+};

--- a/backend/routes/documentWorkflowRoutes.js
+++ b/backend/routes/documentWorkflowRoutes.js
@@ -1,10 +1,21 @@
 const express = require('express');
 const router = express.Router();
-const { getWorkflows, setWorkflow, evaluateWorkflow } = require('../controllers/workflowController');
+const {
+  getWorkflows,
+  setWorkflow,
+  evaluateWorkflow,
+  getInsuranceWorkflow,
+} = require('../controllers/workflowController');
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
 
 router.get('/', authMiddleware, authorizeRoles('admin'), getWorkflows);
 router.post('/', authMiddleware, authorizeRoles('admin'), setWorkflow);
 router.post('/evaluate', authMiddleware, authorizeRoles('admin'), evaluateWorkflow);
+router.get(
+  '/insurance',
+  authMiddleware,
+  authorizeRoles('admin'),
+  getInsuranceWorkflow,
+);
 
 module.exports = router;

--- a/backend/services/aiService.js
+++ b/backend/services/aiService.js
@@ -32,7 +32,7 @@ async function generateErrorSummary(errors) {
   if (!process.env.OPENROUTER_API_KEY) return null;
   const start = Date.now();
   try {
-    const prompt = `You are a helpful assistant for the ClarifyOps AI Document Ops Engine. Given these validation errors, provide a short summary with possible fixes.\n\n${errors.join('\n')}`;
+    const prompt = `You are a helpful assistant for the ClarifyOps AI Document Ops Engine. Given these validation errors on an insurance claim or invoice, provide a short summary with possible fixes using claims terminology where relevant.\n\n${errors.join('\n')}`;
     const aiRes = await openai.chat.completions.create({
       model: 'openai/gpt-3.5-turbo',
       messages: [

--- a/backend/test/rulesController.test.js
+++ b/backend/test/rulesController.test.js
@@ -1,0 +1,53 @@
+const rulesController = require('../controllers/rulesController');
+const { getRules, setRules } = require('../utils/rulesEngine');
+
+function mockRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.body = null;
+  res.status = function (code) {
+    this.statusCode = code;
+    return this;
+  };
+  res.json = function (data) {
+    this.body = data;
+    return this;
+  };
+  return res;
+}
+
+describe('rulesController validation', () => {
+  let baseRules;
+
+  beforeAll(() => {
+    baseRules = getRules().map(({ triggered, ...rest }) => ({ ...rest }));
+  });
+
+  beforeEach(() => {
+    setRules(baseRules.map(r => ({ ...r })));
+  });
+
+  afterAll(() => {
+    setRules(baseRules);
+  });
+
+  test('addRule rejects non-numeric deductibleGreaterThan', () => {
+    const initialCount = getRules().length;
+    const req = { body: { vendor: 'A', flagReason: 'x', deductibleGreaterThan: 'abc' } };
+    const res = mockRes();
+    rulesController.addRule(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(getRules().length).toBe(initialCount);
+  });
+
+  test('updateRule rejects non-numeric benefitMax', () => {
+    const idx = 0;
+    const before = getRules()[idx];
+    const req = { params: { idx: String(idx) }, body: { vendor: 'B', benefitMax: 'oops' } };
+    const res = mockRes();
+    rulesController.updateRule(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(getRules()[idx]).toEqual(before);
+  });
+});
+

--- a/backend/test/rulesEngine.test.js
+++ b/backend/test/rulesEngine.test.js
@@ -1,0 +1,87 @@
+jest.mock('../config/db', () => ({ query: jest.fn() }));
+
+const { applyRules, setRules } = require('../utils/rulesEngine');
+
+describe('applyRules claim field handling', () => {
+  beforeEach(() => {
+    setRules([
+      { deductibleGreaterThan: 1000, flagReason: 'Deductible over $1000' },
+      { benefitMax: 10000, flagReason: 'Benefit exceeds $10000' },
+      { vendor: 'Google', category: 'Marketing' },
+    ]);
+  });
+
+  test('uses invoice-level deductible/benefit fields', async () => {
+    const invoice = {
+      vendor: 'Google',
+      amount: 100,
+      deductible: 1500,
+      benefit_amount: 5000,
+    };
+
+    const result = await applyRules(invoice);
+    expect(result.flagged).toBe(true);
+    expect(result.flag_reason).toBe('Deductible over $1000');
+    expect(result.tags).toContain('Marketing');
+  });
+
+  test('uses claim-level deductible/benefit fields', async () => {
+    const invoice = {
+      vendor: 'Google',
+      amount: 100,
+      claim: {
+        deductible: 500,
+        benefit_amount: 15000,
+      },
+    };
+
+    const result = await applyRules(invoice);
+    expect(result.flagged).toBe(true);
+    expect(result.flag_reason).toBe('Benefit exceeds $10000');
+    expect(result.tags).toContain('Marketing');
+  });
+
+  test('invoice-level values take precedence over claim-level', async () => {
+    const invoice = {
+      vendor: 'Google',
+      amount: 100,
+      deductible: 500,
+      benefit_amount: 9000,
+      claim: {
+        deductible: 1500,
+        benefit_amount: 15000,
+      },
+    };
+
+    const result = await applyRules(invoice);
+    expect(result.flagged).toBe(false);
+    expect(result.flag_reason).toBeNull();
+    expect(result.tags).toContain('Marketing');
+  });
+
+  test('defaults to zero when deductible and benefit missing in both invoice and claim', async () => {
+    const invoice = {
+      vendor: 'Google',
+      amount: 100,
+      claim: {},
+    };
+
+    const result = await applyRules(invoice);
+    expect(result.flagged).toBe(false);
+    expect(result.flag_reason).toBeNull();
+    expect(result.tags).toContain('Marketing');
+  });
+
+  test('no deductible or benefit fields present', async () => {
+    const invoice = {
+      vendor: 'Google',
+      amount: 100,
+    };
+
+    const result = await applyRules(invoice);
+    expect(result.flagged).toBe(false);
+    expect(result.flag_reason).toBeNull();
+    expect(result.tags).toContain('Marketing');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add insurance-focused rules for deductible and benefit limits
- provide default FNOL→estimate→final-bill workflow via new route
- tune AI prompts to include insurance claim terminology in summaries and error explanations
- add rule engine tests covering claim deductible/benefit precedence
- refactor rules engine to centralize deductible/benefit retrieval
- document deductible/benefit precedence in rule helper and rule matching logic
- validate deductible and benefit thresholds in rule APIs and test invalid input
- ensure applyRules defaults deductible and benefit to 0 when invoice and claim omit those fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b6a9c634832eaf8d5e2d46e3aada