### PR TITLE
feat: add design tokens and theme support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 .env
 dist/
 build/
+frontend/test-results/
+frontend/tests/__screenshots__/
 
 # macOS
 .DS_Store

--- a/frontend/.stylelintignore
+++ b/frontend/.stylelintignore
@@ -1,0 +1,2 @@
+src/styles/tokens.css
+src/App.css

--- a/frontend/.stylelintrc.json
+++ b/frontend/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["stylelint-color-format"],
+  "rules": {
+    "color-format/format": {"format": "rgb"}
+  }
+}

--- a/frontend/docs/tokens.md
+++ b/frontend/docs/tokens.md
@@ -1,0 +1,29 @@
+# Using Design Tokens
+
+Design tokens live in `src/styles/tokens.css` and expose semantic CSS variables
+for colors, spacing, typography, motion and more. Tailwind is configured to map
+its theme extensions to these variables so utilities like `bg-surface` and
+`text-ink` reference the tokens instead of hard‑coded values.
+
+The current token version is defined by `--token-version` (presently `1`).
+Increment this when introducing breaking palette changes.
+
+## In CSS
+
+```css
+.my-card {
+  background: var(--bg-surface);
+  color: var(--text-default);
+  box-shadow: var(--shadow-e1);
+}
+```
+
+## In Tailwind
+
+```jsx
+<div className="bg-surface text-ink p-4 shadow-e1">Hello</div>
+```
+
+Accent color, font family and theme mode can be customized through the built-in
+ThemePicker component. These selections are persisted to `localStorage` and
+applied on page load to avoid flashes.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,8 +58,12 @@
         "postcss": "^8.5.3",
         "semver": "^7.5.4",
         "storybook": "^8.1.0",
+        "stylelint": "^16.23.1",
+        "stylelint-color-format": "^1.1.0",
+        "stylelint-config-standard": "^39.0.0",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "wcag-contrast": "^3.0.0"
       },
       "engines": {
         "node": "18.x"
@@ -2137,6 +2141,73 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "license": "MIT"
     },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/media-query-list-parser": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+      "integrity": "sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
     "node_modules/@csstools/normalize.css": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-12.1.1.tgz",
@@ -2421,6 +2492,17 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@dual-bundle/import-meta-resolve": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-+nxncfwHM5SgAtrVzgpzJOI1ol0PkumhVo469KCf9lUi21IGcY90G98VuHm9VRrUypmAzawAHO9bs6hqeADaVg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -3656,6 +3738,13 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@keyv/serialize": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.0.tgz",
+      "integrity": "sha512-RlDgexML7Z63Q8BSaqhXdCYNBy/JQnqYIwxofUrNLGCblOMHp+xux2Q8nLMLlPpgHQPoU0Do8Z6btCpRBEqZ8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -6898,6 +6987,16 @@
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "license": "MIT"
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -7530,6 +7629,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cacheable": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-1.10.3.tgz",
+      "integrity": "sha512-M6p10iJ/VT0wT7TLIGUnm958oVrU2cUK8pQAVU21Zu7h8rbk/PeRtRWrvHJBql97Bhzk3g1N6+2VKC+Rjxna9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.10.0",
+        "keyv": "^5.4.0"
+      }
+    },
+    "node_modules/cacheable/node_modules/keyv": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.0.tgz",
+      "integrity": "sha512-QG7qR2tijh1ftOvClut4YKKg1iW6cx3GZsKoGyJPxHkGWK9oJhG9P3j5deP0QQOGDowBMVQFaP+Vm4NpGYvmIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@keyv/serialize": "^1.1.0"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -7953,6 +8073,17 @@
       "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7969,6 +8100,34 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/colord": {
@@ -8256,6 +8415,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
+      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12 || >=16"
       }
     },
     "node_modules/css-has-pseudo": {
@@ -9498,6 +9667,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -10390,6 +10569,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -10669,6 +10858,16 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -11542,6 +11741,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -11704,6 +11910,13 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/hookified": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-1.11.0.tgz",
+      "integrity": "sha512-aDdIN3GyU5I6wextPplYdfmWCo+aLmjjVbntmX6HLD5RCi/xKsivYEBhnRD+d9224zFf008ZpLMPlWF0ZodYZw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -11823,6 +12036,19 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-tags": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+      "integrity": "sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -12525,6 +12751,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -14040,6 +14276,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/known-css-properties": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+      "integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
@@ -14442,6 +14685,13 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -14574,6 +14824,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -14615,6 +14876,19 @@
       "license": "MIT",
       "dependencies": {
         "map-or-similar": "^1.5.0"
+      }
+    },
+    "node_modules/meow": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+      "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge-descriptors": {
@@ -16789,6 +17063,40 @@
         "postcss": "^8.0.3"
       }
     },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+      "integrity": "sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+      "integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.31"
