### PR TITLE
feat: clarifyops branding and claims messaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,23 @@ jobs:
         run: cd backend && npm run lint || true
       - name: Install frontend deps
         run: cd frontend && npm ci --legacy-peer-deps
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('frontend/package-lock.json') }}
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install --with-deps
+      - name: Frontend tests
+        run: cd frontend && npm test -- --watchAll=false --testPathIgnorePatterns=visual.test.jsx
+      - name: Backend tests
+        run: cd backend && npm test
+      - name: Playwright smoke tests
+        run: cd frontend && npx playwright test
+      - name: Visual regression tests
+        if: github.event_name == 'pull_request'
+        run: cd frontend && npm test src/components/__tests__/visual.pr.test.jsx
       - name: Build frontend
         run: cd frontend && npm run build
+      - name: Lighthouse CI
+        run: cd frontend && npx lhci autorun --config=lighthouserc.js

--- a/docs/grafana/events-panel.json
+++ b/docs/grafana/events-panel.json
@@ -1,0 +1,25 @@
+{
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Hero CTA Clicks",
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(increase(hero_cta_click_total[5m]))" }],
+      "id": 1
+    },
+    {
+      "type": "timeseries",
+      "title": "Glossary Tooltip Opens",
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(increase(glossary_tooltip_open_total[5m]))" }],
+      "id": 2
+    },
+    {
+      "type": "timeseries",
+      "title": "Dashboard Drilldowns",
+      "datasource": "Prometheus",
+      "targets": [{ "expr": "sum(increase(dashboard_drilldown_total[5m]))" }],
+      "id": 3
+    }
+  ]
+}

--- a/frontend/lighthouserc.js
+++ b/frontend/lighthouserc.js
@@ -1,0 +1,16 @@
+export default {
+  ci: {
+    collect: {
+      staticDistDir: 'build',
+      numberOfRuns: 1,
+      settings: { emulatedFormFactor: 'mobile' }
+    },
+    assert: {
+      assertions: {
+        'metrics/largest-contentful-paint': ['error', { 'maxNumericValue': 2500 }],
+        'metrics/interactive': ['error', { 'maxNumericValue': 3500 }],
+        'metrics/cumulative-layout-shift': ['error', { 'maxNumericValue': 0.1 }]
+      }
+    }
+  }
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,9 @@
         "yjs": "^13.6.27"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
+        "@lhci/cli": "^0.13.0",
+        "@playwright/test": "^1.45.0",
         "@storybook/addon-essentials": "^8.1.0",
         "@storybook/react": "^8.1.0",
         "@tailwindcss/postcss": "^4.1.5",
@@ -115,6 +118,19 @@
       },
       "peerDependencies": {
         "ajv": ">=8"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.10.2.tgz",
+      "integrity": "sha512-6/b5BJjG6hDaRNtgzLIfKr5DfwyiLHO4+ByTLB0cJgWSM8Ll7KqtdblIS6bEkwSF642/Ex91vNqIl3GLXGlceg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.10.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3219,6 +3235,62 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.4.tgz",
+      "integrity": "sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/intl-localematcher": "0.6.1",
+        "decimal.js": "^10.4.3",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
+      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.2.tgz",
+      "integrity": "sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/icu-skeleton-parser": "1.8.14",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.14.tgz",
+      "integrity": "sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.1.tgz",
+      "integrity": "sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@gilbarbara/deep-equal": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.3.1.tgz",
@@ -3752,6 +3824,156 @@
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "license": "MIT"
     },
+    "node_modules/@lhci/cli": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.13.0.tgz",
+      "integrity": "sha512-Y/ulyvT3h2j1jeFEoNC9RM5zOTW9s48Np3yC/kpKP6++to4ulMu4mKrmFit5zFHKuH7pC1+bkcYwM1/ul78FfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@lhci/utils": "0.13.0",
+        "chrome-launcher": "^0.13.4",
+        "compression": "^1.7.4",
+        "debug": "^4.3.1",
+        "express": "^4.17.1",
+        "https-proxy-agent": "^5.0.0",
+        "inquirer": "^6.3.1",
+        "isomorphic-fetch": "^3.0.0",
+        "lighthouse": "11.4.0",
+        "lighthouse-logger": "1.2.0",
+        "open": "^7.1.0",
+        "tmp": "^0.1.0",
+        "uuid": "^8.3.1",
+        "yargs": "^15.4.1",
+        "yargs-parser": "^13.1.2"
+      },
+      "bin": {
+        "lhci": "src/cli.js"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@lhci/cli/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/@lhci/cli/node_modules/yargs/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@lhci/utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.13.0.tgz",
+      "integrity": "sha512-QkICuVx9rwP8cw0KIV7nEqMldKCddGwYVHal3NnvXl1dGkGJn+0kHZeN8RYZ6aBbLnjTqTCnK0KNAiVxIpD4cw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "isomorphic-fetch": "^3.0.0",
+        "js-yaml": "^3.13.1",
+        "lighthouse": "11.4.0",
+        "tree-kill": "^1.2.1"
+      }
+    },
     "node_modules/@mdx-js/react": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
@@ -4079,6 +4301,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.17.tgz",
@@ -4144,6 +4382,97 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+      "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.1",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -4349,6 +4678,142 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "license": "MIT"
+    },
+    "node_modules/@sentry/core": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.7.tgz",
+      "integrity": "sha512-tOfZ/umqB2AcHPGbIrsFLcvApdTm9ggpi/kQZFkej7kMphjT+SGBiQfYtjyg9jcRW+ilAR4JXC9BGKsdEQ+8Vw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/hub": "6.19.7",
+        "@sentry/minimal": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/hub": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.7.tgz",
+      "integrity": "sha512-y3OtbYFAqKHCWezF0EGGr5lcyI2KbaXW2Ik7Xp8Mu9TxbSTuwTe4rTntwg8ngPjUQU3SUHzgjqVB8qjiGqFXCA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.7.tgz",
+      "integrity": "sha512-wcYmSJOdvk6VAPx8IcmZgN08XTXRwRtB1aOLZm+MVHjIZIhHoBGZJYTVQS/BWjldsamj2cX3YGbGXNunaCfYJQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/hub": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/node": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.19.7.tgz",
+      "integrity": "sha512-gtmRC4dAXKODMpHXKfrkfvyBL3cI8y64vEi3fDD046uqYcrWdgoQsffuBbxMAizc6Ez1ia+f0Flue6p15Qaltg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/core": "6.19.7",
+        "@sentry/hub": "6.19.7",
+        "@sentry/types": "6.19.7",
+        "@sentry/utils": "6.19.7",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@sentry/types": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.7.tgz",
+      "integrity": "sha512-jH84pDYE+hHIbVnab3Hr+ZXr1v8QABfhx39KknxqKWr2l0oEItzepV0URvbEhB446lk/S/59230dlUUIBGsXbg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "6.19.7",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.7.tgz",
+      "integrity": "sha512-z95ECmE3i9pbWoXQrD/7PgkBAzJYR+iXtPuTkpBjDKs86O3mT+PXOT3BAn79w2wkn7/i3vOGD2xVr1uiMl26dA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sentry/types": "6.19.7",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -5292,6 +5757,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",
@@ -5502,6 +6027,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -6003,6 +6535,17 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
@@ -6655,6 +7198,16 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -7097,6 +7650,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -7388,6 +7948,45 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/bare-events": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
+      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -7600,6 +8199,41 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -7828,6 +8462,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/check-types": {
       "version": "11.2.3",
       "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz",
@@ -7880,6 +8521,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/chrome-launcher": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.13.4.tgz",
+      "integrity": "sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^1.0.5",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "^0.5.3",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "node_modules/chrome-launcher/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
@@ -7887,6 +8553,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+      "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.1",
+        "urlpattern-polyfill": "10.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/ci-info": {
@@ -7942,6 +8622,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+      "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -8229,6 +8929,24 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
     },
+    "node_modules/configstore": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+      "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
@@ -8355,6 +9073,16 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -8377,6 +9105,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/csp_evaluator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/csp_evaluator/-/csp_evaluator-1.1.1.tgz",
+      "integrity": "sha512-N3ASg0C4kNPUaNxt1XAvzHIVuzdtr8KLgfk1O8WDyimp1GisPAHESupArO2ieHk9QWbrJ/WkQODyh21Ps/xhxw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/css-blank-pseudo": {
       "version": "3.0.3",
@@ -9033,6 +9768,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -9113,6 +9858,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
@@ -9209,6 +9964,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/degenerator/node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -9302,6 +10085,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1211954",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1211954.tgz",
+      "integrity": "sha512-f6BRhngr9wpHN8omZOoSaEJFscTL+tjNhmeBqHHC3CZ3K2N75sDeKXZeTkAEkTCcrusDatfwjRRBh0uz4ov/sA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -9481,6 +10271,29 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dot-prop": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+      "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-obj": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dot-prop/node_modules/is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
@@ -9585,6 +10398,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/engine.io-client": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
@@ -9656,6 +10479,20 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/enquirer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
+      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.1",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/entities": {
@@ -10788,6 +11625,84 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/external-editor/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/external-editor/node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10802,6 +11717,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -10897,6 +11819,39 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -11619,6 +12574,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -12124,6 +13094,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -12277,6 +13257,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -12285,6 +13286,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/image-ssim": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
+      "integrity": "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "9.0.21",
@@ -12381,6 +13389,189 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/inquirer": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+      "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.12",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.1.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/inquirer/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inquirer/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/inquirer/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/ansi-regex": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+      "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/string-width/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inquirer/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/inquirer/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -12402,6 +13593,29 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "10.7.16",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.16.tgz",
+      "integrity": "sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.3.4",
+        "@formatjs/fast-memoize": "2.2.7",
+        "@formatjs/icu-messageformat-parser": "2.11.2",
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -12964,6 +14178,17 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
     },
     "node_modules/isomorphic.js": {
       "version": "0.2.5",
@@ -14040,6 +15265,23 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/js-library-detector": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-6.7.0.tgz",
+      "integrity": "sha512-c80Qupofp43y4cJ7+8TTDN/AsDwLi5oOm/plBrWI+iQt485vKXCco+yVmOwEgdo9VOdsYTuV0UlTeetVPTriXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14352,6 +15594,170 @@
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/lighthouse": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-11.4.0.tgz",
+      "integrity": "sha512-NmGBIdLznIBTfla566gpNPdbascVA0uWFG2LyuRQPeMT06ai3QxzDqSpaR5dToDuEQIPkyU0qqxwHj8kst8x+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sentry/node": "^6.17.4",
+        "axe-core": "^4.8.1",
+        "chrome-launcher": "^1.1.0",
+        "configstore": "^5.0.1",
+        "csp_evaluator": "1.1.1",
+        "devtools-protocol": "0.0.1211954",
+        "enquirer": "^2.3.6",
+        "http-link-header": "^1.1.1",
+        "intl-messageformat": "^10.5.3",
+        "jpeg-js": "^0.4.4",
+        "js-library-detector": "^6.7.0",
+        "lighthouse-logger": "^2.0.1",
+        "lighthouse-stack-packs": "1.12.1",
+        "lodash": "^4.17.21",
+        "lookup-closest-locale": "6.2.0",
+        "metaviewport-parser": "0.3.0",
+        "open": "^8.4.0",
+        "parse-cache-control": "1.0.1",
+        "ps-list": "^8.0.0",
+        "puppeteer-core": "^21.5.2",
+        "robots-parser": "^3.0.1",
+        "semver": "^5.3.0",
+        "speedline-core": "^1.4.3",
+        "third-party-web": "^0.24.1",
+        "tldts-icann": "^6.1.0",
+        "ws": "^7.0.0",
+        "yargs": "^17.3.1",
+        "yargs-parser": "^21.0.0"
+      },
+      "bin": {
+        "chrome-debug": "core/scripts/manual-chrome-launcher.js",
+        "lighthouse": "cli/index.js",
+        "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js"
+      },
+      "engines": {
+        "node": ">=18.16"
+      }
+    },
+    "node_modules/lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/lighthouse-logger/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lighthouse-stack-packs": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.12.1.tgz",
+      "integrity": "sha512-i4jTmg7tvZQFwNFiwB+nCK6a7ICR68Xcwo+VIVd6Spi71vBNFUlds5HiDrSbClZdkQDON2Bhqv+KKJIo5zkPeA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lighthouse/node_modules/chrome-launcher": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
+      "integrity": "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "*",
+        "escape-string-regexp": "^4.0.0",
+        "is-wsl": "^2.2.0",
+        "lighthouse-logger": "^2.0.1"
+      },
+      "bin": {
+        "print-chrome-path": "bin/print-chrome-path.cjs"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/lighthouse/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lighthouse/node_modules/lighthouse-logger": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-2.0.2.tgz",
+      "integrity": "sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "marky": "^1.2.2"
+      }
+    },
+    "node_modules/lighthouse/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/lighthouse/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/lighthouse/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lightningcss": {
@@ -14698,6 +16104,13 @@
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "license": "MIT"
     },
