### PR TITLE
feat: add claim dashboards

### DIFF
--- a/backend/controllers/claimController.js
+++ b/backend/controllers/claimController.js
@@ -19,7 +19,9 @@ const {
   fieldExtractCounter,
   exportAttemptCounter,
   feedbackFlaggedCounter,
-  extractDuration
+  extractDuration,
+  claimMetricsDuration,
+  claimMetricsErrorCounter
 } = require('../metrics');
 
 async function refreshSearchable(id) {
@@ -698,5 +700,75 @@ exports.exportClaims = async (req, res) => {
   } catch (err) {
     console.error('Claims export error:', err);
     res.status(500).json({ message: 'Failed to export claims' });
+  }
+};
+
+exports.getClaimMetrics = async (req, res) => {
+  const { from, to } = req.query;
+  const params = [];
+  let where =
+    "doc_type IN ('claim_invoice','medical_bill','fnol_form')";
+  if (from) {
+    params.push(new Date(from));
+    where += ` AND created_at >= $${params.length}`;
+  }
+  if (to) {
+    params.push(new Date(to));
+    where += ` AND created_at <= $${params.length}`;
+  }
+  const endTimer = claimMetricsDuration.startTimer();
+  const requestId = req.headers['x-request-id'] || crypto.randomUUID();
+  res.set('X-Request-Id', requestId);
+  logger.info('Claim metrics requested', { request_id: requestId, from, to });
+  try {
+    const totalRes = await pool.query(
+      `SELECT COUNT(*) AS total,
+              COUNT(*) FILTER (WHERE status = 'Flagged') AS flagged
+         FROM documents WHERE ${where}`,
+      params
+    );
+    const statusRes = await pool.query(
+      `SELECT status, COUNT(*)::int AS count
+         FROM documents WHERE ${where} GROUP BY status`,
+      params
+    );
+    const durationRes = await pool.query(
+      `SELECT
+          AVG(EXTRACT(EPOCH FROM (updated_at - created_at)) / 3600) AS avg,
+          PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (updated_at - created_at)) / 3600) AS p50,
+          PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (updated_at - created_at)) / 3600) AS p90,
+          PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (updated_at - created_at)) / 3600) AS p99
+        FROM documents
+        WHERE ${where} AND status IN ('Approved','Rejected','Closed')`,
+      params
+    );
+    const total = parseInt(totalRes.rows[0].total, 10) || 0;
+    const flagged = parseInt(totalRes.rows[0].flagged, 10) || 0;
+    const status_counts = {};
+    statusRes.rows.forEach((r) => {
+      if (r.count >= 5) status_counts[r.status || 'Unknown'] = r.count;
+    });
+    res.set('Cache-Control', 'public, max-age=30');
+    res.json({
+      window: { from: from || null, to: to || null, timezone: 'UTC' },
+      definitions: {
+        flagged: "status = 'Flagged'",
+        avg_processing_hours:
+          'mean hours between created_at and updated_at for closed claims',
+      },
+      total,
+      flagged_rate: total ? flagged / total : 0,
+      avg_processing_hours: Number(durationRes.rows[0].avg) || 0,
+      p50_processing_hours: Number(durationRes.rows[0].p50) || 0,
+      p90_processing_hours: Number(durationRes.rows[0].p90) || 0,
+      p99_processing_hours: Number(durationRes.rows[0].p99) || 0,
+      status_counts,
+    });
+    endTimer();
+  } catch (err) {
+    claimMetricsErrorCounter.inc();
+    endTimer();
+    console.error('Claim metrics error:', err);
+    res.status(500).json({ message: 'Failed to fetch claim metrics' });
   }
 };

--- a/backend/controllers/claimController.js
+++ b/backend/controllers/claimController.js
@@ -749,6 +749,11 @@ exports.getClaimMetrics = async (req, res) => {
       if (r.count >= 5) status_counts[r.status || 'Unknown'] = r.count;
     });
     res.set('Cache-Control', 'public, max-age=30');
