### PR TITLE
feat: add claim embeddings and insurance integrations

### DIFF
--- a/backend/controllers/claimController.js
+++ b/backend/controllers/claimController.js
@@ -117,6 +117,14 @@ exports.uploadDocument = async (req, res) => {
       ]
     );
     await refreshSearchable(rows[0].id);
+    const embRes = await openrouter.embeddings.create({
+      model: 'openai/text-embedding-ada-002',
+      input: rawText.slice(0, 2000)
+    });
+    await pool.query(
+      'INSERT INTO claim_embeddings (document_id, embedding) VALUES ($1,$2)',
+      [rows[0].id, embRes.data[0].embedding]
+    );
     logger.info('Claim uploaded', { id: rows[0].id, docType });
     claimUploadCounter.labels(docType).inc();
     const { autoAssignDocument } = require('../services/invoiceService');

--- a/backend/controllers/integrationController.js
+++ b/backend/controllers/integrationController.js
@@ -5,6 +5,16 @@ exports.handleZapier = async (req, res) => {
   res.json({ message: 'Event received' });
 };
 
+exports.guidewireTrigger = async (req, res) => {
+  console.log('Guidewire event:', req.body);
+  res.json({ message: 'Guidewire trigger received' });
+};
+
+exports.duckCreekTrigger = async (req, res) => {
+  console.log('Duck Creek event:', req.body);
+  res.json({ message: 'Duck Creek trigger received' });
+};
+
 exports.listPublicInvoices = async (req, res) => {
   try {
     const result = await pool.query('SELECT id, invoice_number, vendor, amount, date FROM invoices LIMIT 100');

--- a/backend/routes/integrationRoutes.js
+++ b/backend/routes/integrationRoutes.js
@@ -1,8 +1,15 @@
 const express = require('express');
 const router = express.Router();
-const { handleZapier, listPublicInvoices } = require('../controllers/integrationController');
+const {
+  handleZapier,
+  listPublicInvoices,
+  guidewireTrigger,
+  duckCreekTrigger,
+} = require('../controllers/integrationController');
 
 router.post('/zapier', handleZapier);
+router.post('/zapier/guidewire', guidewireTrigger);
+router.post('/zapier/duckcreek', duckCreekTrigger);
 router.get('/public/invoices', listPublicInvoices);
 
 module.exports = router;

--- a/backend/utils/dbInit.js
+++ b/backend/utils/dbInit.js
@@ -150,6 +150,15 @@ async function initDb() {
       "CREATE INDEX IF NOT EXISTS idx_doc_chunks_embedding ON document_chunks USING ivfflat (embedding vector_cosine_ops)"
     );
 
+    await pool.query(`CREATE TABLE IF NOT EXISTS claim_embeddings (
+      id SERIAL PRIMARY KEY,
+      document_id INTEGER REFERENCES documents(id) ON DELETE CASCADE,
+      embedding VECTOR(1536)
+    )`);
+    await pool.query(
+      "CREATE INDEX IF NOT EXISTS idx_claim_embeddings ON claim_embeddings USING ivfflat (embedding vector_cosine_ops)"
+    );
+
     await pool.query(`CREATE TABLE IF NOT EXISTS document_versions (
       id SERIAL PRIMARY KEY,
       document_id INTEGER REFERENCES documents(id) ON DELETE CASCADE,

--- a/frontend/src/Archive.js
+++ b/frontend/src/Archive.js
@@ -90,7 +90,7 @@ function Archive() {
   );
 
   return (
-    <MainLayout title="Invoice Archive" helpTopic="archive">
+    <MainLayout title="Claim Document Archive" helpTopic="archive">
       <div className="space-y-4">
         <div className="flex flex-wrap items-end space-x-2">
           <input value={vendor} onChange={(e) => setVendor(e.target.value)} placeholder="Vendor" className="input" />

--- a/frontend/src/AuditDashboard.js
+++ b/frontend/src/AuditDashboard.js
@@ -112,7 +112,7 @@ export default function AuditDashboard() {
               <th className="px-2 py-1 font-bold border">Time</th>
               <th className="px-2 py-1 font-bold border">User</th>
               <th className="px-2 py-1 font-bold border">Action</th>
-              <th className="px-2 py-1 font-bold border">Invoice</th>
+              <th className="px-2 py-1 font-bold border">Claim Document</th>
             </tr>
           </thead>
           <tbody>
@@ -124,7 +124,7 @@ export default function AuditDashboard() {
                   <td colSpan="4" className="p-6 text-center text-gray-500">
                     <div className="flex flex-col items-center gap-2">
                       <MagnifyingGlassIcon className="w-8 h-8 text-gray-400" />
-                      <p>No audit logs found. Try changing your filters or upload an invoice to begin tracking actions.</p>
+                      <p>No audit logs found. Try changing your filters or upload a claim document to begin tracking actions.</p>
                     </div>
                   </td>
                 </tr>

--- a/frontend/src/KanbanDashboard.js
+++ b/frontend/src/KanbanDashboard.js
@@ -109,11 +109,11 @@ export default function KanbanDashboard() {
         </Grid>
       </DragDropContext>
       <Dialog open={Boolean(selected)} onClose={() => setSelected(null)} fullWidth maxWidth="sm">
-        <DialogTitle>Edit Invoice</DialogTitle>
+        <DialogTitle>Edit Claim Document</DialogTitle>
         <DialogContent>
           {selected && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              <TextField label="Invoice #" value={selected.invoice_number || ''} onChange={e => handleField('invoice_number', e.target.value)} />
+              <TextField label="Claim #" value={selected.invoice_number || ''} onChange={e => handleField('invoice_number', e.target.value)} />
               <TextField label="Vendor" value={selected.vendor || ''} onChange={e => handleField('vendor', e.target.value)} />
               <TextField label="Amount" value={selected.amount || ''} onChange={e => handleField('amount', e.target.value)} />
               <Button variant="contained" onClick={() => setSelected(null)} sx={{ mt: 1 }}>Save</Button>


### PR DESCRIPTION
## Summary
- index claim documents with pgvector claim_embeddings table
- add Zapier triggers for Guidewire and Duck Creek
- update UI copy to use claim document terminology

## Testing
- `npm test` (backend)
- `CI=true npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6893cf367c4c832eb33b696cccd17618