### PR TITLE
Rename pages for claims vertical

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The API has been consolidated to a single `/api/claims` namespace (with `/api/in
 
 Originally this project focused solely on invoice processing. It is now evolving into a general **Document AI Platform** that handles invoices, contracts and more. See [docs/TRANSFORMATION_PLAN.md](docs/TRANSFORMATION_PLAN.md) for the roadmap. A quick feature comparison against other tools is available in [docs/MARKET_POSITIONING.md](docs/MARKET_POSITIONING.md).
 
+## Claims Sub-Brand Structure
+
+- ClarifyClaims: Main claims experience (upload, validate, summarize)
+- OpsClaim: Action queue and workflow routing
+- AuditFlow: Risk and audit review for flagged claims
+
 ## Requirements
 - Node.js 18.x LTS
 
@@ -63,7 +69,7 @@ npm install --legacy-peer-deps
 - User ratings on AI responses continuously improve future accuracy
 - Ask Me Anything assistant for financial questions
 - AI assistant can answer billing support queries
- - Context-aware Inbox Copilot chat for each document
+- Context-aware OpsClaim Copilot chat for each claim
 - (e.g. "Which vendors had the most inconsistencies last month?")
  - Role-based access control (Admins and Viewers for the demo)
  - Admins can generate expiring invitation links for Viewer accounts

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -789,7 +789,7 @@ exports.overdueEmailTemplate = async (req, res) => {
   }
 };
 
-// Inbox copilot uses invoice metadata for context-aware answers
+// OpsClaim copilot uses claim metadata for context-aware answers
 exports.invoiceCopilot = async (req, res) => {
   try {
     const id = parseInt(req.params.id, 10);

--- a/docs/CLAIMS_NAMING.md
+++ b/docs/CLAIMS_NAMING.md
@@ -1,0 +1,14 @@
+# ClarifyOps Claims Naming
+
+To support the claims-focused vertical, the following sub-brand naming options provide clarity and positioning:
+
+| Sub-Brand Name | Tagline Idea | Meaning |
+| --- | --- | --- |
+| ClarifyClaims | Clarity in every claim. | Straightforward, keeps the brand rooted |
+| ClarifyX | AI-driven clarity across insurance operations. | A sleeker, "next-gen" feel |
+| OpsClaim | The fastest way to resolve, verify, and validate. | Reflects claims flow and ops insight |
+| VeriClaim | Verified claims. Trusted payouts. | Verification + claims trust |
+| AuditFlow | Claims intelligence with explainability. | Emphasizes auditing, transparency |
+| ClaimLayer | Your AI layer for faster claims decisions. | Positions as the intelligence layer |
+
+These names can be used for product modules, customer-facing tools, or internal vertical code names.

--- a/frontend/src/AuditFlow.js
+++ b/frontend/src/AuditFlow.js
@@ -22,7 +22,7 @@ const DEMO_LOGS = [
   },
 ];
 
-export default function AuditDashboard() {
+export default function AuditFlow() {
   const token = localStorage.getItem('token') || '';
   const role = localStorage.getItem('role') || '';
   const [logs, setLogs] = useState([]);
@@ -86,7 +86,7 @@ export default function AuditDashboard() {
   }
 
   return (
-    <MainLayout title="Audit Dashboard" helpTopic="audit">
+    <MainLayout title="AuditFlow" helpTopic="auditflow">
       <div className="space-y-4">
         <div className="flex flex-wrap items-end gap-4 mb-2">
           <input value={vendor} onChange={e=>setVendor(e.target.value)} placeholder="Vendor" className="input" />
@@ -124,7 +124,7 @@ export default function AuditDashboard() {
                   <td colSpan="4" className="p-6 text-center text-gray-500">
                     <div className="flex flex-col items-center gap-2">
                       <MagnifyingGlassIcon className="w-8 h-8 text-gray-400" />
-                      <p>No audit logs found. Try changing your filters or upload a claim document to begin tracking actions.</p>
+                      <p>No AuditFlow logs found. Try changing your filters or upload a claim document to begin tracking actions.</p>
                     </div>
                   </td>
                 </tr>

--- a/frontend/src/ClaimsBrandingPreview.jsx
+++ b/frontend/src/ClaimsBrandingPreview.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import MainLayout from './components/MainLayout';
+import PageHeader from './components/PageHeader';
+import { ArrowRight } from 'lucide-react';
+
+export default function ClaimsBrandingPreview() {
+  return (
+    <MainLayout title="Claims Branding Preview">
+      <PageHeader
+        title="Claims Branding Preview"
+        subtitle="How ClarifyClaims, OpsClaim, and AuditFlow connect"
+      />
+      <div className="flex items-center justify-center gap-4 mt-8">
+        <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">ClarifyClaims</div>
+        <ArrowRight className="w-6 h-6 text-gray-600 dark:text-gray-300" />
+        <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">OpsClaim</div>
+        <ArrowRight className="w-6 h-6 text-gray-600 dark:text-gray-300" />
+        <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">AuditFlow</div>
+      </div>
+    </MainLayout>
+  );
+}
+

--- a/frontend/src/ClarifyClaims.jsx
+++ b/frontend/src/ClarifyClaims.jsx
@@ -3,10 +3,10 @@ import MainLayout from './components/MainLayout';
 import PageHeader from './components/PageHeader';
 import { API_BASE } from './api';
 
-export default function DocsPage() {
+export default function ClarifyClaims() {
   return (
-    <MainLayout title="Docs">
-      <PageHeader title="Developer Docs" subtitle="Integration Guide" />
+    <MainLayout title="ClarifyClaims">
+      <PageHeader title="ClarifyClaims" subtitle="Clarity in every claim." />
       <div className="space-y-6">
         <section>
           <h2 className="font-semibold text-lg">API Key Instructions</h2>

--- a/frontend/src/OperationsDashboard.js
+++ b/frontend/src/OperationsDashboard.js
@@ -349,8 +349,8 @@ function OperationsDashboard() {
                                   icon={<InboxIcon className="w-5 h-5" />}
                                   title="Claim Documents Pending"
                                   value={stats?.invoicesPending || 0}
-                                  cta="Go to Inbox"
-                                  onCta={() => navigate('/inbox')}
+                                  cta="Go to OpsClaim"
+                                  onCta={() => navigate('/opsclaim')}
                                 />
                               )}
                               {m === 'anomalies' && (

--- a/frontend/src/OpsClaim.js
+++ b/frontend/src/OpsClaim.js
@@ -15,7 +15,7 @@ import {
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
 
-export default function Inbox() {
+export default function OpsClaim() {
   const token = localStorage.getItem('token') || '';
   const tenant = localStorage.getItem('tenant') || 'default';
   const [invoices, setInvoices] = useState([]);
@@ -52,7 +52,7 @@ export default function Inbox() {
         throw new Error(`HTTP ${res.status}`);
       }
     } catch (err) {
-      console.error('Inbox fetch error:', err);
+      console.error('OpsClaim fetch error:', err);
     }
     setLoading(false);
   }, [token, tenant, headers]);
@@ -210,7 +210,7 @@ export default function Inbox() {
   const focusMode = copilotOpen || expandedRows.length > 0 || selectedRows.length > 0;
 
   return (
-    <MainLayout title="Inbox" helpTopic="inbox" collapseSidebar={focusMode}>
+    <MainLayout title="OpsClaim" helpTopic="opsclaim" collapseSidebar={focusMode}>
       {selectedRows.length > 0 && (
         <div className="mb-2 flex gap-2">
           <button onClick={bulkApprove} className="btn btn-ghost text-xs flex items-center gap-1">

--- a/frontend/src/components/BottomNav.js
+++ b/frontend/src/components/BottomNav.js
@@ -12,8 +12,18 @@ export default function BottomNav() {
   const location = useLocation();
   const items = [
     { to: '/operations', icon: HomeIcon, label: 'Home' },
-    { to: '/claims', icon: DocumentIcon, label: 'Claim Documents' },
-    { to: '/inbox', icon: InboxIcon, label: 'Inbox' },
+    {
+      to: '/claims',
+      icon: DocumentIcon,
+      label: 'ClarifyClaims',
+      title: 'Upload, validate, and summarize claims.',
+    },
+    {
+      to: '/opsclaim',
+      icon: InboxIcon,
+      label: 'OpsClaim',
+      title: 'Triage, route, and approve claims with live insights.',
+    },
     { to: '/review', icon: DocumentIcon, label: 'Review' },
     { to: '/archive', icon: ArchiveBoxIcon, label: 'Archive' },
   ];
@@ -25,6 +35,7 @@ export default function BottomNav() {
             <motion.div whileHover={{ scale: 1.1 }} className="py-2">
               <Link
                 to={to}
+                title={item.title}
                 className={`flex flex-col items-center text-xs ${
                   location.pathname === to ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-300'
                 }`}

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -55,17 +55,19 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
             </Link>
             <Link
               to="/claims"
+              title="ClarifyClaims: upload, validate, and summarize claims."
               className={`nav-link border-l-4 ${location.pathname === '/claims' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <FileText className="w-5 h-5" />
-              <span>Claim Documents</span>
+              <span>ClarifyClaims</span>
             </Link>
             <Link
-              to="/inbox"
-              className={`nav-link border-l-4 ${location.pathname === '/inbox' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
+              to="/opsclaim"
+              title="Triage, route, and approve claims with live insights."
+              className={`nav-link border-l-4 ${location.pathname === '/opsclaim' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <Inbox className="w-5 h-5" />
-              <span>Inbox</span>
+              <span>OpsClaim</span>
             </Link>
             <Link
               to="/vendors"
@@ -82,11 +84,12 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
               <span>AI Spend Analytics Hub</span>
             </Link>
             <Link
-              to="/audit"
-              className={`nav-link border-l-4 ${location.pathname === '/audit' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
+              to="/auditflow"
+              title="AuditFlow: risk and audit review for flagged claims."
+              className={`nav-link border-l-4 ${location.pathname === '/auditflow' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
             >
               <FileSearch className="w-5 h-5" />
-              <span>Audit</span>
+              <span>AuditFlow</span>
             </Link>
             <Link
               to="/builder"

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -7,7 +7,7 @@ import SharedDashboard from './SharedDashboard';
 import DashboardBuilder from './DashboardBuilder';
 import ExportTemplateBuilder from './ExportTemplateBuilder';
 import AISpendAnalyticsHub from './AISpendAnalyticsHub';
-import AuditDashboard from './AuditDashboard';
+import AuditFlow from './AuditFlow';
 import FraudReport from './FraudReport';
 import HumanReview from './HumanReview';
 import Archive from './Archive';
@@ -17,7 +17,7 @@ import WorkflowPage from './WorkflowPage';
 import WorkflowBuilderPage from './WorkflowBuilderPage';
 import Board from './Board';
 import KanbanDashboard from './KanbanDashboard';
-import Inbox from './Inbox';
+import OpsClaim from './OpsClaim';
 import NotFound from './NotFound';
 import ResultsViewer from './ResultsViewer';
 import ErrorBoundary from './ErrorBoundary';
@@ -27,7 +27,8 @@ import MultiUploadWizard from './MultiUploadWizard';
 import DemoSandbox from './DemoSandbox';
 import InstantTrial from './InstantTrial';
 import LoginPage from './LoginPage';
-import DocsPage from './DocsPage';
+import ClarifyClaims from './ClarifyClaims';
+import ClaimsBrandingPreview from './ClaimsBrandingPreview';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
@@ -119,9 +120,10 @@ function AnimatedRoutes() {
         <Route path="/adaptive" element={<PageWrapper><AdaptiveDashboard /></PageWrapper>} />
         <Route path="/dashboard/shared/:token" element={<PageWrapper><SharedDashboard /></PageWrapper>} />
         <Route path="/claims" element={<PageWrapper><ClaimsPage /></PageWrapper>} />
-        <Route path="/inbox" element={<PageWrapper><Inbox /></PageWrapper>} />
+        <Route path="/opsclaim" element={<PageWrapper><OpsClaim /></PageWrapper>} />
+        <Route path="/claims/branding-preview" element={<PageWrapper><ClaimsBrandingPreview /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><AISpendAnalyticsHub /></PageWrapper>} />
-        <Route path="/audit" element={<PageWrapper><AuditDashboard /></PageWrapper>} />
+        <Route path="/auditflow" element={<PageWrapper><AuditFlow /></PageWrapper>} />
         <Route path="/fraud" element={<PageWrapper><FraudReport /></PageWrapper>} />
         <Route path="/review" element={<PageWrapper><HumanReview /></PageWrapper>} />
         <Route path="/settings" element={<PageWrapper><TeamManagement /></PageWrapper>} />
@@ -137,7 +139,7 @@ function AnimatedRoutes() {
         <Route path="/onboarding" element={<PageWrapper><OnboardingWizard /></PageWrapper>} />
         <Route path="/sandbox" element={<PageWrapper><DemoSandbox /></PageWrapper>} />
         <Route path="/free-trial" element={<PageWrapper><InstantTrial /></PageWrapper>} />
-        <Route path="/docs" element={<PageWrapper><DocsPage /></PageWrapper>} />
+        <Route path="/clarifyclaims" element={<PageWrapper><ClarifyClaims /></PageWrapper>} />
         <Route path="/results/:id" element={<PageWrapper><ResultsViewer /></PageWrapper>} />
         <Route path="/login" element={<PageWrapper><LoginPage /></PageWrapper>} />
         <Route path="/" element={<PageWrapper><LandingPage /></PageWrapper>} />


### PR DESCRIPTION
## Summary
- Rebrand core pages: DocsPage → ClarifyClaims, AuditDashboard → AuditFlow, Inbox → OpsClaim
- Update routes and navigation to use new names
- Add claims naming guide
- Document sub-brand structure and marketing preview route

## Testing
- `npm install --legacy-peer-deps`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689423314ca4832eb049d5293ddac586