+    const { avg, p50, p90, p99 } = durationRes.rows[0] || {};
+    const toNumber = (val) => {
+      const num = Number(val);
+      return Number.isFinite(num) ? num : 0;
+    };
     res.json({
       window: { from: from || null, to: to || null, timezone: 'UTC' },
       definitions: {
@@ -758,10 +763,10 @@ exports.getClaimMetrics = async (req, res) => {
       },
       total,
       flagged_rate: total ? flagged / total : 0,
-      avg_processing_hours: Number(durationRes.rows[0].avg) || 0,
-      p50_processing_hours: Number(durationRes.rows[0].p50) || 0,
-      p90_processing_hours: Number(durationRes.rows[0].p90) || 0,
-      p99_processing_hours: Number(durationRes.rows[0].p99) || 0,
+      avg_processing_hours: toNumber(avg),
+      p50_processing_hours: toNumber(p50),
+      p90_processing_hours: toNumber(p90),
+      p99_processing_hours: toNumber(p99),
       status_counts,
     });
     endTimer();

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -90,6 +90,76 @@
         }
       }
     },
+    "/api/claims/metrics": {
+      "get": {
+        "summary": "Aggregated claim metrics",
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "description": "Start of window (inclusive, UTC)"
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "format": "date-time" },
+            "description": "End of window (inclusive, UTC)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Metrics for claims in window",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "window": {
+                      "type": "object",
+                      "properties": {
+                        "from": { "type": "string", "format": "date-time" },
+                        "to": { "type": "string", "format": "date-time" },
+                        "timezone": { "type": "string" }
+                      }
+                    },
+                    "definitions": { "type": "object" },
+                    "total": { "type": "integer" },
+                    "flagged_rate": { "type": "number" },
+                    "avg_processing_hours": { "type": "number" },
+                    "p50_processing_hours": { "type": "number" },
+                    "p90_processing_hours": { "type": "number" },
+                    "p99_processing_hours": { "type": "number" },
+                    "status_counts": { "type": "object" }
+                  }
+                },
+                "examples": {
+                  "24h": {
+                    "value": {
+                      "window": {
+                        "from": "2024-01-09T00:00:00Z",
+                        "to": "2024-01-10T00:00:00Z",
+                        "timezone": "UTC"
+                      },
+                      "definitions": { "flagged": "status = 'Flagged'" },
+                      "total": 10,
+                      "flagged_rate": 0.2,
+                      "avg_processing_hours": 12,
+                      "p50_processing_hours": 8,
+                      "p90_processing_hours": 20,
+                      "p99_processing_hours": 30,
+                      "status_counts": { "Pending": 5, "Approved": 5 }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/claims/summarize-errors": {
       "post": {
         "summary": "AI summarize CSV errors",

--- a/backend/metrics.js
+++ b/backend/metrics.js
@@ -48,6 +48,16 @@ const exportDuration = new client.Histogram({
   labelNames: ['export_type'],
 });
 
+const claimMetricsDuration = new client.Histogram({
+  name: 'claim_metrics_latency_seconds',
+  help: 'Latency of claim metrics endpoint',
+});
+
+const claimMetricsErrorCounter = new client.Counter({
+  name: 'claim_metrics_error_total',
+  help: 'Total errors from claim metrics endpoint',
+});
+
 // Usage tracking metrics
 const usageLimitExceededCounter = new client.Counter({
   name: 'usage_limit_exceeded_total',
@@ -83,6 +93,8 @@ module.exports = {
   activeUsersGauge,
   extractDuration,
   exportDuration,
+  claimMetricsDuration,
+  claimMetricsErrorCounter,
   usageLimitExceededCounter,
   usageTrackingCounter,
   usageRemainingGauge,

--- a/backend/routes/claimRoutes.js
+++ b/backend/routes/claimRoutes.js
@@ -24,6 +24,7 @@ const {
   getReviewQueue,
   updateStatus,
   exportClaims,
+  getClaimMetrics,
 } = require('../controllers/claimController');
 const { authMiddleware, authorizeRoles } = require('../controllers/userController');
 
@@ -57,6 +58,12 @@ router.post('/:id/compliance', authMiddleware, checkCompliance);
 router.get('/totals-by-entity', authMiddleware, getEntityTotals);
 router.get('/search', authMiddleware, searchDocuments);
 router.get('/review-queue', authMiddleware, getReviewQueue);
+router.get(
+  '/metrics',
+  authMiddleware,
+  authorizeRoles('admin', 'internal_ops'),
+  getClaimMetrics
+);
 router.get('/report/pdf', authMiddleware, exportSummaryPDF);
 router.post('/export', authMiddleware, exportClaims);
 router.patch('/:id/status', authMiddleware, authorizeRoles('admin', 'internal_ops', 'adjuster'), updateStatus);

--- a/backend/test/claimMetrics.test.js
+++ b/backend/test/claimMetrics.test.js
@@ -1,0 +1,54 @@
+const { getClaimMetrics } = require('../controllers/claimController');
+const pool = require('../config/db');
+
+jest.mock('../config/db', () => ({ query: jest.fn() }));
+
+describe('getClaimMetrics', () => {
+  const res = {
+    json: jest.fn(),
+    status: jest.fn().mockReturnThis(),
+    set: jest.fn(),
+  };
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('aggregates metrics and echoes window', async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ total: '2', flagged: '1' }] })
+      .mockResolvedValueOnce({ rows: [{ status: 'Pending', count: 5 }] })
+      .mockResolvedValueOnce({
+        rows: [{ avg: 1, p50: 0.5, p90: 2, p99: 3 }],
+      });
+    await getClaimMetrics({ query: { from: '2024-01-01', to: '2024-01-02' }, headers: {} }, res);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        window: { from: '2024-01-01', to: '2024-01-02', timezone: 'UTC' },
+        total: 2,
+        flagged_rate: 0.5,
+        p99_processing_hours: 3,
+      })
+    );
+  });
+
+  test('handles empty window', async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ total: '0', flagged: '0' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ avg: null, p50: null, p90: null, p99: null }] });
+    await getClaimMetrics({ query: {}, headers: {} }, res);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ total: 0, flagged_rate: 0 })
+    );
+  });
+
+  test('queries only closed statuses for duration', async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ total: '1', flagged: '0' }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ avg: 0, p50: 0, p90: 0, p99: 0 }] });
+    await getClaimMetrics({ query: {}, headers: {} }, res);
+    const sql = pool.query.mock.calls[2][0];
+    expect(sql).toMatch(/status IN \('Approved','Rejected','Closed'\)/);
+  });
+});

