### PR TITLE
Add review workflow tools and audit trail

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -44,6 +44,7 @@ const eventRoutes = require('./routes/eventRoutes');
 const healthRoutes = require('./routes/healthRoutes');
 const logRoutes = require('./routes/logRoutes');
 const usageRoutes = require('./routes/usageRoutes');
+const auditRoutes = require('./routes/auditRoutes');
 
 // Middleware imports
 const { auditLog } = require('./middleware/auditMiddleware');
@@ -127,6 +128,7 @@ app.use(piiMask);
 // API Routes
 app.use('/api/claims', authRoutes);
 app.use('/api/invoices', authRoutes); // backwards compat
+app.use('/api/:tenantId/invoices', authRoutes);
 app.use('/api/:tenantId/export-templates', exportTemplateRoutes);
 app.use('/api/:tenantId/logo', brandingRoutes);
 app.use('/api/labs/feedback', feedbackRoutes);
@@ -145,11 +147,13 @@ app.use('/api/notifications', notificationRoutes);
 app.use('/api/reminders', reminderRoutes);
 app.use('/api/labs/automations', automationRoutes);
 app.use('/api/logs', logRoutes);
+app.use('/api/audit', auditRoutes);
 app.use('/api/tenants', tenantRoutes);
 app.use('/api/agents', agentRoutes);
 app.use('/api/ai', aiRoutes);
 app.use('/api/claims', claimRoutes);
 app.use('/api/invoices', claimRoutes); // backwards compat
+app.use('/api/:tenantId/invoices', claimRoutes);
 app.use('/api/timeline', timelineRoutes);
 app.use('/api/plugins', pluginRoutes);
 app.use('/api/compliance', complianceRoutes);

--- a/backend/routes/auditRoutes.js
+++ b/backend/routes/auditRoutes.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const { getAuditTrail } = require('../controllers/auditController');
+const { authMiddleware } = require('../controllers/userController');
+
+router.get('/', authMiddleware, getAuditTrail);
+
+module.exports = router;

--- a/backend/test/routes.test.js
+++ b/backend/test/routes.test.js
@@ -24,6 +24,7 @@ const feedbackRouter = express.Router();
 feedbackRouter.post('/api/claims/1/feedback', authMiddleware, (req, res) => res.json({ ok: true }));
 feedbackRouter.get('/api/claims/1/feedback', authMiddleware, (req, res) => res.json({}));
 feedbackRouter.get('/api/claims/1/review-notes', authMiddleware, (req, res) => res.json({ notes: [] }));
+feedbackRouter.get('/api/:tenantId/invoices/1/review-notes', authMiddleware, (req, res) => res.json({ notes: [] }));
 const analyticsRouter = express.Router();
 analyticsRouter.get('/api/analytics/claims', authMiddleware, (req, res) => res.json({}));
 analyticsRouter.get('/api/analytics/claims/fraud', authMiddleware, (req, res) => res.json({}));
