### PR TITLE
Add claim analytics and insurance workflow templates

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -146,6 +146,7 @@ app.use('/api/billing', billingRoutes);
 app.use('/api/payments', paymentRoutes);
 app.use('/api/pos', poRoutes);
 app.use('/api/document-workflows', workflowRoutes);
+app.use('/api/workflows', workflowRoutes);
 app.use('/api/workflow-rules', workflowRuleRoutes);
 app.use('/api/settings', settingsRoutes);
 app.use('/api/recurring', recurringRoutes);

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4,6 +4,15 @@
     "title": "ClarifyOps API",
     "version": "1.0.0"
   },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    }
+  },
   "paths": {
     "/api/{tenantId}/claims": {
       "get": {
@@ -153,6 +162,114 @@
           "content": { "application/json": { "schema": { "type": "object", "properties": { "status": { "type": "string" } } } } }
         },
         "responses": { "200": { "description": "Updated document" } }
+      }
+    },
+    "/api/claims/{id}/extract": {
+      "post": {
+        "summary": "Extract fields from a claim document",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
+          {
+            "name": "schema",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string" },
+            "description": "Optional schema preset to apply during extraction"
+          }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Extracted claim fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "type": "object" },
+                    "schema": { "type": "object", "nullable": true },
+                    "confidence": { "type": "number" }
+                  }
+                },
+                "example": {
+                  "data": {
+                    "party_name": "Acme Co",
+                    "total_amount": 1000,
+                    "doc_date": "2024-01-01"
+                  },
+                  "schema": { "name": "claim" },
+                  "confidence": 0.9
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/api/analytics/claims": {
+      "get": {
+        "summary": "Claim analytics grouped by claim type",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Claim analytics for the authenticated user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "claim_type": { "type": "string", "nullable": true },
+                          "count": { "type": "integer" },
+                          "total_amount": { "type": "number" }
+                        }
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "claims": [
+                    { "claim_type": "auto", "count": 10, "total_amount": 25000 },
+                    { "claim_type": "home", "count": 5, "total_amount": 8000 }
+                  ]
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/api/analytics/claims/fraud": {
+      "get": {
+        "summary": "Detect suspicious claims using ML",
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Array of suspicious claim IDs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "suspicious": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                },
+                "example": { "suspicious": ["c1", "c5"] }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
       }
     },
     "/api/validation/rules": {

--- a/backend/routes/analyticsRoutes.js
+++ b/backend/routes/analyticsRoutes.js
@@ -24,6 +24,8 @@ const {
   getRiskHeatmap,
   getInvoiceClusters,
   getCrossAlerts,
+  getClaimAnalytics,
+  detectClaimFraud,
   listReportSchedules,
   createReportSchedule,
   deleteReportSchedule
@@ -61,5 +63,7 @@ router.get('/dashboard/cross-alerts', authMiddleware, getCrossAlerts);
 router.get('/anomalies/duplicates', authMiddleware, detectDuplicateInvoices);
 router.get('/risk/heatmap', authMiddleware, getRiskHeatmap);
 router.get('/risk/clusters', authMiddleware, getInvoiceClusters);
+router.get('/claims', authMiddleware, getClaimAnalytics);
+router.get('/claims/fraud', authMiddleware, detectClaimFraud);
 
 module.exports = router;

--- a/backend/routes/documentWorkflowRoutes.js
+++ b/backend/routes/documentWorkflowRoutes.js
@@ -8,7 +8,12 @@ const {
 } = require('../controllers/workflowController');
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
 
-router.get('/', authMiddleware, authorizeRoles('admin'), getWorkflows);
+router.get('/', authMiddleware, authorizeRoles('admin'), (req, res) => {
+  if (req.query.type === 'insurance') {
+    return getInsuranceWorkflow(req, res);
+  }
+  return getWorkflows(req, res);
+});
 router.post('/', authMiddleware, authorizeRoles('admin'), setWorkflow);
 router.post('/evaluate', authMiddleware, authorizeRoles('admin'), evaluateWorkflow);
 router.get(

--- a/backend/schemas/claim.json
+++ b/backend/schemas/claim.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Insurance Claim",
+  "type": "object",
+  "properties": {
+    "claim_number": { "type": "string" },
+    "policy_number": { "type": "string" },
+    "claimant_name": { "type": "string" },
+    "claim_type": { "type": "string" },
+    "claim_amount": { "type": "number" },
+    "date_of_service": { "type": "string", "format": "date" }
+  },
+  "required": ["claim_number", "claimant_name", "claim_amount"]
+}

--- a/backend/test/aiCategorize.test.js
+++ b/backend/test/aiCategorize.test.js
@@ -1,0 +1,73 @@
+process.env.JWT_SECRET = 'testsecret';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('axios');
+const axios = require('axios');
+
+jest.mock('../config/db', () => ({ query: jest.fn() }));
+const db = require('../config/db');
+
+jest.mock('../controllers/userController', () => ({
+  authMiddleware: (req, res, next) => {
+    req.user = { id: 1 };
+    next();
+  }
+}));
+
+jest.mock('../middleware/rateLimit', () => ({
+  aiLimiter: (req, res, next) => next()
+}));
+
+const aiRoutes = require('../routes/aiRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/ai', aiRoutes);
+
+beforeEach(() => {
+  axios.post.mockReset();
+  db.query.mockReset();
+});
+
+describe('/api/ai/categorize', () => {
+  test('uses claim_type hint and returns it in categories', async () => {
+    axios.post.mockResolvedValue({
+      data: { choices: [{ message: { content: 'HR, Legal' } }] }
+    });
+    db.query.mockResolvedValue({ rows: [{ id: 1 }] });
+
+    const res = await request(app)
+      .post('/api/ai/categorize')
+      .send({ content: 'document text', claim_type: 'auto' });
+
+    const prompt = axios.post.mock.calls[0][1].messages[0].content;
+    expect(prompt).toMatch('Claim type: auto');
+
+    expect(res.status).toBe(200);
+    res.body.categories.forEach((c) => {
+      expect(c.claim_type).toBe('auto');
+    });
+    expect(res.body.claim_type).toBe('auto');
+  });
+
+  test('omits claim_type when not provided', async () => {
+    axios.post.mockResolvedValue({
+      data: { choices: [{ message: { content: 'HR, Legal' } }] }
+    });
+    db.query.mockResolvedValue({ rows: [{ id: 1 }] });
+
+    const res = await request(app)
+      .post('/api/ai/categorize')
+      .send({ content: 'document text' });
+
+    const prompt = axios.post.mock.calls[0][1].messages[0].content;
+    expect(prompt).not.toMatch(/Claim type/);
+
+    res.body.categories.forEach((c) => {
+      expect(c.claim_type).toBeNull();
+    });
+    expect(res.body.claim_type).toBeNull();
+  });
+});

--- a/backend/test/analyticsClaims.test.js
+++ b/backend/test/analyticsClaims.test.js
@@ -1,0 +1,103 @@
+process.env.JWT_SECRET = 'testsecret';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../config/db', () => ({ query: jest.fn() }));
+const db = require('../config/db');
+
+jest.mock('../ai/fraudDetection', () => ({ detectFraud: jest.fn() }));
+const { detectFraud } = require('../ai/fraudDetection');
+
+jest.mock('../controllers/userController', () => ({
+  authMiddleware: (req, res, next) => {
+    if (req.headers.authorization === 'Bearer validtoken') {
+      req.user = { userId: 1 };
+      return next();
+    }
+    res.status(401).json({ message: 'Unauthorized' });
+  }
+}));
+
+const analyticsRoutes = require('../routes/analyticsRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/analytics', analyticsRoutes);
+
+beforeEach(() => {
+  db.query.mockReset();
+  detectFraud.mockReset();
+});
+
+describe('GET /api/analytics/claims', () => {
+  test('requires auth', async () => {
+    const res = await request(app).get('/api/analytics/claims');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns claim analytics for authorized user', async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [
+        { claim_type: 'auto', count: 2, total_amount: 200 },
+        { claim_type: 'home', count: 1, total_amount: 500 }
+      ]
+    });
+
+    const res = await request(app)
+      .get('/api/analytics/claims')
+      .set('Authorization', 'Bearer validtoken');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      claims: [
+        { claim_type: 'auto', count: 2, total_amount: 200 },
+        { claim_type: 'home', count: 1, total_amount: 500 }
+      ]
+    });
+  });
+
+  test('defaults missing values to zero', async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [
+        { claim_type: 'auto', count: null, total_amount: undefined }
+      ]
+    });
+
+    const res = await request(app)
+      .get('/api/analytics/claims')
+      .set('Authorization', 'Bearer validtoken');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      claims: [{ claim_type: 'auto', count: 0, total_amount: 0 }]
+    });
+  });
+});
+
+describe('GET /api/analytics/claims/fraud', () => {
+  test('requires auth', async () => {
+    const res = await request(app).get('/api/analytics/claims/fraud');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns suspicious claims for authorized user', async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [
+        { id: 1, amount: 100 },
+        { id: 2, amount: 500 }
+      ]
+    });
+    detectFraud.mockReturnValueOnce([false, true]);
+
+    const res = await request(app)
+      .get('/api/analytics/claims/fraud')
+      .set('Authorization', 'Bearer validtoken');
+
+    expect(db.query).toHaveBeenCalled();
+    expect(detectFraud).toHaveBeenCalledWith([[100], [500]]);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ suspicious: [2] });
+  });
+});
+