+      }
+    },
     "node_modules/postcss-selector-not": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-6.0.1.tgz",
@@ -17986,6 +18294,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/relative-luminance": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/relative-luminance/-/relative-luminance-2.0.1.tgz",
+      "integrity": "sha512-wFuITNthJilFPwkK7gNJcULxXBcfFZvZORsvdvxeOdO44wCeZnuQkf3nFFzOR/dpJNxYsdRZJLsepWbyKhnMww==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esm": "^3.0.84"
+      }
+    },
     "node_modules/renderkid": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -18778,6 +19096,23 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -18791,6 +19126,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
     "node_modules/socket.io-client": {
@@ -19450,6 +19803,13 @@
         "webpack": "^5.0.0"
       }
     },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/stylehacks": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
@@ -19464,6 +19824,333 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
+      }
+    },
+    "node_modules/stylelint": {
+      "version": "16.23.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.23.1.tgz",
+      "integrity": "sha512-dNvDTsKV1U2YtiUDfe9d2gp902veFeo3ecCWdGlmLm2WFrAV0+L5LoOj/qHSBABQwMsZPJwfC4bf39mQm1S5zw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "@csstools/media-query-list-parser": "^4.0.3",
+        "@csstools/selector-specificity": "^5.0.0",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.3",
+        "cosmiconfig": "^9.0.0",
+        "css-functions-list": "^3.2.3",
+        "css-tree": "^3.1.0",
+        "debug": "^4.4.1",
+        "fast-glob": "^3.3.3",
+        "fastest-levenshtein": "^1.0.16",
+        "file-entry-cache": "^10.1.3",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.3.1",
+        "ignore": "^7.0.5",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.37.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^13.2.0",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.5.6",
+        "postcss-resolve-nested-selector": "^0.1.6",
+        "postcss-safe-parser": "^7.0.1",
+        "postcss-selector-parser": "^7.1.0",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "supports-hyperlinks": "^3.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.9.0",
+        "write-file-atomic": "^5.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.mjs"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/stylelint-color-format": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-color-format/-/stylelint-color-format-1.1.0.tgz",
+      "integrity": "sha512-3VLzcNjspKuUcZJz6MsIrwf3cQfR1HPXf+skZ11ayvhTQscgmwRz6gVgiqxkbz6TLGMkkVsqP7UkVdBqznkMcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^3.0.0",
+        "style-search": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=7"
+      },
+      "peerDependencies": {
+        "stylelint": ">=8.0.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-17.0.0.tgz",
+      "integrity": "sha512-WaMSdEiPfZTSFVoYmJbxorJfA610O0tlYuU2aEwY33UQhSPgFbClrVJYWvy3jGJx+XW37O+LyNLiZOEXhKhJmA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.23.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "39.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-39.0.0.tgz",
+      "integrity": "sha512-JabShWORb8Bmc1A47ZyJstran60P3yUdI1zWMpGYPeFiC6xzHXJMkpKAd8EjIhq3HPUplIWWMDJ/xu0AiPd+kA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/stylelint"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/stylelint"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "stylelint-config-recommended": "^17.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^16.23.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/@csstools/selector-specificity": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylelint/node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/stylelint/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/file-entry-cache": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-10.1.3.tgz",
+      "integrity": "sha512-D+w75Ub8T55yor7fPgN06rkCAUbAYw2vpxJmmjv/GDAcvCnv9g7IvHhIZoxzRZThrXPFI2maeY24pPbtyYU7Lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^6.1.12"
+      }
+    },
+    "node_modules/stylelint/node_modules/flat-cache": {
+      "version": "6.1.12",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.12.tgz",
+      "integrity": "sha512-U+HqqpZPPXP5d24bWuRzjGqVqUcw64k4nZAbruniDwdRg0H10tvN7H6ku1tjhA4rg5B9GS3siEvwO2qjJJ6f8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cacheable": "^1.10.3",
+        "flatted": "^3.3.3",
+        "hookified": "^1.10.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/stylelint/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/stylelint/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/stylelint/node_modules/postcss-selector-parser": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/stylelint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/stylelint/node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/stylelint/node_modules/write-file-atomic": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/stylis": {
@@ -19589,6 +20276,12 @@
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
       "license": "MIT"
+    },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
     },
     "node_modules/svgo": {
       "version": "1.3.2",
@@ -19766,6 +20459,23 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -20807,6 +21517,16 @@
       "license": "MIT",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/wcag-contrast": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/wcag-contrast/-/wcag-contrast-3.0.0.tgz",
+      "integrity": "sha512-RWbpg/S7FOXDCwqC2oFhN/vh8dHzj0OS6dpyOSDHyQFSmqmR+lAUStV/ziTT1GzDqL9wol+nZQB4vCi5yEak+w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "relative-luminance": "^2.0.0"
       }
     },
     "node_modules/web-vitals": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,14 +55,24 @@
     "eject": "react-scripts eject",
     "prestart": "node scripts/check-node.js",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "lint:css": "stylelint 'src/**/*.css'"
   },
   "proxy": "http://localhost:3000",
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
-    ]
+    ],
+    "rules": {
+      "no-restricted-syntax": [
+        "warn",
+        {
+          "selector": "JSXAttribute[name.name='style'] > JSXExpressionContainer > ObjectExpression > Property[key.name=/color/i]",
+          "message": "Inline style colors are disallowed. Use design tokens or utility classes."
+        }
+      ]
+    }
   },
   "browserslist": {
     "production": [
@@ -84,7 +94,11 @@
     "postcss": "^8.5.3",
     "semver": "^7.5.4",
     "storybook": "^8.1.0",
+    "stylelint": "^16.23.1",
+    "stylelint-color-format": "^1.1.0",
+    "stylelint-config-standard": "^39.0.0",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "wcag-contrast": "^3.0.0"
   }
 }

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Work+Sans:wght@100..900&display=swap"
-      rel="stylesheet"
-    />
+      <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Manrope:wght@300..800&family=Space+Grotesk:wght@500;700&display=swap"
+        rel="stylesheet"
+      />
     <link rel="icon" href="/logo.png" type="image/png" />   
     <link rel="preload" href="/logo.png" as="image" />
     <meta name="theme-color" content="#4338ca" />