+    "node_modules/lookup-closest-locale": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.2.0.tgz",
+      "integrity": "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -14737,6 +16150,13 @@
       "dependencies": {
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -14814,6 +16234,13 @@
       "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/marky": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -14914,6 +16341,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/metaviewport-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.3.0.tgz",
+      "integrity": "sha512-EoYJ8xfjQ6kpe9VbVHvZTZHiOl4HL1Z18CrZ+qahvLXT7ZO4YTC2JMyt5FaUp9JJp6J4Ybb/z7IsCXZt86/QkQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/methods": {
       "version": "1.1.2",
@@ -15057,6 +16491,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -15068,6 +16509,13 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",
@@ -15102,6 +16550,13 @@
       "bin": {
         "multicast-dns": "cli.js"
       }
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -15159,6 +16614,16 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "license": "MIT"
     },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/ngraph.events": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ngraph.events/-/ngraph.events-1.2.2.tgz",
@@ -15211,6 +16676,52 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -15524,6 +17035,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -15590,6 +17111,78 @@
         "node": ">=6"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -15623,6 +17216,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -15737,6 +17336,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -15847,6 +17453,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/polished": {
@@ -17313,6 +18966,16 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -17374,6 +19037,94 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+      "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.1",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ps-list": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-8.1.1.tgz",
+      "integrity": "sha512-OPS9kEJYVmiO48u/B9qneqhkMvgCxT+Tm28VCEJpheTpl8cJ0ffZRRNgS5mrQRTrX5yRTpaJ+hRDeefXYmmorQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -17386,6 +19137,17 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -17393,6 +19155,78 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+      "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "1.9.1",
+        "chromium-bidi": "0.5.8",
+        "cross-fetch": "4.0.0",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1232444",
+        "ws": "8.16.0"
+      },
+      "engines": {
+        "node": ">=16.13.2"
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer-core/node_modules/devtools-protocol": {
+      "version": "0.0.1232444",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+      "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/puppeteer-core/node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/q": {
@@ -18335,6 +20169,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -18460,6 +20301,43 @@
         "node": ">=10"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -18493,6 +20371,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/robots-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-3.0.1.tgz",
+      "integrity": "sha512-s+pyvQeIKIZ0dx5iJiQk1tPLJAWln39+MI5jtM8wnyws+G5azk+dMnMX0qfbqNetKKNgcWWOdi0sfm+FbQbgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/rollup": {
@@ -18549,6 +20437,16 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/run-async": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -18571,6 +20469,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
@@ -18933,6 +20851,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -19146,6 +21071,17 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/socket.io-client": {
       "version": "4.8.1",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
@@ -19217,6 +21153,46 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/source-list-map": {
@@ -19318,6 +21294,21 @@
         "obuf": "^1.1.2",
         "readable-stream": "^3.0.6",
         "wbuf": "^1.7.3"
+      }
+    },
+    "node_modules/speedline-core": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.3.tgz",
+      "integrity": "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "image-ssim": "^0.2.0",
+        "jpeg-js": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -19519,6 +21510,20 @@
         "prettier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -20572,6 +22577,30 @@
         "node": ">=18"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/tar/node_modules/mkdirp": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
@@ -20725,6 +22754,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -20757,6 +22796,13 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-web": {
+      "version": "0.24.5",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.24.5.tgz",
+      "integrity": "sha512-1rUOdMYpNTRajgk1F7CmHD26oA6rTKekBjHay854J6OkPXeNyPcR54rhWDaamlWyi9t2wAVPQESdedBhucmOLA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/three": {
       "version": "0.178.0",
@@ -20822,6 +22868,13 @@
       "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==",
       "license": "MIT"
     },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -20847,6 +22900,50 @@
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "^2.9.0"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts-icann": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-6.1.86.tgz",
+      "integrity": "sha512-NFxmRT2lAEMcCOBgeZ0NuM0zsK/xgmNajnY6n4S1mwAKocft2s2ise1O3nQxrH3c+uY6hgHUV9GGNVp7tUE4Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rimraf": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tmp/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
     "node_modules/tmpl": {
@@ -20920,6 +23017,16 @@
       "dependencies": {
         "@gilbarbara/deep-equal": "^0.3.1",
         "is-lite": "^1.2.1"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
       }
     },
     "node_modules/tryer": {
@@ -21165,6 +23272,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/underscore": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
@@ -21325,6 +23443,13 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-memo-one": {
       "version": "1.1.3",
@@ -21919,6 +24044,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
@@ -22325,6 +24457,16 @@
         }
       }
     },
+    "node_modules/xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/xlsx": {
       "version": "0.18.5",
       "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
@@ -22456,6 +24598,17 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,8 +50,10 @@
   },
   "scripts": {
     "start": "PORT=3001 react-scripts start",
+    "prebuild": "node scripts/update-sitemap.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "test:e2e": "playwright test",
     "eject": "react-scripts eject",
     "prestart": "node scripts/check-node.js",
     "storybook": "storybook dev -p 6006",
@@ -87,6 +89,9 @@
     ]
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
+    "@lhci/cli": "^0.13.0",
+    "@playwright/test": "^1.45.0",
     "@storybook/addon-essentials": "^8.1.0",
     "@storybook/react": "^8.1.0",
     "@tailwindcss/postcss": "^4.1.5",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://localhost:3001',
+    viewport: { width: 375, height: 667 },
+  },
+  webServer: {
+    command: 'npm start',
+    port: 3001,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: 'mobile-chromium',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+});

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -5,23 +5,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Manrope:wght@300..800&family=Space+Grotesk:wght@500;700&display=swap"
-        rel="stylesheet"
-      />
+    <link
+      rel="preload"
+      as="style"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Manrope:wght@300..800&family=Space+Grotesk:wght@500;700&display=swap"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=Manrope:wght@300..800&family=Space+Grotesk:wght@500;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="preload" href="/static/css/main.css" as="style" />
     <link rel="icon" href="/logo.png" type="image/png" />   
     <link rel="preload" href="/logo.png" as="image" />
     <meta name="theme-color" content="#4338ca" />
-    <title>AI Claims Data Extractor</title>
+    <title>AI Medical Claims Review | ClarifyClaims</title>
     <meta
       name="description"
-      content="Extract structured claim data in seconds with AI-driven workflows."
+      content="Extract, validate, and resolve medical claims with AI. Faster reviews, fewer denials."
     />
-    <meta property="og:title" content="AI Claims Data Extractor" />
+    <meta property="og:title" content="AI Medical Claims Review" />
     <meta property="og:type" content="website" />
     <meta
       property="og:description"
-      content="Streamline claim processing with AI-driven validation and instant analytics."
+      content="Extract, validate, and resolve medical claims with AI. Faster reviews, fewer denials."
     />
     <meta property="og:image" content="/logo.png" />
     <meta property="og:image:width" content="512" />
@@ -29,11 +35,12 @@
     <meta property="og:image:alt" content="AI Claims Data Extractor logo" />
     <meta property="og:url" content="https://clarifyops.com/" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="AI Claims Data Extractor" />