--- a/frontend/src/ClarifyClaims.jsx
+++ b/frontend/src/ClarifyClaims.jsx
@@ -1,35 +1,145 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import MainLayout from './components/MainLayout';
-import PageHeader from './components/PageHeader';
+import StatCard from './components/StatCard.jsx';
+import { Card } from './components/ui/Card';
 import { API_BASE } from './api';
+import {
+  ClipboardDocumentListIcon,
+  ExclamationTriangleIcon,
+  ClockIcon,
+  ChartPieIcon,
+} from '@heroicons/react/24/outline';
+import useSWR from 'swr';
+import { useNavigate } from 'react-router-dom';
+import Skeleton from './components/Skeleton';
 
 export default function ClarifyClaims() {
+  const token = localStorage.getItem('token') || '';
+  const [range, setRange] = useState('7d');
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const navigate = useNavigate();
+
+  const { from, to } = useMemo(() => {
+    const toDate = new Date();
+    const fromDate = new Date();
+    if (range === '24h') fromDate.setDate(toDate.getDate() - 1);
+    else if (range === '7d') fromDate.setDate(toDate.getDate() - 7);
+    else if (range === '30d') fromDate.setDate(toDate.getDate() - 30);
+    toDate.setSeconds(0, 0);
+    fromDate.setSeconds(0, 0);
+    return { from: fromDate.toISOString(), to: toDate.toISOString() };
+  }, [range]);
+
+  const fetcher = (url) =>
+    fetch(url, { headers: { Authorization: `Bearer ${token}` } }).then((r) =>
+      r.json()
+    );
+
+  const { data, error, isLoading, mutate } = useSWR(
+    token ? [`${API_BASE}/api/claims/metrics?from=${from}&to=${to}`, token] : null,
+    ([url]) => fetcher(url),
+    { refreshInterval: 60000, revalidateOnFocus: true }
+  );
+
+  useEffect(() => {
+    const handler = () => mutate();
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [mutate]);
+
+  useEffect(() => {
+    if (data) setLastUpdated(new Date());
+  }, [data]);
+
+  const total = data?.total ?? 0;
+  const percentFlagged = data
+    ? `${(data.flagged_rate * 100).toFixed(1)}%`
+    : '0%';
+  const avgProcessing = data
+    ? `${data.avg_processing_hours.toFixed(1)}h`
+    : '0h';
+  const statusBreakdown = data?.status_counts || {};
+
+  const drillToQueue = (opts = {}) => {
+    const params = new URLSearchParams({ from, to });
+    if (opts.flagged) params.set('flagged', 'true');
+    if (opts.status) params.set('status', opts.status);
+    navigate(`/opsclaim?${params.toString()}`);
+  };
+
   return (
     <MainLayout title="ClarifyClaims">
-      <PageHeader title="ClarifyClaims" subtitle="Clarity in every claim." />
       <div className="space-y-6">
-        <section>
-          <h2 className="font-semibold text-lg">API Key Instructions</h2>
-          <p className="text-sm">Generate a key in Settings and include it in requests:</p>
-          <pre className="bg-gray-100 p-2 rounded text-xs whitespace-pre-wrap">
-Authorization: Bearer YOUR_KEY
-          </pre>
-        </section>
-        <section>
-          <h2 className="font-semibold text-lg">Claim Upload Example</h2>
-          <pre className="bg-gray-100 p-2 rounded text-xs whitespace-pre-wrap">
-curl -X POST -H "Authorization: Bearer YOUR_KEY" \
-     -F file=@claim.pdf {API_BASE}/api/claims
-          </pre>
-        </section>
-        <section>
-          <h2 className="font-semibold text-lg">Export Formats</h2>
-          <p className="text-sm">Export claim data as CSV or JSON from the dashboard or via the export endpoint.</p>
-        </section>
-        <section>
-          <h2 className="font-semibold text-lg">Status Lifecycle</h2>
-          <p className="text-sm">Claims move through pending, processing and done statuses. Failed extractions show an error state.</p>
-        </section>
+        <h1 className="text-2xl font-semibold">ClarifyClaims Summary</h1>
+        <div className="flex items-center gap-2 text-sm">
+          <select
+            value={range}
+            onChange={(e) => setRange(e.target.value)}
+            className="border rounded p-1"
+          >
+            <option value="24h">Last 24h</option>
+            <option value="7d">Last 7d</option>
+            <option value="30d">Last 30d</option>
+          </select>
+          <button onClick={() => mutate()} className="text-indigo-600">
+            Refresh
+          </button>
+          {lastUpdated && (
+            <span className="ml-auto text-gray-500">
+              Last updated {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+        </div>
+        {error && (
+          <div className="bg-red-100 text-red-700 p-2 text-sm rounded flex items-center gap-2">
+            <span>Failed to load metrics.</span>
+            <button onClick={() => mutate()} className="underline">
+              Retry
+            </button>
+          </div>
+        )}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <StatCard
+            icon={<ClipboardDocumentListIcon className="w-6 h-6" />}
+            title="Total Claims"
+            value={isLoading ? <Skeleton rows={1} className="w-16" /> : total}
+            onClick={() => drillToQueue()}
+          />
+          <StatCard
+            icon={<ExclamationTriangleIcon className="w-6 h-6" />}
+            title="% Flagged"
+            value={isLoading ? <Skeleton rows={1} className="w-16" /> : percentFlagged}
+            onClick={() => drillToQueue({ flagged: true })}
+          />
+          <StatCard
+            icon={<ClockIcon className="w-6 h-6" />}
+            title="Avg. Processing Time"
+            value={
+              isLoading ? <Skeleton rows={1} className="w-16" /> : avgProcessing
+            }
+          />
+        </div>
+        <Card>
+          <div className="flex items-center gap-2 mb-2">
+            <ChartPieIcon className="w-5 h-5 text-indigo-600" />
+            <h2 className="font-semibold">Claim Status Breakdown</h2>
+          </div>
+          <ul className="text-sm">
+            {isLoading && <Skeleton rows={3} />}
+            {!isLoading &&
+              Object.entries(statusBreakdown).map(([s, count]) => (
+                <li key={s}>
+                  <button
+                    onClick={() => drillToQueue({ status: s })}
+                    className="hover:underline"
+                  >
+                    {s}: {count}
+                  </button>
+                </li>
+              ))}
+            {!isLoading && !Object.keys(statusBreakdown).length && <li>No data</li>}
+          </ul>
+        </Card>
       </div>
     </MainLayout>
   );

--- a/frontend/src/__tests__/ClarifyClaims.test.jsx
+++ b/frontend/src/__tests__/ClarifyClaims.test.jsx
@@ -1,0 +1,71 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import ClarifyClaims from '../ClarifyClaims';
+import { API_BASE } from '../api';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../components/MainLayout', () => ({ children }) => <div>{children}</div>);
+jest.mock('../components/StatCard.jsx', () => ({ title, value, onClick }) => (
+  <div onClick={onClick}>
+    <span>{title}</span>
+    <span>{value}</span>
+  </div>
+));
+jest.mock('../components/ui/Card', () => ({ Card: ({ children }) => <div>{children}</div> }));
+
+beforeEach(() => {
+  localStorage.setItem('token', 'test-token');
+  jest.useFakeTimers().setSystemTime(new Date('2024-01-10T00:00:45Z'));
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+  jest.useRealTimers();
+});
+
+test('fetches metrics for range, allows drilldown and refetch', async () => {
+  const metrics = {
+    total: 3,
+    flagged_rate: 2 / 3,
+    avg_processing_hours: 28,
+    status_counts: { Pending: 1, Approved: 1, Flagged: 1 },
+  };
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(metrics) })
+  );
+
+  await act(async () => {
+    render(<ClarifyClaims />);
+  });
+
+  const from7d = '2024-01-03T00:00:00.000Z';
+  const to = '2024-01-10T00:00:00.000Z';
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  expect(fetch).toHaveBeenCalledWith(
+    `${API_BASE}/api/claims/metrics?from=${from7d}&to=${to}`,
+    expect.any(Object)
+  );
+
+  const totalLabel = await screen.findByText('Total Claims');
+  expect(totalLabel.nextSibling.textContent).toBe('3');
+  const flaggedLabel = screen.getByText('% Flagged');
+  expect(flaggedLabel.nextSibling.textContent).toBe('66.7%');
+
+  fireEvent.click(flaggedLabel.parentElement);
+  expect(mockNavigate).toHaveBeenCalledWith(
+    `/opsclaim?from=${encodeURIComponent(from7d)}&to=${encodeURIComponent(to)}&flagged=true`
+  );
+
+  fetch.mockClear();
+  fireEvent.change(screen.getByRole('combobox'), { target: { value: '24h' } });
+  const from24h = '2024-01-09T00:00:00.000Z';
+  await waitFor(() => expect(fetch).toHaveBeenCalled());
+  expect(fetch).toHaveBeenCalledWith(
+    `${API_BASE}/api/claims/metrics?from=${from24h}&to=${to}`,
+    expect.any(Object)
+  );
+});

--- a/frontend/src/__tests__/OpsClaim.test.js
+++ b/frontend/src/__tests__/OpsClaim.test.js
@@ -1,6 +1,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import OpsClaim from '../OpsClaim';
 import { mockAuditLogs } from '../mocks/mockAuditLogs';
+import { API_BASE } from '../api';
 
 jest.mock('../components/ChatSidebar', () => () => <div />);
 jest.mock('../components/MainLayout', () => ({ children }) => <div>{children}</div>);
@@ -16,9 +18,9 @@ afterEach(() => {
 });
 
 test('audit trail popover fetches and displays log data', async () => {
-  const invoice = {
+  const claim = {
     id: 1,
-    invoice_number: 'INV-001',
+    claim_number: 'CLM-001',
     vendor: 'Vendor A',
     amount: 100,
     approval_status: 'Pending',
@@ -29,18 +31,102 @@ test('audit trail popover fetches and displays log data', async () => {
     if (url.includes('/api/audit')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve(mockAuditLogs) });
     }
-    if (url.includes('/api/default/invoices?status=Pending')) {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve([invoice]) });
+    if (url.includes('/api/default/claims?status=Pending')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([claim]) });
     }
     return Promise.reject(new Error('unknown url'));
   });
 
-  render(<OpsClaim />);
+  render(
+    <MemoryRouter initialEntries={['/opsclaim']}>
+      <OpsClaim />
+    </MemoryRouter>
+  );
 
-  expect(await screen.findByText('INV-001')).toBeInTheDocument();
+  expect(await screen.findByText('CLM-001')).toBeInTheDocument();
   const auditBtn = screen.getByTitle('Audit Trail');
   fireEvent.mouseEnter(auditBtn);
   await waitFor(() => {
     expect(screen.getByText(/Created invoice/)).toBeInTheDocument();
   });
+});
+
+test('applies flagged filter from query string', async () => {
+  const claims = [
+    {
+      id: 1,
+      claim_number: 'CLM-001',
+      vendor: 'Vendor A',
+      amount: 100,
+      approval_status: 'Pending',
+      flagged: true,
+      flagged_issues: 0,
+    },
+    {
+      id: 2,
+      claim_number: 'CLM-002',
+      vendor: 'Vendor B',
+      amount: 50,
+      approval_status: 'Pending',
+      flagged: false,
+      flagged_issues: 0,
+    },
+  ];
+
+  global.fetch = jest.fn((url) => {
+    if (url.includes('/api/default/claims?status=Pending')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(claims) });
+    }
+    return Promise.reject(new Error('unknown url'));
+  });
+
+  render(
+    <MemoryRouter initialEntries={['/opsclaim?flagged=true']}>
+      <OpsClaim />
+    </MemoryRouter>
+  );
+
+  expect(await screen.findByText('CLM-001')).toBeInTheDocument();
+  expect(screen.queryByText('CLM-002')).toBeNull();
+});
+
+test('includes from/to parameters when present', async () => {
+  const claim = {
+    id: 1,
+    claim_number: 'CLM-001',
+    vendor: 'Vendor A',
+    amount: 100,
+    approval_status: 'Pending',
+    flagged_issues: 0,
+  };
+  const from = '2024-01-03T00:00:00.000Z';
+  const to = '2024-01-10T00:00:00.000Z';
+
+  global.fetch = jest.fn((url) => {
+    if (
+      url ===
+      `${API_BASE}/api/default/claims?status=Pending&from=${encodeURIComponent(
+        from
+      )}&to=${encodeURIComponent(to)}`
+    ) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([claim]) });
+    }
+    return Promise.reject(new Error('unknown url'));
+  });
+
+  render(
+    <MemoryRouter
+      initialEntries={[`/opsclaim?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`]}
+    >
+      <OpsClaim />
+    </MemoryRouter>
+  );
+
+  expect(await screen.findByText('CLM-001')).toBeInTheDocument();
+  expect(fetch).toHaveBeenCalledWith(
+    `${API_BASE}/api/default/claims?status=Pending&from=${encodeURIComponent(
+      from
+    )}&to=${encodeURIComponent(to)}`,
+    expect.any(Object)
+  );
 });