@@ -34,6 +34,18 @@
     <meta name="twitter:image" content="/logo.png" />
     <meta name="twitter:image:alt" content="AI Claims Data Extractor logo" />
     <link rel="canonical" href="https://clarifyops.com/" />
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem('theme');
+          if (!t) {
+            t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+          }
+          if (t === 'dark') document.documentElement.classList.add('dark');
+          document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/frontend/src/HumanReview.js
+++ b/frontend/src/HumanReview.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import MainLayout from './components/MainLayout';
 import { API_BASE } from './api';
+import { getStatusDetails } from './theme/statuses';
 
 function HumanReview() {
   const token = localStorage.getItem('token') || '';
@@ -21,12 +22,13 @@ function HumanReview() {
   useEffect(() => { fetchDocs(); }, [fetchDocs]);
 
   const badge = (s) => {
-    const map = {
-      needs_review: 'bg-yellow-200 text-yellow-800',
-      incorrect: 'bg-red-200 text-red-800',
-      correct: 'bg-green-200 text-green-800'
-    };
-    return <span className={`px-1 rounded text-xs ${map[s] || 'bg-gray-200 text-gray-800'}`}>{s}</span>;
+    const { class: cls, icon: Icon } = getStatusDetails(s);
+    return (
+      <span className={`px-1 rounded text-xs inline-flex items-center gap-1 ${cls}`}>
+        <Icon className="w-3 h-3" aria-hidden="true" />
+        {s}
+      </span>
+    );
   };
 
   return (

--- a/frontend/src/components/ExtractionFeedback.js
+++ b/frontend/src/components/ExtractionFeedback.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { API_BASE } from '../api';
+import { getStatusDetails } from '../theme/statuses';
 
 export default function ExtractionFeedback({ documentId, initialStatus, onChange }) {
   const [status, setStatus] = useState(initialStatus || '');
@@ -42,15 +43,29 @@ export default function ExtractionFeedback({ documentId, initialStatus, onChange
     }
   };
 
-  const btnCls = (val, base) =>
-    `px-2 py-1 border rounded text-xs ${base} ${status === val ? 'opacity-100' : 'opacity-50'}`;
+  const btnCls = (val) => {
+    const { class: cls } = getStatusDetails(val);
+    return `px-2 py-1 border rounded text-xs inline-flex items-center gap-1 ${cls} ${status === val ? 'opacity-100' : 'opacity-50'}`;
+  };
+  const IconCorrect = getStatusDetails('correct').icon;
+  const IconIncorrect = getStatusDetails('incorrect').icon;
+  const IconReview = getStatusDetails('needs_review').icon;
 
   return (
     <div className="mt-2 space-y-2">
       <div className="flex gap-2">
-        <button onClick={() => send('correct')} className={btnCls('correct','bg-green-200 dark:bg-green-700')}>Correct</button>
-        <button onClick={() => send('incorrect')} className={btnCls('incorrect','bg-red-200 dark:bg-red-700')}>Incorrect</button>
-        <button onClick={() => send('needs_review')} className={btnCls('needs_review','bg-yellow-200 dark:bg-yellow-700')}>Needs Review</button>
+        <button onClick={() => send('correct')} className={btnCls('correct')}>
+          <IconCorrect className="w-3 h-3" aria-hidden="true" />
+          Correct
+        </button>
+        <button onClick={() => send('incorrect')} className={btnCls('incorrect')}>
+          <IconIncorrect className="w-3 h-3" aria-hidden="true" />
+          Incorrect
+        </button>
+        <button onClick={() => send('needs_review')} className={btnCls('needs_review')}>
+          <IconReview className="w-3 h-3" aria-hidden="true" />
+          Needs Review
+        </button>
       </div>
       {status && (
         <div className="flex flex-col gap-2">

--- a/frontend/src/components/StatusChip.jsx
+++ b/frontend/src/components/StatusChip.jsx
@@ -1,27 +1,28 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
 import { STATUS_TRANSITIONS } from '../lib/claimStatus';
-
-const STYLES = {
-  Extracted: 'bg-blue-100 text-blue-800',
-  'Needs Review': 'bg-yellow-100 text-yellow-800',
-  Flagged: 'bg-red-100 text-red-800',
-  Approved: 'bg-green-100 text-green-800',
-  Escalated: 'bg-purple-100 text-purple-800',
-};
+import { getStatusDetails } from '../theme/statuses';
+import { logEvent } from '../lib/analytics';
 
 export default function StatusChip({ status }) {
-  const cls = STYLES[status] || 'bg-gray-100 text-gray-800';
-  const next = STATUS_TRANSITIONS[status] || [];
-  const tip = next.length ? `Next: ${next.join(', ')}` : 'Terminal state';
-  return (
-    <Tippy content={tip}>
-      <span className={`px-2 py-1 rounded text-xs font-medium ${cls}`}>{status || 'Unknown'}</span>
-    </Tippy>
-  );
-}
+    const detail = getStatusDetails(status?.toLowerCase().replace(/\s+/g, '_'));
+    const next = STATUS_TRANSITIONS[status] || [];
+    const tip = next.length ? `Next: ${next.join(', ')}` : 'Terminal state';
+    const Icon = detail.icon;
+    useEffect(() => {
+      if (status) logEvent('status_chip_impression', { status });
+    }, [status]);
+    return (
+      <Tippy content={tip}>
+        <span className={`px-2 py-1 rounded text-xs font-medium inline-flex items-center gap-1 ${detail.class}`}>
+          <Icon className="w-3 h-3" aria-hidden="true" />
+          {status || 'Unknown'}
+        </span>
+      </Tippy>
+    );
+  }
 
 StatusChip.propTypes = {
   status: PropTypes.string,

--- a/frontend/src/components/ThemePicker.js
+++ b/frontend/src/components/ThemePicker.js
@@ -7,7 +7,7 @@ export default function ThemePicker({ darkMode, setDarkMode, tenant = 'default' 
   const wrapperRef = useRef(null);
   useOutsideClick(wrapperRef, () => setOpen(false));
   const [mode, setMode] = useState(() => localStorage.getItem(`themeMode_${tenant}`) || (darkMode ? 'dark' : 'light'));
-  const [accent, setAccent] = useState(() => localStorage.getItem(`accentColor_${tenant}`) || '#4f46e5');
+  const [accent, setAccent] = useState(() => localStorage.getItem(`accentColor_${tenant}`) || '#059669');
   const [font, setFont] = useState(() => localStorage.getItem(`fontFamily_${tenant}`) || 'Inter');
 
   useEffect(() => {
@@ -29,27 +29,35 @@ export default function ThemePicker({ darkMode, setDarkMode, tenant = 'default' 
   }, [mode, setDarkMode, tenant]);
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--accent-color', accent);
+    document.documentElement.style.setProperty('--cta-bg', accent);
+    document.documentElement.style.setProperty('--cta-hover', accent);
+    document.documentElement.style.setProperty('--cta-active', accent);
+    document.documentElement.style.setProperty('--focus-ring-color', accent);
     localStorage.setItem(`accentColor_${tenant}`, accent);
   }, [accent, tenant]);
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--font-base', font);
+    document.documentElement.style.setProperty('--font-ui', font);
     localStorage.setItem(`fontFamily_${tenant}`, font);
   }, [font, tenant]);
 
   useEffect(() => {
     const savedAccent = localStorage.getItem(`accentColor_${tenant}`);
-    if (savedAccent) document.documentElement.style.setProperty('--accent-color', savedAccent);
+    if (savedAccent) {
+      document.documentElement.style.setProperty('--cta-bg', savedAccent);
+      document.documentElement.style.setProperty('--cta-hover', savedAccent);
+      document.documentElement.style.setProperty('--cta-active', savedAccent);
+      document.documentElement.style.setProperty('--focus-ring-color', savedAccent);
+    }
     const savedFont = localStorage.getItem(`fontFamily_${tenant}`);
-    if (savedFont) document.documentElement.style.setProperty('--font-base', savedFont);
+    if (savedFont) document.documentElement.style.setProperty('--font-ui', savedFont);
   }, [tenant]);
 
   return (
     <div className="relative" ref={wrapperRef}>
       <button
         onClick={() => setOpen(o => !o)}
-        className="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+        className="rounded"
         title="Theme Picker"
         aria-label="Theme Picker"
       >

--- a/frontend/src/hooks/__tests__/useDarkMode.test.js
+++ b/frontend/src/hooks/__tests__/useDarkMode.test.js
@@ -1,0 +1,20 @@
+import { renderHook, act } from '@testing-library/react';
+import useDarkMode from '../useDarkMode';
+
+describe('useDarkMode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.className = '';
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('writes theme to localStorage and data attribute', () => {
+    const { result } = renderHook(() => useDarkMode());
+    act(() => result.current[1](true));
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark');
+    act(() => result.current[1](false));
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+});

--- a/frontend/src/hooks/useDarkMode.js
+++ b/frontend/src/hooks/useDarkMode.js
@@ -1,17 +1,40 @@
 import { useEffect, useState } from 'react';
+import { logEvent } from '../lib/analytics';
 
 export default function useDarkMode() {
-  const [darkMode, setDarkMode] = useState(() => localStorage.getItem('theme') === 'dark');
+  const prefersDark =
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : false;
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    return stored ? stored === 'dark' : prefersDark;
+  });
 
   useEffect(() => {
-    if (darkMode) {
-      document.documentElement.classList.add('dark');
-      localStorage.setItem('theme', 'dark');
-    } else {
-      document.documentElement.classList.remove('dark');
-      localStorage.setItem('theme', 'light');
-    }
+      const theme = darkMode ? 'dark' : 'light';
+      if (darkMode) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+      document.documentElement.setAttribute('data-theme', theme);
+      localStorage.setItem('theme', theme);
+      logEvent('theme_change', { theme });
   }, [darkMode]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined' && window.matchMedia) {
+      const mq = window.matchMedia('(prefers-color-scheme: dark)');
+      const listener = (e) => {
+        if (!localStorage.getItem('theme')) {
+          setDarkMode(e.matches);
+        }
+      };
+      mq.addEventListener('change', listener);
+      return () => mq.removeEventListener('change', listener);
+    }
+  }, []);
 
   return [darkMode, setDarkMode];
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,25 +3,32 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --accent-color: #4338ca;
-  --accent-color-dark: #6366f1;
-  --font-base: 'InterVariable', 'Inter', 'Work Sans', ui-sans-serif, system-ui;
-}
+@import './styles/tokens.css';
 
+  body {
+    margin: 0;
+    font-family: var(--font-ui), -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+      'Helvetica Neue', sans-serif;
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-color: var(--bg-surface, rgb(245 245 244));
+    color: var(--text-default, rgb(15 23 42));
+    transition: background-color var(--motion-medium) var(--motion-ease-in-out),
+      color var(--motion-medium) var(--motion-ease-in-out);
+    color-scheme: light dark;
+  }
 
-body {
-  margin: 0;
-  font-family: var(--font-base), -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-    'Helvetica Neue', sans-serif;
-  font-size: 16px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  transition: background-color 0.3s ease, color 0.3s ease;
-  @apply bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-100;
-  color-scheme: light dark;
+/* Global focus styles */
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
 }
 
 @media (max-width: 640px) {
@@ -63,14 +70,15 @@ code {
 
 @layer components {
   .btn {
-    @apply px-4 py-2 rounded-lg text-sm transition-all duration-300 ease-in-out shadow-md hover:shadow-lg hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-indigo-400;
+    letter-spacing: 0.025em;
+    line-height: 1.25;
+    transition-duration: var(--motion-fast);
+    transition-timing-function: var(--motion-ease-out);
+    @apply px-4 py-2 rounded-lg text-sm transition-all shadow-md hover:shadow-lg hover:-translate-y-0.5;
   }
   .btn-primary {
-    background-image: linear-gradient(to bottom right, var(--accent-color), var(--accent-color-dark));
-    @apply text-white hover:brightness-110;
-  }
-  .dark .btn-primary {
-    background-image: linear-gradient(to bottom right, var(--accent-color-dark), #8b5cf6);
+    background-color: var(--cta-bg);
+    @apply text-white hover:bg-[var(--cta-hover)] active:bg-[var(--cta-active)];
   }
   .btn-secondary {
     @apply bg-gray-200 text-gray-800 hover:bg-gray-300;
@@ -85,10 +93,11 @@ code {
     @apply bg-yellow-400 text-black hover:bg-yellow-500;
   }
   .nav-link {
-    @apply flex items-center space-x-2 px-4 py-2 rounded transition text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-indigo-400;
+    @apply flex items-center space-x-2 px-4 py-2 rounded transition text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-700;
   }
   .input {
-    @apply border border-gray-300 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 outline-none;
+    @apply border rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100;
+    border-color: var(--border-default);
   }
   .card {
     @apply bg-white/80 dark:bg-gray-800/70 backdrop-blur rounded-xl shadow-md p-6;
@@ -99,10 +108,10 @@ code {
 .high-contrast body {
   @apply bg-black text-yellow-300;
 }
-.high-contrast .btn-primary {
-  background-color: #ffff00;
-  @apply text-black;
-}
+  .high-contrast .btn-primary {
+    background-color: rgb(255 255 0);
+    @apply text-black;
+  }
 .high-contrast .input {
   @apply border-yellow-400 bg-black text-yellow-300;
 }
@@ -135,6 +144,16 @@ code {
 /* Badges */
 .badge {
   @apply inline-block px-2 py-0.5 text-xs rounded-full bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200;
+}
+
+/* Status badges */
+  .status-neutral { background-color: var(--status-neutral, rgb(107 114 128)); color: rgb(255 255 255); }
+  .status-amber { background-color: var(--status-amber, rgb(245 158 11)); color: rgb(0 0 0); }
+  .status-green { background-color: var(--status-green, rgb(4 120 87)); color: rgb(255 255 255); }
+  .status-red { background-color: var(--status-red, rgb(220 38 38)); color: rgb(255 255 255); }
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-heading);
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -77,18 +77,27 @@ window.fetch = async (url, options) => {
 };
 
 const currentTenant = localStorage.getItem('tenant') || 'default';
-const savedTheme = localStorage.getItem(`themeMode_${currentTenant}`);
-if (savedTheme === 'dark') {
+const savedTheme = localStorage.getItem(`themeMode_${currentTenant}`) || localStorage.getItem('theme');
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+if (savedTheme === 'dark' || ((!savedTheme || savedTheme === 'system') && prefersDark)) {
   document.documentElement.classList.add('dark');
+  document.documentElement.setAttribute('data-theme', 'dark');
+} else {
+  document.documentElement.setAttribute('data-theme', 'light');
 }
 const savedContrast = localStorage.getItem('contrast');
 if (savedContrast === 'high') {
   document.documentElement.classList.add('high-contrast');
 }
 const savedAccent = localStorage.getItem(`accentColor_${currentTenant}`);
-if (savedAccent) document.documentElement.style.setProperty('--accent-color', savedAccent);
+if (savedAccent) {
+  document.documentElement.style.setProperty('--cta-bg', savedAccent);
+  document.documentElement.style.setProperty('--cta-hover', savedAccent);
+  document.documentElement.style.setProperty('--cta-active', savedAccent);
+  document.documentElement.style.setProperty('--focus-ring-color', savedAccent);
+}
 const savedFont = localStorage.getItem(`fontFamily_${currentTenant}`);
-if (savedFont) document.documentElement.style.setProperty('--font-base', savedFont);
+if (savedFont) document.documentElement.style.setProperty('--font-ui', savedFont);
 
 if (API_BASE) {
   // Hit the health endpoint instead of /api/claims since the
@@ -104,7 +113,7 @@ function PageWrapper({ children }) {
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
-      transition={{ duration: 0.2 }}
+      transition={{ duration: 0.25, ease: 'easeInOut' }}
     >
       {children}
     </motion.div>

--- a/frontend/src/lib/analytics.js
+++ b/frontend/src/lib/analytics.js
@@ -1,0 +1,13 @@
+export function logEvent(event, data = {}) {
+  try {
+    if (window.analytics && typeof window.analytics.track === 'function') {
+      window.analytics.track(event, data);
+    } else if (window.dataLayer && Array.isArray(window.dataLayer)) {
+      window.dataLayer.push({ event, ...data });
+    } else {
+      console.log('analytics event', event, data);
+    }
+  } catch (e) {
+    // swallow analytics errors
+  }
+}

--- a/frontend/src/stories/ThemeTokens.stories.jsx
+++ b/frontend/src/stories/ThemeTokens.stories.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect } from 'react';
+import StatusChip from '../components/StatusChip';
+
+const ThemeWrap = ({ theme, accent, children }) => {
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.style.setProperty('--cta-bg', accent);
+    document.documentElement.style.setProperty('--cta-hover', accent);
+    document.documentElement.style.setProperty('--cta-active', accent);
+    document.documentElement.style.setProperty('--focus-ring-color', accent);
+  }, [theme, accent]);
+  return <div className="p-4 space-y-4 bg-surface text-ink">{children}</div>;
+};
+
+export default {
+  title: 'Design/Tokens',
+  render: (args) => (
+    <ThemeWrap {...args}>
+      <button className="btn btn-primary">Primary Button</button>
+      <div className="flex gap-2">
+        <StatusChip status="Extracted" />
+        <StatusChip status="Needs Review" />
+        <StatusChip status="Approved" />
+        <StatusChip status="Flagged" />
+      </div>
+      <div className="card">Card surface</div>
+    </ThemeWrap>
+  ),
+  argTypes: {
+    theme: { control: { type: 'inline-radio' }, options: ['light', 'dark'] },
+    accent: { control: 'color' },
+  },
+  args: { theme: 'light', accent: '#059669' },
+};

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -1,0 +1,91 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Manrope:wght@400;700&family=Space+Grotesk:wght@500;700&display=swap');
+
+/* ===== Design Tokens ===== */
+:root {
+    --token-version: 1;
+    /* Colors - base palette */
+    --color-ink: #0f172a; /* deep blue/ink */
+    --color-charcoal: #f5f5f4; /* soft charcoal */
+    --color-emerald: #059669; /* accent emerald */
+    --color-gold: #b45309; /* accent gold */
+    --color-red: #ef4444;
+    --color-green: #10b981;
+    --color-amber: #f59e0b;
+    --color-gray: #6b7280;
+    --color-gray-light: #9ca3af;
+
+    /* Colors - semantic aliases */
+    --bg-surface: var(--color-charcoal, #f5f5f4);
+    --text-default: var(--color-ink, #0f172a);
+    --text-muted: var(--color-gray, #6b7280);
+    --border-default: var(--color-gray-light, #9ca3af);
+    --focus-ring-color: var(--color-emerald, #059669);
+    --focus-ring-width: 2px;
+    --focus-ring-offset: 2px;
+    --cta-bg: var(--color-emerald, #059669);
+    --cta-hover: #047857;
+    --cta-active: #065f46;
+
+    /* Status colors */
+    --status-neutral: var(--color-gray, #6b7280);
+    --status-amber: var(--color-amber, #f59e0b);
+    --status-green: #047857;
+    --status-red: #dc2626;
+
+    /* Typography */
+    --font-ui: 'Inter', 'Manrope', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+      'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+      'Helvetica Neue', sans-serif;
+    --font-heading: 'Space Grotesk', 'Inter', 'Manrope', -apple-system, BlinkMacSystemFont,
+      'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+      'Droid Sans', 'Helvetica Neue', sans-serif;
+
+  /* Spacing scale */
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+
+  /* Radii */
+  --radius-sm: 0.125rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 1rem;
+
+  /* Shadows / elevation */
+  --shadow-e1: 0 1px 2px 0 rgba(0,0,0,0.05);
+  --shadow-e2: 0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -2px rgba(0,0,0,0.1);
+  --shadow-e3: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -4px rgba(0,0,0,0.1);
+
+  /* Z-index tiers */
+  --z-dropdown: 1000;
+  --z-modal: 1100;
+  --z-popover: 1200;
+
+  /* Motion */
+  --motion-fast: 150ms;
+  --motion-medium: 200ms;
+  --motion-modal: 250ms;
+  --motion-ease-out: cubic-bezier(0.0, 0.0, 0.2, 1);
+  --motion-ease-in-out: cubic-bezier(0.4, 0.0, 0.2, 1);
+}
+
+/* Dark theme overrides */
+.dark {
+  --bg-surface: #1f2937;
+  --text-default: #e2e8f0;
+  --text-muted: #9ca3af;
+  --border-default: #374151;
+  --cta-hover: #34d399;
+  --cta-active: #059669;
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-fast: 0ms;
+    --motion-medium: 0ms;
+    --motion-modal: 50ms;
+  }
+}

--- a/frontend/src/theme/__tests__/statuses.test.js
+++ b/frontend/src/theme/__tests__/statuses.test.js
@@ -1,0 +1,56 @@
+import { STATUS_MAP, STATUS_DETAILS, getStatusDetails } from '../statuses';
+import fs from 'fs';
+import path from 'path';
+import { hex as contrast } from 'wcag-contrast';
+
+// helper to resolve CSS variable values from tokens.css
+const tokensCss = fs.readFileSync(
+  path.join(__dirname, '../../styles/tokens.css'),
+  'utf8'
+);
+
+const escapeRegExp = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const getColor = (varName) => {
+  const esc = escapeRegExp(varName);
+  const hexMatch = new RegExp(`^\\s*${esc}:\\s*(#[0-9a-fA-F]{6})`, 'm').exec(tokensCss);
+  if (hexMatch) return hexMatch[1];
+  const varMatch = new RegExp(`^\\s*${esc}:\\s*var\\((--[\\w-]+)(?:,\\s*(#[0-9a-fA-F]{6}))?\\)`, 'm').exec(tokensCss);
+  if (varMatch) return varMatch[2] || getColor(varMatch[1]);
+  return null;
+};
+
+test('every status has mapped class and icon', () => {
+  Object.keys(STATUS_MAP).forEach((key) => {
+    const detail = getStatusDetails(key);
+    expect(detail.class).toBeDefined();
+    expect(detail.icon).toBeDefined();
+  });
+});
+
+test('status classes and icons are unique', () => {
+  const classes = new Set();
+  const icons = new Set();
+  Object.values(STATUS_DETAILS).forEach(({ class: cls, icon }) => {
+    expect(classes.has(cls)).toBe(false);
+    expect(icons.has(icon)).toBe(false);
+    classes.add(cls);
+    icons.add(icon);
+  });
+});
+
+test('status colors meet contrast ratio', () => {
+  const textColors = {
+    neutral: '#ffffff',
+    amber: '#000000',
+    green: '#ffffff',
+    red: '#ffffff',
+  };
+
+  Object.keys(STATUS_DETAILS).forEach((key) => {
+    const bg = getColor(`--status-${key}`);
+    const fg = textColors[key];
+    const ratio = contrast(bg, fg);
+    expect(ratio).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/frontend/src/theme/statuses.js
+++ b/frontend/src/theme/statuses.js
@@ -1,0 +1,25 @@
+import { CheckCircle, AlertTriangle, XCircle, MinusCircle } from 'lucide-react';
+
+export const STATUS_MAP = {
+  extracted: 'neutral',
+  needs_review: 'amber',
+  approved: 'green',
+  escalated: 'red',
+  flagged: 'red',
+  correct: 'green',
+  incorrect: 'red',
+};
+
+export const STATUS_DETAILS = {
+  neutral: { class: 'status-neutral', icon: MinusCircle, label: 'Extracted' },
+  amber: { class: 'status-amber', icon: AlertTriangle, label: 'Needs Review' },
+  green: { class: 'status-green', icon: CheckCircle, label: 'Approved' },
+  red: { class: 'status-red', icon: XCircle, label: 'Flagged' },
+};
+
+export const getStatusDetails = (status) => {
+  const key = STATUS_MAP[status] || 'neutral';
+  return STATUS_DETAILS[key];
+};
+
+export const getStatusClass = (status) => getStatusDetails(status).class;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,23 +1,71 @@
 // frontend/tailwind.config.js
-const colors = require('tailwindcss/colors');
-
 module.exports = {
   content: ["./src/**/*.{js,jsx,ts,tsx}"],
   darkMode: "class",
   theme: {
     extend: {
       fontFamily: {
-        sans: ['"InterVariable"', 'Inter', '"Work Sans"', 'ui-sans-serif', 'system-ui'],
+        sans: ['var(--font-ui)'],
+        heading: ['var(--font-heading)'],
       },
       colors: {
-        primary: colors.indigo,
+        surface: 'var(--bg-surface)',
+        ink: 'var(--text-default)',
+        muted: 'var(--text-muted)',
+        border: 'var(--border-default)',
+        accent: {
+          DEFAULT: 'var(--cta-bg)',
+          hover: 'var(--cta-hover)',
+          active: 'var(--cta-active)',
+        },
+        status: {
+          neutral: 'var(--status-neutral)',
+          amber: 'var(--status-amber)',
+          green: 'var(--status-green)',
+          red: 'var(--status-red)',
+        },
       },
       spacing: {
-        '128': '32rem',
-        '144': '36rem',
+        1: 'var(--space-1)',
+        2: 'var(--space-2)',
+        4: 'var(--space-4)',
+        6: 'var(--space-6)',
+        8: 'var(--space-8)',
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+        xl: 'var(--radius-xl)',
       },
       boxShadow: {
+        e1: 'var(--shadow-e1)',
+        e2: 'var(--shadow-e2)',
+        e3: 'var(--shadow-e3)',
         'xl-deep': '0 35px 60px -15px rgba(0,0,0,0.5)',
+      },
+      zIndex: {
+        dropdown: 'var(--z-dropdown)',
+        modal: 'var(--z-modal)',
+        popover: 'var(--z-popover)',
+      },
+      transitionDuration: {
+        fast: 'var(--motion-fast)',
+        medium: 'var(--motion-medium)',
+        modal: 'var(--motion-modal)',
+      },
+      transitionTimingFunction: {
+        'ease-out-custom': 'var(--motion-ease-out)',
+        'ease-in-out-custom': 'var(--motion-ease-in-out)',
+      },
+      ringColor: {
+        focus: 'var(--focus-ring-color)',
+      },
+      ringWidth: {
+        focus: 'var(--focus-ring-width)',
+      },
+      ringOffsetWidth: {
+        focus: 'var(--focus-ring-offset)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- enforce design token usage with stylelint hex guards and ESLint warnings for inline color styles
- add token version, CSS var fallbacks, font preconnects and analytics hooks for theme and status usage
- introduce Playwright visual regression snapshots for buttons and status chips
- remove committed Playwright screenshots and config to avoid binary artifacts

## Testing
- `npm run lint:css --prefix frontend`
- `npm test --prefix frontend -- --watchAll=false`
- `npx --prefix frontend eslint frontend/src --ext .js,.jsx` *(fails: no-undef, testing-library/no-node-access, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689bc65e7908832e98c0f997e182a766