-    <meta name="twitter:description" content="Streamline claim processing with AI-driven validation and instant analytics." />
+    <meta name="twitter:title" content="AI Medical Claims Review" />
+    <meta name="twitter:description" content="Extract, validate, and resolve medical claims with AI. Faster reviews, fewer denials." />
     <meta name="twitter:image" content="/logo.png" />
     <meta name="twitter:image:alt" content="AI Claims Data Extractor logo" />
     <link rel="canonical" href="https://clarifyops.com/" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <script>
       (function () {
         try {

--- a/frontend/public/logo.svg
+++ b/frontend/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 28" fill="none">
+  <text x="0" y="20" font-family="Arial, sans-serif" font-size="20" fill="#4f46e5">ClarifyOps</text>
+</svg>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://clarifyops.com/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://clarifyops.com/</loc>
+  </url>
+</urlset>

--- a/frontend/scripts/update-sitemap.js
+++ b/frontend/scripts/update-sitemap.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const path = require('path');
+const site = process.env.SITE_URL || 'https://clarifyops.com';
+const sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n  <url>\n    <loc>${site}/</loc>\n  </url>\n</urlset>`;
+fs.writeFileSync(path.join(__dirname, '..', 'public', 'sitemap.xml'), sitemap);
+const robots = `# https://www.robotstxt.org/robotstxt.html\nUser-agent: *\nDisallow:\nSitemap: ${site}/sitemap.xml\n`;
+fs.writeFileSync(path.join(__dirname, '..', 'public', 'robots.txt'), robots);

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -14,7 +14,7 @@ test('renders login heading by default', () => {
       <LoginPage />
     </MemoryRouter>
   );
-  const heading = screen.getByRole('heading', { name: 'AI Claims Data Extractor / Dashboard' });
+  const heading = screen.getByRole('heading', { name: 'ClarifyOps › ClarifyClaims' });
   expect(heading).toBeInTheDocument();
 });
 

--- a/frontend/src/Board.js
+++ b/frontend/src/Board.js
@@ -72,7 +72,7 @@ export default function Board() {
 
   return (
     <MainLayout title="Approval Board">
-      <PageHeader title="AI Claims Data Extractor / Dashboard" subtitle="Approval Board" />
+      <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Approval Board" />
       <DragDropContext onDragEnd={onDragEnd}>
         <div className="flex space-x-4 overflow-x-auto">
             {renderColumn('pending', 'Pending', columns.pending)}

--- a/frontend/src/Claims.js
+++ b/frontend/src/Claims.js
@@ -2105,7 +2105,7 @@ useEffect(() => {
 
       <main className="flex-1 w-full bg-white dark:bg-gray-800 shadow-md rounded-lg p-6 m-4">
         <div className="flex justify-between items-center mb-4">
-          <PageHeader title="AI Claims Data Extractor / Dashboard" />
+          <PageHeader title="ClarifyOps › ClarifyClaims" />
           <LiveFeed token={token} tenant={tenant} />
         </div>
   
@@ -2964,7 +2964,7 @@ useEffect(() => {
                         }`}
                       >
                         <div className="flex items-center space-x-2">
-                          <img src="/logo.png" alt="logo" className="w-8 h-8 object-contain rounded" />
+                          <img src="/logo.svg" alt="ClarifyOps logo" className="w-8 h-8 object-contain rounded" />
                           <span className="text-sm font-semibold">{inv.vendor}</span>
                         </div>
                         <div className="flex-1 text-sm space-y-1">

--- a/frontend/src/ClaimsBrandingPreview.jsx
+++ b/frontend/src/ClaimsBrandingPreview.jsx
@@ -5,15 +5,15 @@ import { ArrowRight } from 'lucide-react';
 
 export default function ClaimsBrandingPreview() {
   return (
-    <MainLayout title="Claims Branding Preview">
-      <PageHeader
-        title="Claims Branding Preview"
-        subtitle="How ClarifyClaims, OpsClaim, and AuditFlow connect"
-      />
+    <MainLayout title="ClarifyOps › ClarifyClaims">
+      <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Claims Branding Preview" />
+      <p className="text-sm text-gray-500 mb-4">
+        How ClarifyClaims, ClarifyOps, and AuditFlow connect
+      </p>
       <div className="flex items-center justify-center gap-4 mt-8">
         <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">ClarifyClaims</div>
         <ArrowRight className="w-6 h-6 text-gray-600 dark:text-gray-300" />
-        <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">OpsClaim</div>
+        <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">ClarifyOps</div>
         <ArrowRight className="w-6 h-6 text-gray-600 dark:text-gray-300" />
         <div className="p-4 rounded bg-indigo-100 dark:bg-indigo-900">AuditFlow</div>
       </div>

--- a/frontend/src/ClarifyClaims.jsx
+++ b/frontend/src/ClarifyClaims.jsx
@@ -64,7 +64,7 @@ export default function ClarifyClaims() {
     const params = new URLSearchParams({ from, to });
     if (opts.flagged) params.set('flagged', 'true');
     if (opts.status) params.set('status', opts.status);
-    navigate(`/opsclaim?${params.toString()}`);
+    navigate(`/claims?${params.toString()}`);
   };
 
   return (

--- a/frontend/src/DashboardBuilder.js
+++ b/frontend/src/DashboardBuilder.js
@@ -129,7 +129,7 @@ export default function DashboardBuilder() {
 
   return (
     <MainLayout title="Dashboard Builder">
-      <PageHeader title="AI Claims Data Extractor / Dashboard" subtitle="Create Your Dashboard" />
+      <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Create Your Dashboard" />
         <DragDropContext onDragEnd={handleDragEnd}>
           <Droppable droppableId="widgets">
             {(provided) => (

--- a/frontend/src/DemoSandbox.js
+++ b/frontend/src/DemoSandbox.js
@@ -58,7 +58,7 @@ export default function DemoSandbox() {
     <div className="min-h-screen p-6 flex flex-col items-center bg-gradient-to-br from-purple-50 via-indigo-100 to-indigo-200 dark:from-purple-900 dark:via-indigo-900 dark:to-gray-900 text-gray-900 dark:text-gray-100">
       <div className="max-w-2xl w-full space-y-6">
         <div className="text-center">
-          <PageHeader title="AI Claims Data Extractor / Dashboard" subtitle="Interactive Demo Sandbox" />
+          <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Interactive Demo Sandbox" />
         </div>
         {step === 1 && (
           <>

--- a/frontend/src/ExportTemplateBuilder.js
+++ b/frontend/src/ExportTemplateBuilder.js
@@ -36,12 +36,12 @@ export default function ExportTemplateBuilder() {
   };
 
   return (
-    <MainLayout title="Export Templates">
+    <MainLayout title="ClarifyOps › ClarifyClaims">
       <div className="space-y-4 max-w-xl">
-        <PageHeader
-          title="Export Templates"
-          subtitle="Select which fields to include in your export template."
-        />
+        <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Export Templates" />
+        <p className="text-sm text-gray-500">
+          Select which fields to include in your export template.
+        </p>
         <div className="bg-white p-6 rounded-xl shadow-sm space-y-4">
           <h2 className="text-lg font-semibold mb-2">Export Template Fields</h2>
           <p className="text-sm text-gray-500 mb-4">

--- a/frontend/src/InstantTrial.js
+++ b/frontend/src/InstantTrial.js
@@ -63,7 +63,7 @@ export default function InstantTrial() {
     <div className="min-h-screen p-6 flex flex-col items-center bg-gradient-to-br from-purple-50 via-indigo-100 to-indigo-200 dark:from-purple-900 dark:via-indigo-900 dark:to-gray-900 text-gray-900 dark:text-gray-100">
       <div className="max-w-2xl w-full space-y-6">
         <div className="text-center">
-          <PageHeader title="AI Claims Data Extractor / Dashboard" subtitle="Instant Free Trial" />
+          <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Instant Free Trial" />
         </div>
         {step === 1 && (
           <div className="space-y-4">

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
@@ -41,29 +41,57 @@ import FaqAccordion from './components/FaqAccordion';
 import TestimonialSlider from './components/TestimonialSlider';
 import PriceCalculator from './components/PriceCalculator';
 import TrustSection from './components/TrustSection';
+import { logEvent } from './lib/analytics';
 
 export default function LandingPage() {
   const [demoOpen, setDemoOpen] = useState(false);
+  const [sent50, setSent50] = useState(false);
+  const [sent90, setSent90] = useState(false);
+  const timeRange = JSON.parse(localStorage.getItem('timeRange') || '{}');
+
+  useEffect(() => {
+    const onScroll = () => {
+      const depth = (window.scrollY + window.innerHeight) / document.body.scrollHeight;
+      if (!sent50 && depth >= 0.5) {
+        logEvent('scroll_depth', { depth: 50 });
+        setSent50(true);
+      }
+      if (!sent90 && depth >= 0.9) {
+        logEvent('scroll_depth', { depth: 90 });
+        setSent90(true);
+      }
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, [sent50, sent90]);
+
   return (
-    <div className="min-h-screen flex flex-col bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-      <nav className="sticky top-0 bg-white/80 backdrop-blur dark:bg-gray-900/80 shadow z-30">
+    <>
+      <a
+        href="#hero"
+        className="sr-only focus:not-sr-only focus:absolute top-0 left-0 bg-surface text-accent p-2"
+      >
+        Skip to content
+      </a>
+      <div className="min-h-screen flex flex-col bg-surface text-ink">
+      <nav className="sticky top-0 bg-surface/80 backdrop-blur shadow z-30">
         <div className="container mx-auto flex justify-between items-center p-4">
           <div className="flex items-center space-x-2">
-            <img src="/logo.png" alt="AI Claims Data Extractor" className="w-6 h-6" />
-            <span className="font-bold text-lg">AI Claims Data Extractor</span>
+            <img src="/logo.svg" alt="ClarifyOps logo" className="h-7 w-auto" />
+            <span className="font-bold text-lg">ClarifyClaims</span>
           </div>
           <div className="hidden md:flex items-center space-x-6 text-sm">
-            <a href="#product" className="hover:text-indigo-600">Claims Processing</a>
-            <a href="#how-it-works" className="hover:text-indigo-600">How It Works</a>
-            <a href="#customers" className="hover:text-indigo-600">Insurance Teams</a>
-            <a href="#pricing" className="hover:text-indigo-600">Pricing</a>
-            <a href="#resources" className="hover:text-indigo-600">Resources</a>
+            <a href="#product" className="hover:text-accent transition-colors duration-fast">Claims Processing</a>
+            <a href="#how-it-works" className="hover:text-accent transition-colors duration-fast">How It Works</a>
+            <a href="#customers" className="hover:text-accent transition-colors duration-fast">Insurance Teams</a>
+            <a href="#pricing" className="hover:text-accent transition-colors duration-fast">Pricing</a>
+            <a href="#resources" className="hover:text-accent transition-colors duration-fast">Resources</a>
           </div>
           <div className="hidden sm:flex items-center space-x-2">
             <Button onClick={() => setDemoOpen(true)}>Request Demo</Button>
             <a
               href="#pricing"
-              className="underline text-sm hover:text-indigo-600"
+              className="underline text-sm hover:text-accent transition-colors duration-fast"
             >
               See all plans
             </a>
@@ -79,7 +107,9 @@ export default function LandingPage() {
         </div>
       </nav>
       <div className="max-w-6xl mx-auto px-4 py-6">
-        <HeroSection onRequestDemo={() => setDemoOpen(true)} />
+        <div id="hero" tabIndex="-1">
+          <HeroSection onRequestDemo={() => setDemoOpen(true)} />
+        </div>
       <ProblemSolutionSection />
       <section className="py-16">
         <h2 className="text-3xl font-bold text-center mb-6">Interactive Claims Processing Demo</h2>
@@ -225,9 +255,9 @@ export default function LandingPage() {
       </section>
       <section className="py-16">
         <h2 className="text-3xl font-bold text-center mb-2">Try Claims Processing →</h2>
-        <p className="text-center mb-4 text-gray-600 dark:text-gray-300">No signup needed. Test claims extraction instantly.</p>
+        <p className="text-center mb-4 text-muted">No signup needed. Test claims extraction instantly.</p>
         <div className="container mx-auto px-6">
-          <ProgressDashboard />
+          <ProgressDashboard from={timeRange.from} to={timeRange.to} />
           <div className="text-center mt-4">
             <DummyDataButton className="btn btn-primary text-lg" />
           </div>
@@ -247,10 +277,10 @@ export default function LandingPage() {
         <div className="container mx-auto overflow-x-auto px-6">
           <div className="flex items-center space-x-4 w-max">
             <Card className="min-w-[150px] flex flex-col items-center space-y-2">
-              <DocumentArrowUpIcon className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
+              <DocumentArrowUpIcon className="w-8 h-8 text-accent" />
               <span className="font-semibold">Upload Claim</span>
             </Card>
-            <ArrowLongRightIcon className="w-6 h-6 text-indigo-600 flex-shrink-0" />
+            <ArrowLongRightIcon className="w-6 h-6 text-accent flex-shrink-0" />
             <Card className="min-w-[150px] flex flex-col items-center space-y-2">
               <CheckCircleIcon className="w-8 h-8 text-indigo-600 dark:text-indigo-400" />
               <span className="font-semibold">AI Extract</span>
@@ -446,9 +476,9 @@ export default function LandingPage() {
           © {new Date().getFullYear()} AI Claims Data Extractor - Insurance Claims Processing Automation
         </p>
       </footer>
-      </div>
-      <ChatWidget />
-      <ScheduleDemoModal open={demoOpen} onClose={() => setDemoOpen(false)} />
     </div>
+    <ChatWidget />
+    <ScheduleDemoModal open={demoOpen} onClose={() => setDemoOpen(false)} />
+  </>
   );
 }

--- a/frontend/src/LegacyClaimsRedirect.jsx
+++ b/frontend/src/LegacyClaimsRedirect.jsx
@@ -1,0 +1,10 @@
+import { Navigate, useLocation } from 'react-router-dom';
+
+export default function LegacyClaimsRedirect() {
+  const location = useLocation();
+  // guard against redirect loops
+  if (location.pathname.startsWith('/claims')) return null;
+  const suffix = location.pathname.replace(/^\/opsclaim/, '');
+  const target = `/claims${suffix}${location.search}${location.hash}`;
+  return <Navigate to={target} replace />;
+}

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -38,10 +38,10 @@ export default function Login({ onLogin, addToast }) {
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       <nav className="fixed top-0 left-0 right-0 bg-indigo-700 dark:bg-indigo-900 text-white shadow p-2 z-20 flex justify-between items-center">
-        <h1 className="text-xl font-bold flex items-center space-x-1">
-          <img src="/logo.png" alt="logo" className="h-5 w-5" />
-          <span>AI Claims Data Extractor</span>
-        </h1>
+        <div className="text-xl font-bold flex items-center space-x-1">
+          <img src="/logo.svg" alt="ClarifyOps logo" className="h-7 w-auto" />
+          <span>ClarifyClaims</span>
+        </div>
         <div className="flex items-center gap-2">
           <HighContrastToggle />
           <DarkModeToggle />
@@ -50,7 +50,7 @@ export default function Login({ onLogin, addToast }) {
       <div className="flex-1 flex items-center justify-center pt-20">
         <Card className="w-80 space-y-4">
           <form onSubmit={(e) => { e.preventDefault(); handleLogin(); }} className="space-y-4">
-          <PageHeader title="AI Claims Data Extractor / Dashboard" subtitle="Login" />
+          <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Login" />
 
           {error && (
             <div className="bg-red-100 text-red-700 p-2 mb-4 text-sm rounded" role="alert">{error}</div>

--- a/frontend/src/NotFound.js
+++ b/frontend/src/NotFound.js
@@ -5,7 +5,7 @@ import PageHeader from './components/PageHeader';
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center text-center p-4">
-      <PageHeader title="AI Claims Data Extractor / Dashboard" subtitle="404 - Page Not Found" />
+      <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="404 - Page Not Found" />
       <p className="mb-4">The page you are looking for does not exist.</p>
       <Link to="/operations" className="text-indigo-600 underline">
         Go to Operations Dashboard

--- a/frontend/src/OperationsDashboard.js
+++ b/frontend/src/OperationsDashboard.js
@@ -349,8 +349,8 @@ function OperationsDashboard() {
                                   icon={<InboxIcon className="w-5 h-5" />}
                                   title="Claim Documents Pending"
                                   value={stats?.invoicesPending || 0}
-                                  cta="Go to OpsClaim"
-                                  onCta={() => navigate('/opsclaim')}
+                                  cta="Go to ClarifyClaims"
+                                  onCta={() => navigate('/claims')}
                                 />
                               )}
                               {m === 'anomalies' && (

--- a/frontend/src/OpsClaim.js
+++ b/frontend/src/OpsClaim.js
@@ -4,6 +4,7 @@ import Skeleton from './components/Skeleton';
 import { motion } from 'framer-motion';
 import ChatSidebar from './components/ChatSidebar';
 import NotesModal from './components/NotesModal';
+import PageHeader from './components/PageHeader';
 import { API_BASE } from './api';
 import {
   Cog6ToothIcon,
@@ -70,7 +71,7 @@ export default function OpsClaim() {
         throw new Error(`HTTP ${res.status}`);
       }
     } catch (err) {
-      console.error('OpsClaim fetch error:', err);
+      console.error('ClarifyClaims fetch error:', err);
     }
     setLoading(false);
   }, [token, tenant, headers, statusFilter, from, to]);
@@ -249,7 +250,8 @@ export default function OpsClaim() {
   const focusMode = copilotOpen || expandedRows.length > 0 || selectedRows.length > 0;
 
   return (
-    <MainLayout title="OpsClaim" helpTopic="opsclaim" collapseSidebar={focusMode}>
+    <MainLayout title="ClarifyOps › ClarifyClaims" helpTopic="opsclaim" collapseSidebar={focusMode}>
+      <PageHeader title="ClarifyOps › ClarifyClaims" subtitle="Triage Queue" />
       {selectedRows.length > 0 && (
         <div className="mb-2 flex gap-2">
           <button onClick={bulkApprove} className="btn btn-ghost text-xs flex items-center gap-1">

--- a/frontend/src/__tests__/ClarifyClaims.test.jsx
+++ b/frontend/src/__tests__/ClarifyClaims.test.jsx
@@ -57,7 +57,7 @@ test('fetches metrics for range, allows drilldown and refetch', async () => {
 
   fireEvent.click(flaggedLabel.parentElement);
   expect(mockNavigate).toHaveBeenCalledWith(
-    `/opsclaim?from=${encodeURIComponent(from7d)}&to=${encodeURIComponent(to)}&flagged=true`
+    `/claims?from=${encodeURIComponent(from7d)}&to=${encodeURIComponent(to)}&flagged=true`
   );
 
   fetch.mockClear();

--- a/frontend/src/__tests__/breadcrumb.test.jsx
+++ b/frontend/src/__tests__/breadcrumb.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+
+test('deep link renders full breadcrumb trail', () => {
+  render(
+    <MemoryRouter initialEntries={["/claims/123/audit/note"]}>
+      <Navbar tenant="t" role="admin" />
+    </MemoryRouter>
+  );
+  const crumb = screen.getByText('ClarifyClaims').parentElement;
+  expect(crumb.textContent).toMatch(/ClarifyOps.*ClarifyClaims.*Claim 123.*Audit.*Note/);
+});

--- a/frontend/src/__tests__/legacyRedirect.test.jsx
+++ b/frontend/src/__tests__/legacyRedirect.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import LegacyClaimsRedirect from '../LegacyClaimsRedirect';
+
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname + location.search + location.hash}</div>;
+}
+
+test('redirect preserves query and hash', () => {
+  render(
+    <MemoryRouter initialEntries={['/opsclaim?foo=bar#baz']}>
+      <Routes>
+        <Route path="/opsclaim/*" element={<LegacyClaimsRedirect />} />
+        <Route path="*" element={<LocationDisplay />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  expect(screen.getByTestId('location').textContent).toBe('/claims?foo=bar#baz');
+});

--- a/frontend/src/__tests__/productSwitcher.test.jsx
+++ b/frontend/src/__tests__/productSwitcher.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+
+test('product switcher preserves query params and time filters', () => {
+  sessionStorage.setItem('claimsQuery', '?status=open&from=1&to=2&page=3');
+  render(
+    <MemoryRouter initialEntries={["/analytics?view=chart"]}>
+      <Navbar tenant="t" role="admin" />
+    </MemoryRouter>
+  );
+  const link = screen.getByTitle('switchProduct');
+  expect(link.getAttribute('href')).toBe('/claims?status=open&from=1&to=2&page=3');
+});

--- a/frontend/src/components/AIInsightChip.jsx
+++ b/frontend/src/components/AIInsightChip.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Tippy from '@tippyjs/react';
 import 'tippy.js/dist/tippy.css';
+import HelpTooltip from './HelpTooltip';
 
 export default function AIInsightChip({ insight }) {
   if (!insight) {
@@ -13,8 +14,9 @@ export default function AIInsightChip({ insight }) {
   const conf = confidence != null ? ` (${Math.round(confidence * 100)}%)` : '';
   return (
     <Tippy content={why || ''}>
-      <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs">
+      <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded text-xs inline-flex items-center">
         {message}
+        <HelpTooltip term={message} />
         {conf}
       </span>
     </Tippy>

--- a/frontend/src/components/BottomNav.js
+++ b/frontend/src/components/BottomNav.js
@@ -4,7 +4,6 @@ import { motion } from 'framer-motion';
 import {
   HomeIcon,
   DocumentIcon,
-  InboxIcon,
   ArchiveBoxIcon,
 } from '@heroicons/react/24/outline';
 
@@ -18,24 +17,18 @@ export default function BottomNav() {
       label: 'ClarifyClaims',
       title: 'Upload, validate, and summarize claims.',
     },
-    {
-      to: '/opsclaim',
-      icon: InboxIcon,
-      label: 'OpsClaim',
-      title: 'Triage, route, and approve claims with live insights.',
-    },
     { to: '/review', icon: DocumentIcon, label: 'Review' },
     { to: '/archive', icon: ArchiveBoxIcon, label: 'Archive' },
   ];
   return (
     <nav className="sm:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t z-20">
       <ul className="flex justify-around">
-        {items.map(({ to, icon: Icon, label }) => (
+        {items.map(({ to, icon: Icon, label, title }) => (
           <li key={to} className="flex-1">
             <motion.div whileHover={{ scale: 1.1 }} className="py-2">
               <Link
                 to={to}
-                title={item.title}
+                title={title}
                 className={`flex flex-col items-center text-xs ${
                   location.pathname === to ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-300'
                 }`}

--- a/frontend/src/components/EmptyState.js
+++ b/frontend/src/components/EmptyState.js
@@ -13,11 +13,11 @@ export default function EmptyState({
 }) {
   return (
     <div className="relative">
-      <img
-        src="/logo.png"
-        alt="logo watermark"
-        className="hidden sm:block absolute -z-10 bottom-0 right-0 w-32 opacity-10 pointer-events-none select-none"
-      />
+        <img
+          src="/logo.svg"
+          alt="ClarifyOps watermark"
+          className="hidden sm:block absolute -z-10 bottom-0 right-0 w-32 opacity-10 pointer-events-none select-none"
+        />
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}

--- a/frontend/src/components/HelpTooltip.js
+++ b/frontend/src/components/HelpTooltip.js
@@ -1,28 +1,78 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import { QuestionMarkCircleIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import { logEvent } from '../lib/analytics';
 
-export default function HelpTooltip({ topic, token }) {
-  const [guide, setGuide] = useState('');
+export default function HelpTooltip({ term }) {
+  const { t } = useTranslation();
+  const id = term?.toLowerCase().replace(/\s+/g, '_');
+  const definition = t(`glossary.${id}`);
+  const version = t('glossary.version');
+  const [open, setOpen] = useState(false);
+  const [seen, setSeen] = useState(() => {
+    const seenState = JSON.parse(localStorage.getItem('glossarySeen') || '{}');
+    return !!seenState[id];
+  });
+  const tooltipRef = useRef(null);
 
   useEffect(() => {
-    const fetchGuide = async () => {
-      try {
-        const res = await fetch(`http://localhost:3000/api/invoices/help/onboarding?topic=${encodeURIComponent(topic)}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        const data = await res.json();
-        if (res.ok) setGuide(data.guide);
-      } catch (e) {
-        console.error('Help fetch failed:', e);
+    function handleOutside(e) {
+      if (tooltipRef.current && !tooltipRef.current.contains(e.target)) {
+        setOpen(false);
       }
-    };
-    fetchGuide();
-  }, [topic, token]);
+    }
+    if (open) document.addEventListener('mousedown', handleOutside);
+    return () => document.removeEventListener('mousedown', handleOutside);
+  }, [open]);
 
-  if (!guide) return null;
+  if (!definition) return null;
+
+  const markSeen = () => {
+    if (seen) return;
+    const seenState = JSON.parse(localStorage.getItem('glossarySeen') || '{}');
+    seenState[id] = true;
+    localStorage.setItem('glossarySeen', JSON.stringify(seenState));
+    setSeen(true);
+  };
+
+  const toggle = () => {
+    const next = !open;
+    setOpen(next);
+    if (next) {
+      markSeen();
+      logEvent('glossary_tooltip_open', { term: id, version });
+    }
+  };
 
   return (
-    <div className="absolute bg-yellow-100 text-gray-800 p-2 rounded shadow text-xs" style={{ maxWidth: '200px' }}>
-      {guide}
-    </div>
+    <span className="inline-block relative">
+      <button
+        type="button"
+        onClick={toggle}
+        onKeyDown={(e) => e.key === 'Escape' && setOpen(false)}
+        aria-label={term}
+        className={`ml-1 text-muted focus:outline-none focus:ring-focus focus:ring-offset-2 rounded transition-colors duration-fast ${seen ? 'opacity-60' : ''}`}
+      >
+        <QuestionMarkCircleIcon className="w-4 h-4" aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          ref={tooltipRef}
+          role="tooltip"
+          className="absolute z-popover bg-surface text-ink border border-default rounded-md p-2 shadow-e2 mt-1 text-sm w-56"
+        >
+          <div className="pr-4">{definition}</div>
+          <button
+            type="button"
+            aria-label={t('close')}
+            onClick={() => setOpen(false)}
+            className="absolute top-1 right-1 text-muted focus:outline-none focus:ring-focus rounded"
+          >
+            <XMarkIcon className="w-3 h-3" />
+          </button>
+          <div className="mt-2 text-[10px] text-muted">v{version}</div>
+        </div>
+      )}
+    </span>
   );
 }