--- a/backend/test/claimExtract.test.js
+++ b/backend/test/claimExtract.test.js
@@ -1,0 +1,94 @@
+process.env.JWT_SECRET = 'testsecret';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../config/db', () => ({ query: jest.fn() }));
+const db = require('../config/db');
+
+jest.mock('../ai/claimFieldExtractor', () => ({ extractClaimFields: jest.fn() }));
+const { extractClaimFields } = require('../ai/claimFieldExtractor');
+
+jest.mock('../controllers/userController', () => ({
+  authMiddleware: (req, res, next) => {
+    req.user = { userId: 1 };
+    next();
+  }
+}));
+
+jest.mock('../metrics', () => ({
+  claimUploadCounter: { labels: () => ({ inc: jest.fn() }) },
+  fieldExtractCounter: { labels: () => ({ inc: jest.fn() }) },
+  exportAttemptCounter: { labels: () => ({ inc: jest.fn() }) },
+  feedbackFlaggedCounter: { labels: () => ({ inc: jest.fn() }) },
+  extractDuration: { startTimer: () => jest.fn() }
+}));
+
+jest.mock('../utils/documentVersionLogger', () => ({ recordDocumentVersion: jest.fn() }));
+jest.mock('../utils/logger', () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+
+const claimRoutes = require('../routes/claimRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/claims', claimRoutes);
+
+const claimSchema = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../schemas/claim.json'), 'utf8')
+);
+
+describe('POST /api/claims/:id/extract', () => {
+  let tmpFile;
+  const fields = { claim_number: 'CL123', claimant_name: 'John Doe', claim_amount: 1000 };
+
+  beforeEach(() => {
+    tmpFile = path.join(os.tmpdir(), `doc-${Date.now()}.txt`);
+    fs.writeFileSync(tmpFile, 'dummy content');
+    db.query.mockReset();
+    extractClaimFields.mockReset();
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
+  });
+
+  test('returns fields and schema when valid preset is provided', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ id: 1, doc_type: 'claim_invoice', path: tmpFile }] });
+    db.query.mockResolvedValue({ rows: [] });
+    extractClaimFields.mockResolvedValue({ fields });
+
+    const res = await request(app).post('/api/claims/1/extract?schema=claim');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(fields);
+    expect(res.body.schema).toEqual(claimSchema);
+  });
+
+  test('returns fields without schema when preset is missing', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ id: 1, doc_type: 'claim_invoice', path: tmpFile }] });
+    db.query.mockResolvedValue({ rows: [] });
+    extractClaimFields.mockResolvedValue({ fields });
+
+    const res = await request(app).post('/api/claims/1/extract');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(fields);
+    expect(res.body.schema).toBeUndefined();
+  });
+
+  test('returns fields and null schema when preset is invalid', async () => {
+    db.query.mockResolvedValueOnce({ rows: [{ id: 1, doc_type: 'claim_invoice', path: tmpFile }] });
+    db.query.mockResolvedValue({ rows: [] });
+    extractClaimFields.mockResolvedValue({ fields });
+
+    const res = await request(app).post('/api/claims/1/extract?schema=unknown');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual(fields);
+    expect(res.body.schema).toBeNull();
+  });
+});
+