--- a/frontend/src/components/StatCard.jsx
+++ b/frontend/src/components/StatCard.jsx
@@ -17,6 +17,7 @@ export default function StatCard({
   onCta,
   badge,
   children,
+  onClick,
 }) {
   const TrendIcon =
     typeof trend === 'number'
@@ -36,7 +37,13 @@ export default function StatCard({
       : 'text-gray-500';
 
   return (
-    <Card className="p-6 flex flex-col gap-2 relative">
+    <Card
+      onClick={onClick}
+      className={cn(
+        'p-6 flex flex-col gap-2 relative',
+        onClick && 'cursor-pointer'
+      )}
+    >
       <div className="flex items-start gap-1">
         {icon && <span className="text-indigo-600">{icon}</span>}
         <span className="text-xs text-gray-500 dark:text-gray-400 flex-1">


### PR DESCRIPTION
## Summary
- refine claim metrics endpoint with explicit window echo, metric definitions, p50/p90/p99 stats, caching, logging, and Prometheus counters
- align ClarifyClaims and OpsClaim on minute-snapped time ranges with shared from/to params, error handling, and revalidation
- gate metrics behind RBAC and document `/api/claims/metrics` in OpenAPI

## Testing
- `npm install --legacy-peer-deps`
- `cd frontend && npm test -- --watchAll=false`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689526e59e20832ea708be1979f7e044