@@ -94,6 +95,8 @@ describe('Auth and documents', () => {
     expect(res2.statusCode).toBe(401);
     const res3 = await request(app).get('/api/claims/1/review-notes');
     expect(res3.statusCode).toBe(401);
+    const res4 = await request(app).get('/api/default/invoices/1/review-notes');
+    expect(res4.statusCode).toBe(401);
   });
 
   test('claim analytics requires auth', async () => {

--- a/frontend/src/__tests__/OpsClaim.test.js
+++ b/frontend/src/__tests__/OpsClaim.test.js
@@ -1,0 +1,46 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import OpsClaim from '../OpsClaim';
+import { mockAuditLogs } from '../mocks/mockAuditLogs';
+
+jest.mock('../components/ChatSidebar', () => () => <div />);
+jest.mock('../components/MainLayout', () => ({ children }) => <div>{children}</div>);
+jest.mock('../components/Skeleton', () => ({ children }) => <div>{children}</div>);
+
+beforeEach(() => {
+  localStorage.setItem('token', 'fake-token');
+  localStorage.setItem('tenant', 'default');
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('audit trail popover fetches and displays log data', async () => {
+  const invoice = {
+    id: 1,
+    invoice_number: 'INV-001',
+    vendor: 'Vendor A',
+    amount: 100,
+    approval_status: 'Pending',
+    flagged_issues: 0,
+  };
+
+  global.fetch = jest.fn((url) => {
+    if (url.includes('/api/audit')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(mockAuditLogs) });
+    }
+    if (url.includes('/api/default/invoices?status=Pending')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([invoice]) });
+    }
+    return Promise.reject(new Error('unknown url'));
+  });
+
+  render(<OpsClaim />);
+
+  expect(await screen.findByText('INV-001')).toBeInTheDocument();
+  const auditBtn = screen.getByTitle('Audit Trail');
+  fireEvent.mouseEnter(auditBtn);
+  await waitFor(() => {
+    expect(screen.getByText(/Created invoice/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/NotesModal.js
+++ b/frontend/src/components/NotesModal.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { API_BASE } from '../api';
+
+export default function NotesModal({ invoice, open, onClose }) {
+  const token = localStorage.getItem('token') || '';
+  const tenant = localStorage.getItem('tenant') || 'default';
+  const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+  const [notes, setNotes] = useState([]);
+  const [newNote, setNewNote] = useState('');
+
+  useEffect(() => {
+    if (open && invoice) {
+      fetch(`${API_BASE}/api/${tenant}/invoices/${invoice.id}/review-notes`, { headers })
+        .then((res) => res.json())
+        .then((data) => setNotes(data.notes || []))
+        .catch(() => setNotes([]));
+    }
+  }, [open, invoice]);
+
+  const addNote = async () => {
+    if (!newNote.trim()) return;
+    await fetch(`${API_BASE}/api/${tenant}/invoices/${invoice.id}/review-notes`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ note: newNote })
+    }).catch(() => {});
+    setNewNote('');
+    try {
+      const res = await fetch(`${API_BASE}/api/${tenant}/invoices/${invoice.id}/review-notes`, { headers });
+      const data = await res.json();
+      setNotes(data.notes || []);
+    } catch {
+      // ignore
+    }
+  };
+
+  if (!open || !invoice) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-white rounded p-4 w-96 max-h-[80vh] overflow-y-auto">
+        <h2 className="text-lg font-semibold mb-2">Notes for {invoice.invoice_number}</h2>
+        <div className="mb-2 space-y-2">
+          {notes.length === 0 && <p className="text-sm text-gray-500">No notes yet.</p>}
+          {notes.map((n) => (
+            <div key={n.id} className="border p-2 rounded">
+              <p className="text-xs text-gray-500 mb-1">{new Date(n.created_at).toLocaleString()}</p>
+              <p className="text-sm">{n.note}</p>
+            </div>
+          ))}
+        </div>
+        <textarea
+          value={newNote}
+          onChange={(e) => setNewNote(e.target.value)}
+          rows={3}
+          className="w-full border p-1 text-sm mb-2"
+          placeholder="Add a note"
+        />
+        <div className="flex justify-end gap-2">
+          <button onClick={onClose} className="btn btn-ghost text-xs">Close</button>
+          <button onClick={addNote} className="btn btn-primary text-xs" disabled={!newNote.trim()}>Add</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/NotesModal.test.js
+++ b/frontend/src/components/__tests__/NotesModal.test.js
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import NotesModal from '../NotesModal';
+import { mockReviewNotes } from '../../mocks/mockReviewNotes';
+
+beforeEach(() => {
+  localStorage.setItem('token', 'fake-token');
+  localStorage.setItem('tenant', 'default');
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('loads and posts notes correctly', async () => {
+  const invoice = { id: 1, invoice_number: 'INV-001' };
+  let notes = [...mockReviewNotes];
+  global.fetch = jest.fn((url, options = {}) => {
+    if (url.includes('/review-notes')) {
+      if (options.method === 'POST') {
+        const body = JSON.parse(options.body);
+        notes.push({ id: notes.length + 1, note: body.note, created_at: '2024-01-02T00:00:00Z' });
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ notes }) });
+    }
+    return Promise.reject(new Error('unknown url'));
+  });
+
+  render(<NotesModal invoice={invoice} open={true} onClose={() => {}} />);
+
+  expect(await screen.findByText('Initial note')).toBeInTheDocument();
+  fireEvent.change(screen.getByPlaceholderText('Add a note'), {
+    target: { value: 'Another note' },
+  });
+  fireEvent.click(screen.getByText('Add'));
+  await waitFor(() => {
+    expect(screen.getByText('Another note')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/mocks/mockAuditLogs.js
+++ b/frontend/src/mocks/mockAuditLogs.js
@@ -1,0 +1,8 @@
+export const mockAuditLogs = [
+  {
+    id: 1,
+    created_at: '2024-01-01T00:00:00Z',
+    action: 'Created invoice',
+    username: 'alice'
+  },
+];

--- a/frontend/src/mocks/mockReviewNotes.js
+++ b/frontend/src/mocks/mockReviewNotes.js
@@ -1,0 +1,7 @@
+export const mockReviewNotes = [
+  {
+    id: 1,
+    created_at: '2024-01-01T00:00:00Z',
+    note: 'Initial note'
+  },
+];


### PR DESCRIPTION
## Summary
- expose backend audit log API
- add notes modal for claim review
- enrich OpsClaim with status chips, AI insights, review buttons, and audit trail popover
- add frontend tests for audit trail popover and notes modal
- serve review notes at tenant-scoped invoice endpoint

## Testing
- `npm test` (backend)
- `npm install --legacy-peer-deps` (frontend dependencies)
- `npm test -- --watchAll=false` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_6894f96e824c832e8d59f4efb5d7e84c