--- a/backend/test/workflowRoutes.test.js
+++ b/backend/test/workflowRoutes.test.js
@@ -1,0 +1,49 @@
+process.env.JWT_SECRET = 'testsecret';
+
+const request = require('supertest');
+const express = require('express');
+
+jest.mock('../config/db', () => ({ query: jest.fn() }));
+
+jest.mock('../controllers/userController', () => ({
+  authMiddleware: (req, res, next) => {
+    if (req.headers.authorization === 'Bearer validtoken') {
+      req.user = { role: 'admin' };
+      return next();
+    }
+    res.status(401).json({ message: 'Unauthorized' });
+  },
+  authorizeRoles: (...roles) => (req, res, next) => {
+    if (req.user && roles.includes(req.user.role)) {
+      return next();
+    }
+    res.status(403).json({ message: 'Forbidden' });
+  },
+}));
+
+const workflowRoutes = require('../routes/documentWorkflowRoutes');
+
+const app = express();
+app.use(express.json());
+app.use('/api/workflows', workflowRoutes);
+
+describe('GET /api/workflows?type=insurance', () => {
+  test('requires auth', async () => {
+    const res = await request(app).get('/api/workflows?type=insurance');
+    expect(res.status).toBe(401);
+  });
+
+  test('returns insurance workflow for admin', async () => {
+    const res = await request(app)
+      .get('/api/workflows?type=insurance')
+      .set('Authorization', 'Bearer validtoken');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      workflow: {
+        doc_type: 'claim',
+        steps: ['fnol', 'estimate', 'final_bill'],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- support claim_type in AI categorization responses
- allow schema presets during claim document extraction
- add claim analytics and fraud detection endpoints
- expose insurance workflow templates via `/api/workflows?type=insurance`
- add tests covering claim_type hint propagation in `/api/ai/categorize`
- add integration tests for claim analytics and fraud detection endpoints
- document claim analytics endpoints in the OpenAPI spec
- ensure claim analytics `total_amount` values are returned as numbers
- default missing `count` or `total_amount` values to zero in claim analytics responses
- defensively coerce non-numeric claim analytics values to zero
- document optional schema preset on `/api/claims/{id}/extract` in the OpenAPI spec
- add schema preset tests for `/api/claims/:id/extract`
- return `schema: null` when a requested extract preset is missing or invalid
- add integration test ensuring insurance workflow templates require auth and return the expected preset

## Testing
- `npm test --prefix backend`
- `npm run lint --prefix backend` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6893d1fc13f8832eacae0b73172b30a2