### PR TITLE
Replace unsupported PillIcon and clean up build issues

### DIFF
--- a/frontend/src/AuditFlow.js
+++ b/frontend/src/AuditFlow.js
@@ -6,7 +6,7 @@ import {
   CalendarIcon,
   MagnifyingGlassIcon,
   ExclamationTriangleIcon,
-  PillIcon,
+  ClipboardDocumentListIcon,
   UserGroupIcon,
 } from '@heroicons/react/24/outline';
 import { API_BASE } from './api';
@@ -120,7 +120,7 @@ export default function AuditFlow() {
             value={anomalyCount}
           />
           <StatCard
-            icon={<PillIcon className="w-6 h-6" />}
+            icon={<ClipboardDocumentListIcon className="w-6 h-6" />}
             title="CPT Issue Types"
             value={cptIssues.length}
           >

--- a/frontend/src/Claims.js
+++ b/frontend/src/Claims.js
@@ -391,10 +391,8 @@ const [selectedAssignee, setSelectedAssignee] = useState('');
               body: JSON.stringify({ tags: uniqueTags }),
             });
             if (colorRes.ok) {
-              const colorData = await colorRes.json();
-              if (colorData.colors) {
-                setTagColors(colorData.colors);
-              }
+              // Tag color suggestions are fetched but currently unused
+              await colorRes.json();
             }
           } catch (e) {
             console.error('Tag color fetch failed:', e);

--- a/frontend/src/components/ReviewButtons.jsx
+++ b/frontend/src/components/ReviewButtons.jsx
@@ -7,7 +7,6 @@ import useClaimActions from '../hooks/useClaimActions';
 const ENABLED = process.env.REACT_APP_REVIEW_ACTIONS === 'true';
 
 export default function ReviewButtons({ claimId, status, addToast }) {
-  if (!ENABLED) return null;
   const {
     canApprove,
     canRequestInfo,
@@ -19,6 +18,8 @@ export default function ReviewButtons({ claimId, status, addToast }) {
     escalate,
     escalating,
   } = useClaimActions(claimId, status);
+
+  if (!ENABLED) return null;
 
   const handle = async (actionFn, confirm = false) => {
     if (confirm && !window.confirm('Are you sure?')) return;


### PR DESCRIPTION
## Summary
- replace missing PillIcon with ClipboardDocumentListIcon
- drop unused setTagColors call
- call useClaimActions hook unconditionally to satisfy lint

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d216c0b3c832eb98a70a9ed7dbe50