--- a/frontend/src/components/HeroSection.jsx
+++ b/frontend/src/components/HeroSection.jsx
@@ -1,66 +1,71 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import PartnerLogos from './PartnerLogos';
 import { Button } from './ui/Button';
+import { logEvent } from '../lib/analytics';
+import { useTranslation } from 'react-i18next';
+import HelpTooltip from './HelpTooltip';
 
 export default function HeroSection({ onRequestDemo }) {
+  const prefersReduced = useReducedMotion();
+  const { t } = useTranslation();
   return (
     <section
       id="product"
-      className="relative overflow-hidden min-h-[70vh] px-6 py-20 flex items-center justify-center bg-white dark:bg-gray-900"
+      className="relative overflow-hidden min-h-[70vh] px-6 py-20 flex items-center justify-center bg-surface text-ink"
     >
       <img
-        src="/logo.png"
-        alt="logo watermark"
+        src="/logo.svg"
+        alt="ClarifyOps watermark"
         className="hidden md:block absolute right-10 bottom-0 w-1/2 max-w-md opacity-10 pointer-events-none select-none"
       />
       <div className="container mx-auto grid md:grid-cols-2 gap-8 items-center">
         <motion.div
           initial={{ opacity: 0, x: -20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.6 }}
+          transition={{ duration: prefersReduced ? 0 : 0.2 }}
           className="space-y-6 text-center md:text-left"
         >
           <>
-            <h1 className="text-6xl md:text-7xl font-extrabold tracking-tight">
-              AI Claims Data Extractor
-            </h1>
-            <p className="text-xl md:text-2xl max-w-xl mx-auto md:mx-0 text-gray-600 dark:text-gray-300">
-              Automate manual claims extraction with AI. Extract structured data from unstructured insurance claims in seconds.
-            </p>
-            <p className="text-lg text-gray-500 dark:text-gray-400 max-w-lg mx-auto md:mx-0">
-              Built for insurance operations teams and claims processors who need fast, accurate data extraction without the manual work.
+            <h1 className="text-5xl md:text-6xl font-extrabold tracking-tight">{t('hero.headline')}</h1>
+            <p className="text-xl md:text-2xl max-w-xl mx-auto md:mx-0 text-muted">
+              {t('hero.subhead')} <HelpTooltip term="AI Extracted from CMS1500" />
             </p>
           </>
           <div className="flex flex-col sm:flex-row gap-4 justify-center md:justify-start">
-            <Button onClick={onRequestDemo} className="text-lg px-8 py-3">
-              Request Demo
+            <Button
+              onClick={() => {
+                logEvent('hero_cta_click');
+                onRequestDemo();
+              }}
+              className="text-lg px-8 py-3 min-h-[44px]"
+            >
+              {t('hero.cta')}
             </Button>
-            <Button asChild variant="secondary" className="text-lg px-8 py-3">
-              <a href="/free-trial">Start Free Trial</a>
-            </Button>
+            <a
+              href="/free-trial"
+              className="self-center text-muted hover:text-ink underline mt-2 sm:mt-0"
+            >
+              {t('hero.secondary')}
+            </a>
           </div>
-          <div className="flex items-center justify-center md:justify-start space-x-6 text-sm text-gray-500">
-            <div className="flex items-center space-x-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-              <span>No setup required</span>
-            </div>
-            <div className="flex items-center space-x-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-              <span>Process claims in seconds</span>
-            </div>
-          </div>
+          <ul className="flex items-center justify-center md:justify-start space-x-6 text-sm text-muted">
+            <li>{t('hero.proof1')}</li>
+            <li>{t('hero.proof2')}</li>
+            <li>{t('hero.proof3')}</li>
+          </ul>
           <PartnerLogos />
         </motion.div>
         <motion.div
           initial={{ opacity: 0, x: 20 }}
           animate={{ opacity: 1, x: 0 }}
-          transition={{ duration: 0.6 }}
+          transition={{ duration: prefersReduced ? 0 : 0.2 }}
           className="w-full"
         >
           <img
-            src="https://dummyimage.com/800x450/f3f4f6/1e40af.png&text=Claims+Extraction+Dashboard"
+            src="https://placehold.co/800x450/webp?text=Claims+Extraction+Dashboard"
             alt="AI Claims Data Extraction Dashboard"
+            loading="lazy"
             className="w-full rounded-lg shadow-lg"
           />
         </motion.div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -17,9 +17,9 @@ import {
   ArchiveBoxIcon,
   ArrowUpTrayIcon,
   UsersIcon,
-  QuestionMarkCircleIcon,
   Squares2X2Icon,
   FlagIcon,
+  ChevronDownIcon,
 } from '@heroicons/react/24/outline';
 import HelpTooltip from './HelpTooltip';
 
@@ -43,7 +43,6 @@ export default function Navbar({
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [userOpen, setUserOpen] = useState(false);
-  const [helpOpen, setHelpOpen] = useState(false);
   const [darkMode, setDarkMode] = useDarkMode();
   const [tenantName, setTenantName] = useState(tenant);
   const menuRef = useRef(null);
@@ -53,10 +52,17 @@ export default function Navbar({
   const { t } = useTranslation();
   const location = useLocation();
 
-  const crumbs = location.pathname
-    .split('/')
-    .filter(Boolean)
-    .map((c) => c[0].toUpperCase() + c.slice(1));
+  const pathParts = location.pathname.split('/').filter(Boolean);
+  const crumbs = pathParts.slice(1).map((c, i) => {
+    if (i === 0 && /^\d+$/.test(c)) return `Claim ${c}`;
+    return c.replace(/-/g, ' ').replace(/^./, (ch) => ch.toUpperCase());
+  });
+
+  useEffect(() => {
+    if (location.pathname.startsWith('/claims')) {
+      sessionStorage.setItem('claimsQuery', location.search);
+    }
+  }, [location.pathname, location.search]);
 
   useEffect(() => {
     if (!token) return;
@@ -72,16 +78,29 @@ export default function Navbar({
         <div className="flex items-center space-x-2">
           <Link to="/claims" className="flex items-center space-x-1" onClick={() => { setMenuOpen(false); setUserOpen(false); }}>
             <img
-              src="/logo.png"
-              alt="logo"
-              className="h-5 w-5"
+              src="/logo.svg"
+              alt="ClarifyOps logo"
+              className="h-7 w-auto"
             />
             <span className="font-semibold text-sm">{t('title')}</span>
             <span className="ml-1 text-xs opacity-80">{tenantName}</span>
           </Link>
-          {crumbs.length > 0 && (
-            <span className="text-xs opacity-80">/ {crumbs.join(' / ')}</span>
-          )}
+          <span className="text-xs opacity-80">›</span>
+          <Link
+            to={`/claims${sessionStorage.getItem('claimsQuery') || ''}`}
+            className="flex items-center text-sm font-medium"
+            title={t('switchProduct')}
+            aria-label={t('switchProduct')}
+          >
+            ClarifyClaims
+            <ChevronDownIcon className="h-4 w-4 ml-1" />
+          </Link>
+          {crumbs.map((c) => (
+            <React.Fragment key={c}>
+              <span className="text-xs opacity-80">›</span>
+              <span className="text-xs opacity-80">{c}</span>
+            </React.Fragment>
+          ))}
         </div>
         <input
           id="searchInput"
@@ -134,8 +153,8 @@ export default function Navbar({
                 <button
                   className="focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
                   onClick={() => setMenuOpen((o) => !o)}
-                  title="Menu"
-                  aria-label="Menu"
+                  title={t('menu')}
+                  aria-label={t('menu')}
                 >
                   <Bars3Icon className="h-6 w-6" />
                 </button>
@@ -195,14 +214,7 @@ export default function Navbar({
                   </div>
                 )}
               </div>
-              <div
-                className="relative"
-                onMouseEnter={() => setHelpOpen(true)}
-                onMouseLeave={() => setHelpOpen(false)}
-              >
-              <QuestionMarkCircleIcon className="h-6 w-6 cursor-help" />
-              {helpOpen && <HelpTooltip topic="dashboard" token={token} />}
-            </div>
+            <HelpTooltip term="dashboard" />
             <HighContrastToggle />
             <DarkModeToggle />
             <ThemePicker darkMode={darkMode} setDarkMode={setDarkMode} tenant={tenant} />
@@ -210,8 +222,8 @@ export default function Navbar({
                 <button
                   onClick={() => setUserOpen((o) => !o)}
                   className="flex items-center space-x-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white rounded"
-                  title="Account"
-                  aria-label="Account"
+                  title={t('account')}
+                  aria-label={t('account')}
                 >
                   <img
                     src="https://api.dicebear.com/7.x/initials/svg?seed=bini&backgroundColor=5B21B6&textColor=ffffff"
@@ -227,14 +239,14 @@ export default function Navbar({
                         onClick={() => { onStartTour(); setUserOpen(false); }}
                         className="block px-4 py-2 text-left w-full hover:bg-gray-100 dark:hover:bg-gray-700"
                       >
-                        Start Tour
+                        {t('startTour')}
                       </button>
                     )}
                     <button
                       onClick={onLogout}
                       className="block px-4 py-2 text-left w-full hover:bg-gray-100 dark:hover:bg-gray-700"
                     >
-                      Logout
+                      {t('logout')}
                     </button>
                   </div>
                 )}

--- a/frontend/src/components/ProgressDashboard.js
+++ b/frontend/src/components/ProgressDashboard.js
@@ -1,42 +1,92 @@
 import React, { useEffect, useState } from 'react';
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import { useNavigate } from 'react-router-dom';
 import Skeleton from './Skeleton';
 import { API_BASE } from '../api';
+import { useTranslation } from 'react-i18next';
+import { logEvent } from '../lib/analytics';
 
-export default function ProgressDashboard() {
+export default function ProgressDashboard({ from, to, role = 'reviewer' }) {
   const token = localStorage.getItem('token') || '';
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [lastUpdated, setLastUpdated] = useState(null);
+  const navigate = useNavigate();
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (!token) return;
     const headers = { Authorization: `Bearer ${token}` };
-    fetch(`${API_BASE}/api/invoices/progress`, { headers })
-      .then(r => r.json().then(d => ({ ok: r.ok, d })))
-      .then(({ ok, d }) => {
-        if (ok) setStats(d);
-      })
-      .finally(() => setLoading(false));
-  }, [token]);
+    let es;
+    const url = `${API_BASE}/api/invoices/progress?from=${from || ''}&to=${to || ''}`;
+    const fetchData = () => {
+      fetch(url, { headers })
+        .then((r) => r.json().then((d) => ({ ok: r.ok, d })))
+        .then(({ ok, d }) => {
+          if (ok) {
+            setStats(d);
+            setLastUpdated(new Date());
+          }
+        })
+        .finally(() => setLoading(false));
+    };
+    fetchData();
+    try {
+      es = new EventSource(`${url}&stream=1`, { withCredentials: true });
+      es.onmessage = (e) => {
+        setStats(JSON.parse(e.data));
+        setLastUpdated(new Date());
+      };
+    } catch {
+      const id = setInterval(fetchData, 30000);
+      return () => clearInterval(id);
+    }
+    return () => es && es.close();
+  }, [token, from, to]);
 
   if (loading) return <Skeleton rows={3} className="h-40" />;
   if (!stats) return null;
 
+  const safeStats = { ...stats };
+  if (role === 'reviewer') {
+    safeStats.flagged = null;
+    logEvent('metric_access_denied', { role, metric: 'flagged' });
+  }
+  if (role === 'payer') {
+    safeStats.uploaded = null;
+    logEvent('metric_access_denied', { role, metric: 'uploaded' });
+  }
+
   const data = [
-    { name: 'Uploaded', value: stats.uploaded },
-    { name: 'Categorized', value: stats.categorized },
-    { name: 'Flagged', value: stats.flagged },
+    { name: 'Uploaded', value: safeStats.uploaded },
+    { name: 'Categorized', value: safeStats.categorized },
+    { name: 'Flagged', value: safeStats.flagged },
   ];
 
+  const handleBarClick = (bar) => {
+    const status = bar.activeLabel?.toLowerCase();
+    if (!status) return;
+    const requestId = crypto.randomUUID();
+    logEvent('dashboard_drilldown', { status, from, to, request_id: requestId });
+    navigate(`/claims?status=${status}&from=${from || ''}&to=${to || ''}`);
+  };
+
   return (
-    <ResponsiveContainer width="100%" height={200}>
-      <BarChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="name" />
-        <YAxis allowDecimals={false} />
-        <Tooltip />
-        <Bar dataKey="value" fill="#6366f1" />
-      </BarChart>
-    </ResponsiveContainer>
+    <div className="space-y-2">
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }} onClick={handleBarClick}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Bar dataKey="value" fill="#6366f1" />
+        </BarChart>
+      </ResponsiveContainer>
+      {lastUpdated && (
+        <div className="text-xs text-muted">
+          {t('lastUpdated')}: {lastUpdated.toLocaleTimeString()}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/components/SidebarNav.js
+++ b/frontend/src/components/SidebarNav.js
@@ -11,7 +11,6 @@ import {
   LayoutGrid,
   Archive,
   Flag,
-  Inbox,
   FileBarChart2,
   ChevronLeft,
   Menu,
@@ -60,14 +59,6 @@ export default function SidebarNav({ notifications = [], collapsed = false }) {
             >
               <FileText className="w-5 h-5" />
               <span>ClarifyClaims</span>
-            </Link>
-            <Link
-              to="/opsclaim"
-              title="Triage, route, and approve claims with live insights."
-              className={`nav-link border-l-4 ${location.pathname === '/opsclaim' ? 'font-semibold bg-indigo-100 dark:bg-indigo-700 border-indigo-500' : 'border-transparent'}`}
-            >
-              <Inbox className="w-5 h-5" />
-              <span>OpsClaim</span>
             </Link>
             <Link
               to="/vendors"

--- a/frontend/src/components/TopNavbar.js
+++ b/frontend/src/components/TopNavbar.js
@@ -7,22 +7,16 @@ import DarkModeToggle from './DarkModeToggle';
 import HighContrastToggle from './HighContrastToggle';
 
 export default function TopNavbar({ title, helpTopic }) {
-  const token = localStorage.getItem('token') || '';
   const { t } = useTranslation();
+  const token = typeof window !== 'undefined' ? localStorage.getItem('token') : '';
   return (
     <header className="sticky top-0 z-30 h-12 bg-indigo-700/60 dark:bg-indigo-900/60 backdrop-blur text-white shadow flex items-center justify-between px-4">
-      <h1 className="text-lg font-semibold flex items-center space-x-2">
-        <img src="/logo.png" alt="logo" className="h-6 w-6" />
+      <div className="text-lg font-semibold flex items-center space-x-2">
+        <img src="/logo.svg" alt="ClarifyOps logo" className="h-7 w-auto" />
         <span>{t('title')}</span>
         <span className="opacity-70">/ {title}</span>
-        {helpTopic && (
-          <span className="relative group cursor-help">❓
-            <span className="hidden group-hover:block absolute z-10">
-              <HelpTooltip topic={helpTopic} token={token} />
-            </span>
-          </span>
-        )}
-      </h1>
+        {helpTopic && <HelpTooltip term={helpTopic} />}
+      </div>
       <div className="flex items-center gap-2">
         <LanguageSelector />
         <HighContrastToggle />

--- a/frontend/src/components/__tests__/HelpTooltip.test.jsx
+++ b/frontend/src/components/__tests__/HelpTooltip.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import HelpTooltip from '../HelpTooltip';
+
+describe('HelpTooltip', () => {
+  test('opens via keyboard and stores seen state', async () => {
+    localStorage.clear();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <HelpTooltip term="overcoded" />
+      </I18nextProvider>
+    );
+    const btn = screen.getByRole('button', { name: /overcoded/i });
+    await userEvent.tab();
+    expect(btn).toHaveFocus();
+    await userEvent.keyboard('{Enter}');
+    const tip = await screen.findByRole('tooltip');
+    expect(tip).toHaveTextContent(/billed CPT/i);
+    const seen = JSON.parse(localStorage.getItem('glossarySeen'));
+    expect(seen.overcoded).toBe(true);
+  });
+});

--- a/frontend/src/components/__tests__/__snapshots__/visual.pr.test.jsx.snap
+++ b/frontend/src/components/__tests__/__snapshots__/visual.pr.test.jsx.snap
@@ -1,0 +1,463 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hero snapshot light and dark 1`] = `
+<DocumentFragment>
+  <section
+    class="relative overflow-hidden min-h-[70vh] px-6 py-20 flex items-center justify-center bg-surface text-ink"
+    id="product"
+  >
+    <img
+      alt="ClarifyOps watermark"
+      class="hidden md:block absolute right-10 bottom-0 w-1/2 max-w-md opacity-10 pointer-events-none select-none"
+      src="/logo.svg"
+    />
+    <div
+      class="container mx-auto grid md:grid-cols-2 gap-8 items-center"
+    >
+      <div
+        class="space-y-6 text-center md:text-left"
+        style="opacity: 0; transform: translateX(-20px);"
+      >
+        <h1
+          class="text-5xl md:text-6xl font-extrabold tracking-tight"
+        >
+          extract, validate, and resolve medical claims with AI. faster reviews, fewer denials.
+        </h1>
+        <p
+          class="text-xl md:text-2xl max-w-xl mx-auto md:mx-0 text-muted"
+        >
+          from CMS-1500 and UB-04 to CPT/HCPCS checks and audit trails—built for adjusters, reviewers, and payers. 
+          <span
+            class="inline-block relative"
+          >
+            <button
+              aria-label="AI Extracted from CMS1500"
+              class="ml-1 text-muted focus:outline-none focus:ring-focus focus:ring-offset-2 rounded transition-colors duration-fast "
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="w-4 h-4"
+                data-slot="icon"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </span>
+        </p>
+        <div
+          class="flex flex-col sm:flex-row gap-4 justify-center md:justify-start"
+        >
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap rounded-full font-medium transition-colors duration-fast focus:outline-none focus:ring-focus focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-accent text-white hover:bg-accent-hover h-10 text-lg px-8 py-3 min-h-[44px]"
+          >
+            Request Demo
+          </button>
+          <a
+            class="self-center text-muted hover:text-ink underline mt-2 sm:mt-0"
+            href="/free-trial"
+          >
+            Start Free Trial
+          </a>
+        </div>
+        <ul
+          class="flex items-center justify-center md:justify-start space-x-6 text-sm text-muted"
+        >
+          <li>
+            -42% review time
+          </li>
+          <li>
+            HIPAA-ready
+          </li>
+          <li>
+            p50 turnaround 2.1h
+          </li>
+        </ul>
+        <div
+          class="pt-4 text-center md:text-left"
+        >
+          <p
+            class="text-sm text-gray-500 dark:text-gray-400 mb-2 font-medium"
+          >
+            Trusted by insurance teams at
+          </p>
+          <div
+            class="flex justify-center md:justify-start items-center gap-4 opacity-80"
+          >
+            <img
+              alt="State Farm"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=State%20Farm"
+            />
+            <img
+              alt="Allstate"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=Allstate"
+            />
+            <img
+              alt="Progressive"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=Progressive"
+            />
+            <img
+              alt="Liberty Mutual"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=Liberty%20Mutual"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="w-full"
+        style="opacity: 0; transform: translateX(20px);"
+      >
+        <img
+          alt="AI Claims Data Extraction Dashboard"
+          class="w-full rounded-lg shadow-lg"
+          loading="lazy"
+          src="https://placehold.co/800x450/webp?text=Claims+Extraction+Dashboard"
+        />
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`hero snapshot light and dark 2`] = `
+<DocumentFragment>
+  <section
+    class="relative overflow-hidden min-h-[70vh] px-6 py-20 flex items-center justify-center bg-surface text-ink"
+    id="product"
+  >
+    <img
+      alt="ClarifyOps watermark"
+      class="hidden md:block absolute right-10 bottom-0 w-1/2 max-w-md opacity-10 pointer-events-none select-none"
+      src="/logo.svg"
+    />
+    <div
+      class="container mx-auto grid md:grid-cols-2 gap-8 items-center"
+    >
+      <div
+        class="space-y-6 text-center md:text-left"
+        style="opacity: 0; transform: translateX(-20px);"
+      >
+        <h1
+          class="text-5xl md:text-6xl font-extrabold tracking-tight"
+        >
+          extract, validate, and resolve medical claims with AI. faster reviews, fewer denials.
+        </h1>
+        <p
+          class="text-xl md:text-2xl max-w-xl mx-auto md:mx-0 text-muted"
+        >
+          from CMS-1500 and UB-04 to CPT/HCPCS checks and audit trails—built for adjusters, reviewers, and payers. 
+          <span
+            class="inline-block relative"
+          >
+            <button
+              aria-label="AI Extracted from CMS1500"
+              class="ml-1 text-muted focus:outline-none focus:ring-focus focus:ring-offset-2 rounded transition-colors duration-fast "
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="w-4 h-4"
+                data-slot="icon"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+          </span>
+        </p>
+        <div
+          class="flex flex-col sm:flex-row gap-4 justify-center md:justify-start"
+        >
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap rounded-full font-medium transition-colors duration-fast focus:outline-none focus:ring-focus focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-accent text-white hover:bg-accent-hover h-10 text-lg px-8 py-3 min-h-[44px]"
+          >
+            Request Demo
+          </button>
+          <a
+            class="self-center text-muted hover:text-ink underline mt-2 sm:mt-0"
+            href="/free-trial"
+          >
+            Start Free Trial
+          </a>
+        </div>
+        <ul
+          class="flex items-center justify-center md:justify-start space-x-6 text-sm text-muted"
+        >
+          <li>
+            -42% review time
+          </li>
+          <li>
+            HIPAA-ready
+          </li>
+          <li>
+            p50 turnaround 2.1h
+          </li>
+        </ul>
+        <div
+          class="pt-4 text-center md:text-left"
+        >
+          <p
+            class="text-sm text-gray-500 dark:text-gray-400 mb-2 font-medium"
+          >
+            Trusted by insurance teams at
+          </p>
+          <div
+            class="flex justify-center md:justify-start items-center gap-4 opacity-80"
+          >
+            <img
+              alt="State Farm"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=State%20Farm"
+            />
+            <img
+              alt="Allstate"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=Allstate"
+            />
+            <img
+              alt="Progressive"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=Progressive"
+            />
+            <img
+              alt="Liberty Mutual"
+              class="h-8 object-contain rounded"
+              src="https://dummyimage.com/120x60/4b2ad3/ffffff.png&text=Liberty%20Mutual"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="w-full"
+        style="opacity: 0; transform: translateX(20px);"
+      >
+        <img
+          alt="AI Claims Data Extraction Dashboard"
+          class="w-full rounded-lg shadow-lg"
+          loading="lazy"
+          src="https://placehold.co/800x450/webp?text=Claims+Extraction+Dashboard"
+        />
+      </div>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`navbar snapshot light and dark 1`] = `
+<DocumentFragment>
+  <header
+    class="sticky top-0 z-30 h-12 bg-indigo-700/60 dark:bg-indigo-900/60 backdrop-blur text-white shadow flex items-center justify-between px-4"
+  >
+    <div
+      class="text-lg font-semibold flex items-center space-x-2"
+    >
+      <img
+        alt="ClarifyOps logo"
+        class="h-7 w-auto"
+        src="/logo.svg"
+      />
+      <span>
+        ClarifyOps
+      </span>
+      <span
+        class="opacity-70"
+      >
+        / Test
+      </span>
+    </div>
+    <div
+      class="flex items-center gap-2"
+    >
+      <select
+        class="input px-1 text-sm"
+      >
+        <option
+          value="en"
+        >
+          EN
+        </option>
+        <option
+          value="es"
+        >
+          ES
+        </option>
+        <option
+          value="fr"
+        >
+          FR
+        </option>
+      </select>
+      <button
+        aria-label="Toggle high contrast mode"
+        class="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+        title="Enable high contrast"
+      >
+        <svg
+          aria-hidden="true"
+          class="h-6 w-6"
+          data-slot="icon"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15 11.25 1.5 1.5.75-.75V8.758l2.276-.61a3 3 0 1 0-3.675-3.675l-.61 2.277H12l-.75.75 1.5 1.5M15 11.25l-8.47 8.47c-.34.34-.8.53-1.28.53s-.94.19-1.28.53l-.97.97-.75-.75.97-.97c.34-.34.53-.8.53-1.28s.19-.94.53-1.28L12.75 9M15 11.25 12.75 9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Toggle dark mode"
+        class="p-2 ml-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+        title="Switch to dark mode"
+      >
+        <svg
+          aria-hidden="true"
+          class="h-6 w-6 text-indigo-200 transform transition-transform duration-300"
+          data-slot="icon"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+      <a
+        class="underline"
+        href="/"
+      >
+        Back to App
+      </a>
+    </div>
+  </header>
+</DocumentFragment>
+`;
+
+exports[`navbar snapshot light and dark 2`] = `
+<DocumentFragment>
+  <header
+    class="sticky top-0 z-30 h-12 bg-indigo-700/60 dark:bg-indigo-900/60 backdrop-blur text-white shadow flex items-center justify-between px-4"
+  >
+    <div
+      class="text-lg font-semibold flex items-center space-x-2"
+    >
+      <img
+        alt="ClarifyOps logo"
+        class="h-7 w-auto"
+        src="/logo.svg"
+      />
+      <span>
+        ClarifyOps
+      </span>
+      <span
+        class="opacity-70"
+      >
+        / Test
+      </span>
+    </div>
+    <div
+      class="flex items-center gap-2"
+    >
+      <select
+        class="input px-1 text-sm"
+      >
+        <option
+          value="en"
+        >
+          EN
+        </option>
+        <option
+          value="es"
+        >
+          ES
+        </option>
+        <option
+          value="fr"
+        >
+          FR
+        </option>
+      </select>
+      <button
+        aria-label="Toggle high contrast mode"
+        class="focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded"
+        title="Enable high contrast"
+      >
+        <svg
+          aria-hidden="true"
+          class="h-6 w-6"
+          data-slot="icon"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m15 11.25 1.5 1.5.75-.75V8.758l2.276-.61a3 3 0 1 0-3.675-3.675l-.61 2.277H12l-.75.75 1.5 1.5M15 11.25l-8.47 8.47c-.34.34-.8.53-1.28.53s-.94.19-1.28.53l-.97.97-.75-.75.97-.97c.34-.34.53-.8.53-1.28s.19-.94.53-1.28L12.75 9M15 11.25 12.75 9"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+      <button
+        aria-label="Toggle dark mode"
+        class="p-2 ml-1 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 transition-colors"
+        title="Switch to dark mode"
+      >
+        <svg
+          aria-hidden="true"
+          class="h-6 w-6 text-indigo-200 transform transition-transform duration-300"
+          data-slot="icon"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+      <a
+        class="underline"
+        href="/"
+      >
+        Back to App
+      </a>
+    </div>
+  </header>
+</DocumentFragment>
+`;

--- a/frontend/src/components/__tests__/visual.pr.test.jsx
+++ b/frontend/src/components/__tests__/visual.pr.test.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../i18n';
+import HeroSection from '../HeroSection';
+import TopNavbar from '../TopNavbar';
+
+test('hero snapshot light and dark', () => {
+  const { asFragment, unmount } = render(
+    <I18nextProvider i18n={i18n}>
+      <HeroSection onRequestDemo={() => {}} />
+    </I18nextProvider>
+  );
+  expect(asFragment()).toMatchSnapshot();
+  unmount();
+  document.documentElement.classList.add('dark');
+  const { asFragment: darkFrag } = render(
+    <I18nextProvider i18n={i18n}>
+      <HeroSection onRequestDemo={() => {}} />
+    </I18nextProvider>
+  );
+  expect(darkFrag()).toMatchSnapshot();
+  document.documentElement.classList.remove('dark');
+});
+
+test('navbar snapshot light and dark', () => {
+  const { asFragment, unmount } = render(
+    <MemoryRouter>
+      <I18nextProvider i18n={i18n}>
+        <TopNavbar title="Test" />
+      </I18nextProvider>
+    </MemoryRouter>
+  );
+  expect(asFragment()).toMatchSnapshot();
+  unmount();
+  document.documentElement.classList.add('dark');
+  const { asFragment: darkFrag } = render(
+    <MemoryRouter>
+      <I18nextProvider i18n={i18n}>
+        <TopNavbar title="Test" />
+      </I18nextProvider>
+    </MemoryRouter>
+  );
+  expect(darkFrag()).toMatchSnapshot();
+  document.documentElement.classList.remove('dark');
+});

--- a/frontend/src/components/ui/Button.js
+++ b/frontend/src/components/ui/Button.js
@@ -4,14 +4,13 @@ import { cva } from 'class-variance-authority';
 import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-all duration-300 ease-in-out transform hover:scale-105 focus:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  'inline-flex items-center justify-center whitespace-nowrap rounded-full text-sm font-medium transition-colors duration-fast focus:outline-none focus:ring-focus focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'bg-gradient-to-br from-indigo-500 to-purple-600 text-white hover:brightness-110',
-        secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
-        outline:
-          'border border-gray-300 text-gray-700 bg-transparent hover:bg-gray-50',
+        default: 'bg-accent text-white hover:bg-accent-hover',
+        secondary: 'bg-surface text-ink border border-default hover:bg-accent hover:text-white',
+        outline: 'border border-default text-ink bg-transparent hover:bg-surface',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -17,7 +17,6 @@ import WorkflowPage from './WorkflowPage';
 import WorkflowBuilderPage from './WorkflowBuilderPage';
 import Board from './Board';
 import KanbanDashboard from './KanbanDashboard';
-import OpsClaim from './OpsClaim';
 import NotFound from './NotFound';
 import ResultsViewer from './ResultsViewer';
 import ErrorBoundary from './ErrorBoundary';
@@ -29,7 +28,8 @@ import InstantTrial from './InstantTrial';
 import LoginPage from './LoginPage';
 import ClarifyClaims from './ClarifyClaims';
 import ClaimsBrandingPreview from './ClaimsBrandingPreview';
-import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation, Navigate } from 'react-router-dom';
+import LegacyClaimsRedirect from './LegacyClaimsRedirect';
 import { AnimatePresence, motion } from 'framer-motion';
 import './index.css';
 import './i18n';
@@ -129,7 +129,7 @@ function AnimatedRoutes() {
         <Route path="/adaptive" element={<PageWrapper><AdaptiveDashboard /></PageWrapper>} />
         <Route path="/dashboard/shared/:token" element={<PageWrapper><SharedDashboard /></PageWrapper>} />
         <Route path="/claims" element={<PageWrapper><ClaimsPage /></PageWrapper>} />
-        <Route path="/opsclaim" element={<PageWrapper><OpsClaim /></PageWrapper>} />
+        <Route path="/opsclaim/*" element={<LegacyClaimsRedirect />} />
         <Route path="/claims/branding-preview" element={<PageWrapper><ClaimsBrandingPreview /></PageWrapper>} />
         <Route path="/analytics" element={<PageWrapper><AISpendAnalyticsHub /></PageWrapper>} />
         <Route path="/auditflow" element={<PageWrapper><AuditFlow /></PageWrapper>} />
@@ -148,10 +148,12 @@ function AnimatedRoutes() {
         <Route path="/onboarding" element={<PageWrapper><OnboardingWizard /></PageWrapper>} />
         <Route path="/sandbox" element={<PageWrapper><DemoSandbox /></PageWrapper>} />
         <Route path="/free-trial" element={<PageWrapper><InstantTrial /></PageWrapper>} />
-        <Route path="/clarifyclaims" element={<PageWrapper><ClarifyClaims /></PageWrapper>} />
+        <Route path="/claims/summary" element={<PageWrapper><ClarifyClaims /></PageWrapper>} />
         <Route path="/results/:id" element={<PageWrapper><ResultsViewer /></PageWrapper>} />
         <Route path="/login" element={<PageWrapper><LoginPage /></PageWrapper>} />
         <Route path="/" element={<PageWrapper><LandingPage /></PageWrapper>} />
+        <Route path="/invoice" element={<Navigate to="/claims" replace />} />
+        <Route path="/invoices/*" element={<Navigate to="/claims" replace />} />
         <Route path="*" element={<PageWrapper><NotFound /></PageWrapper>} />
       </Routes>
     </AnimatePresence>

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1,5 +1,5 @@
 {
-  "title": "AI Claims Data Extractor",
+  "title": "ClarifyOps",
   "upload": "Upload",
   "searchPlaceholder": "Search...",
   "demoUpload": "Demo Upload",
@@ -8,6 +8,27 @@
   "close": "Close",
   "seedDummyData": "Load Demo Data",
   "seeding": "Seeding...",
-  "seeded": "Seeded!"
-  ,"uploadSummary": "Upload Summary"
+  "seeded": "Seeded!",
+  "uploadSummary": "Upload Summary",
+  "lastUpdated": "Last updated",
+  "switchProduct": "Switch product",
+  "menu": "Menu",
+  "account": "Account",
+  "logout": "Logout",
+  "startTour": "Start Tour",
+  "glossary": {
+    "version": "2023-09-15",
+    "ai_extracted_from_cms1500": "Source document and extraction confidence shown.",
+    "overcoded": "The billed CPT may not match documentation detail; consider downcoding.",
+    "missing_modifier": "Claim may require a modifier (e.g., 25, 59) to bypass NCCI edits."
+  },
+  "hero": {
+    "headline": "extract, validate, and resolve medical claims with AI. faster reviews, fewer denials.",
+    "subhead": "from CMS-1500 and UB-04 to CPT/HCPCS checks and audit trails—built for adjusters, reviewers, and payers.",
+    "cta": "Request Demo",
+    "secondary": "Start Free Trial",
+    "proof1": "-42% review time",
+    "proof2": "HIPAA-ready",
+    "proof3": "p50 turnaround 2.1h"
+  }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1,5 +1,5 @@
 {
-  "title": "AI Claims Data Extractor",
+  "title": "ClarifyOps",
   "upload": "Subir",
   "searchPlaceholder": "Buscar...",
   "demoUpload": "Carga de Demostración",
@@ -8,6 +8,27 @@
   "close": "Cerrar",
   "seedDummyData": "Generar Datos de Prueba",
   "seeding": "Generando...",
-  "seeded": "¡Generado!"
-  ,"uploadSummary": "Resumen de Subida"
+  "seeded": "¡Generado!",
+  "uploadSummary": "Resumen de Subida",
+  "lastUpdated": "Última actualización",
+  "switchProduct": "Cambiar producto",
+  "menu": "Menú",
+  "account": "Cuenta",
+  "logout": "Cerrar sesión",
+  "startTour": "Iniciar recorrido",
+  "glossary": {
+    "version": "2023-09-15",
+    "ai_extracted_from_cms1500": "Documento de origen y confianza de extracción mostrados.",
+    "overcoded": "El CPT facturado puede no coincidir con la documentación; considere bajar el código.",
+    "missing_modifier": "La reclamación puede requerir un modificador (p. ej., 25, 59) para evitar ediciones NCCI."
+  },
+  "hero": {
+    "headline": "extraiga, valide y resuelva reclamaciones médicas con IA. revisiones más rápidas, menos denegaciones.",
+    "subhead": "de CMS-1500 y UB-04 a comprobaciones CPT/HCPCS y rastros de auditoría—para ajustadores, revisores y pagadores.",
+    "cta": "Solicitar demostración",
+    "secondary": "Iniciar prueba gratuita",
+    "proof1": "-42% tiempo de revisión",
+    "proof2": "Preparado para HIPAA",
+    "proof3": "p50 tiempo de respuesta 2.1h"
+  }
 }

--- a/frontend/src/locales/fr/translation.json
+++ b/frontend/src/locales/fr/translation.json
@@ -1,5 +1,5 @@
 {
-  "title": "AI Claims Data Extractor",
+  "title": "ClarifyOps",
   "upload": "Téléverser",
   "searchPlaceholder": "Recherche...",
   "demoUpload": "Téléversement Démo",
@@ -8,6 +8,27 @@
   "close": "Fermer",
   "seedDummyData": "Générer des Données d'Essai",
   "seeding": "Génération...",
-  "seeded": "Généré !"
-  ,"uploadSummary": "Récapitulatif de Téléversement"
+  "seeded": "Généré !",
+  "uploadSummary": "Récapitulatif de Téléversement",
+  "lastUpdated": "Dernière mise à jour",
+  "switchProduct": "Changer de produit",
+  "menu": "Menu",
+  "account": "Compte",
+  "logout": "Déconnexion",
+  "startTour": "Démarrer la visite",
+  "glossary": {
+    "version": "2023-09-15",
+    "ai_extracted_from_cms1500": "Document source et confiance d'extraction affichés.",
+    "overcoded": "Le CPT facturé peut ne pas correspondre aux pièces; envisagez une décote.",
+    "missing_modifier": "La demande peut nécessiter un modificateur (ex. 25, 59) pour éviter les éditions NCCI."
+  },
+  "hero": {
+    "headline": "extraire, valider et résoudre les demandes médicales avec l'IA. examens plus rapides, moins de refus.",
+    "subhead": "du CMS-1500 et UB-04 aux vérifications CPT/HCPCS et pistes d'audit—conçu pour les experts, réviseurs et payeurs.",
+    "cta": "Demander une démo",
+    "secondary": "Commencer l'essai gratuit",
+    "proof1": "-42% temps d'examen",
+    "proof2": "Compatible HIPAA",
+    "proof3": "p50 délai de traitement 2,1 h"
+  }
 }

--- a/frontend/tests/a11y.spec.js
+++ b/frontend/tests/a11y.spec.js
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+test('landing page has no obvious accessibility issues', async ({ page }) => {
+  await page.goto('/');
+  const results = await new AxeBuilder({ page }).analyze();
+  expect(results.violations).toEqual([]);
+});

--- a/frontend/tests/glossary.spec.js
+++ b/frontend/tests/glossary.spec.js
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('glossary tooltip opens via keyboard', async ({ page }) => {
+  await page.goto('/');
+  const help = page.getByLabel(/AI Extracted from CMS1500/i);
+  await help.focus();
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('tooltip')).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('tooltip')).not.toBeVisible();
+});

--- a/frontend/tests/mobile.spec.js
+++ b/frontend/tests/mobile.spec.js
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('navbar collapse and hero CTA', async ({ page }) => {
+  await page.goto('/');
+  const cta = page.getByRole('button', { name: /request demo/i });
+  await expect(cta).toBeVisible();
+  await cta.click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+});

--- a/nginx/Default.conf
+++ b/nginx/Default.conf
@@ -19,8 +19,18 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    location ~ ^/opsclaim(.*)$ {
+        return 308 /claims$1$is_args$args;
+    }
+
     location / {
         proxy_pass http://frontend;
         try_files $uri /index.html;
     }
+
+    add_header Content-Security-Policy "script-src 'self' https://static.hotjar.com; object-src 'none'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=()" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -19,8 +19,18 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    location ~ ^/opsclaim(.*)$ {
+        return 308 /claims$1$is_args$args;
+    }
+
     location / {
         proxy_pass http://frontend;
         try_files $uri /index.html;
     }
+
+    add_header Content-Security-Policy "script-src 'self' https://static.hotjar.com; object-src 'none'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=()" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -24,6 +24,10 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    location ~ ^/opsclaim(.*)$ {
+        return 308 /claims$1$is_args$args;
+    }
+
     # Everything else goes to frontend
     location / {
         proxy_pass http://frontend;
@@ -36,6 +40,12 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
     }
+
+    add_header Content-Security-Policy "script-src 'self' https://static.hotjar.com; object-src 'none'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=()" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
 }
 
 # Production server (HTTPS) - only used if SSL certificates exist
@@ -62,6 +72,10 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    location ~ ^/opsclaim(.*)$ {
+        return 308 /claims$1$is_args$args;
+    }
+
     location / {
         proxy_pass http://frontend;
         proxy_http_version 1.1;
@@ -73,5 +87,11 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
     }
+
+    add_header Content-Security-Policy "script-src 'self' https://static.hotjar.com; object-src 'none'" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=()" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
 }
 


### PR DESCRIPTION
## Summary
- add 308 legacy opsclaim redirect with security headers and sitemap generation script
- translate landing hero, add glossary shortcut, and log RBAC drilldowns
- tighten CI with lighthouse budgets, smoke tests, and visual snapshots
- test breadcrumbs for deep claim links and product switcher query preservation

## Testing
- `cd frontend && npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `cd backend && npm test`
- `cd frontend && npx playwright test` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_689cad36c870832e941f265a1519c254